### PR TITLE
Pretty HashMap from template render

### DIFF
--- a/src/win.rs
+++ b/src/win.rs
@@ -42,7 +42,6 @@ mod imp {
     use gtk::StringObject;
     use isahc::RequestExt;
     use srtemplate::SrTemplate;
-    use srtemplate::SrTemplateError;
 
     use crate::client::Request;
     use crate::client::RequestError;
@@ -149,7 +148,7 @@ mod imp {
             context: &SrTemplate,
         ) -> Result<HashMap<String, String>, CarteroError> {
             let vector = self.header_pane.get_entries();
-            let possible_entries: Vec<Result<(String, String), SrTemplateError>> = vector
+            vector
                 .iter()
                 .filter(|h| h.is_usable())
                 .map(|h| {
@@ -157,19 +156,7 @@ mod imp {
                     let header_value = context.render(h.header_value())?;
                     Ok((header_name, header_value))
                 })
-                .collect();
-
-            // TODO: I am pretty sure there is a way to collect() without having to do this.
-            let mut headers = HashMap::new();
-            for possible_entry in possible_entries {
-                match possible_entry {
-                    Ok((h, v)) => {
-                        headers.insert(h.clone(), v.clone());
-                    }
-                    Err(e) => return Err(e.into()),
-                }
-            }
-            Ok(headers)
+                .collect()
         }
 
         // Convert from UI state into a Request object


### PR DESCRIPTION
He notado que existía la intención de hacer este fragmento de código mucho mas limpio, la manera mas sencilla y limpia es usando el [`collect()`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.collect), la razón por la que esto funciona se explica en la documentación, pero dejo un resumen explicado:

La función de `collect()` es capaz de agrupar iteraciones que tengan por item cualquier `Result<T, E>`, dando como resultado un `Result<Iter<T>, E>`, ejemplos:

```rs
let results = [Ok(1), Err("nop"), Ok(3), Err("malo")];
let result: Result<Vec<i32>, &str> = results.iter().cloned().collect();

// Obtenemos el primer error que aparezca en la iteracion
assert_eq!(Err("nop"), result);

let results = [Ok(1), Ok(3)];
let result: Result<Vec<i32>, &str> = results.iter().cloned().collect();

// Como no hay errores, obtenemos la lista completa envuelta en un `Ok(Iter<T>)`
assert_eq!(Ok(vec![1, 3]), result);
```

Y la conversion de la tupla de `String` es posible gracias a que tiene implementado el trait [`FromIterator<(K, V)>`](https://doc.rust-lang.org/std/collections/struct.HashMap.html#impl-FromIterator%3C(K,+V)%3E-for-HashMap%3CK,+V,+S%3E) necesario para el `collect()`

Y por ultimo, no hace falta hacer la conversion de `SrTemplateError` a `CarteroError` porque gracias a [`thiserror`](https://crates.io/crates/thiserror), `CarteroError` ya trae una implementacion de `From<SrTemplateError>`

> [!IMPORTANT]
> En ningun momento hace falta indicar los tipos mediante [`turbofish`](https://techblog.tonsser.com/posts/what-is-rusts-turbofish) ya que se infiere de lo que espera la función como salida