### PR TITLE
Add missing packages for Windows compilation

### DIFF
--- a/WINDOWS.md
+++ b/WINDOWS.md
@@ -27,6 +27,8 @@ honest, I don't want to.
    * `mingw-w64-x86_64-librsvg`
    * `mingw-w64-x86_64-meson`
    * `mingw-w64-x86_64-pkgconf`
+   * `mingw-w64-x86_64-libadwaita`
+   * `mingw-w64-x86_64-blueprint-compiler`
    * `meson`
 6. Once the repository is cloned, you should be able to compile from inside a
 MSYS2 shell. Instructions in the README.md file apply here as well.


### PR DESCRIPTION
Probé a compilar Cartero con una instalación limpia de MSYS2, y esto pasó...

Procedí a instalar todos los paquetes necesarios indicados en el archivo de compilación para Windows, y al momento de hacer el setup con Meson me topé con el siguiente error:

```shell
josal@DESKTOP-PUA53LS MINGW64 ~/cartero
$ meson setup build --prefix=/usr
The Meson build system
Version: 1.4.1
Source dir: C:/msys64/home/josal/cartero
Build dir: C:/msys64/home/josal/cartero/build
Build type: native build
Project name: cartero
Project version: 0.1
Rust compiler for the host machine: rustc -C linker=cc (rustc 1.79.0)
Rust linker for the host machine: rustc -C linker=cc ld.bfd 2.42
Host machine cpu family: x86_64
Host machine cpu: x86_64
Found pkg-config: YES (C:\msys64\mingw64\bin/pkg-config.EXE) 2.2.0
Run-time dependency glib-2.0 found: YES 2.80.3
Run-time dependency gtk4 found: YES 4.14.4
Run-time dependency gtksourceview-5 found: YES 5.12.1
Did not find CMake 'cmake'
Found CMake: NO
Run-time dependency libadwaita-1 found: NO (tried pkgconfig)

meson.build:34:0: ERROR: Dependency "libadwaita-1" not found, tried pkgconfig

A full log can be found at C:/msys64/home/josal/cartero/build/meson-logs/meson-log.txt
```

Ante este error, procedí a instalar adwaita con el siguiente comando:

```shell
$ pacman -S mingw-w64-x86_64-libadwaita
```

Volví a ejecutar el comando `meson setup build`, esta vez reconociendo la existencia de adwaita en mi MSYS2 y dejándome seguir con la compilación. Por esta razón entra el primer paquete que propongo añadir a la lista de paquetes necesarios para compilar Cartero.

Luego de ello, ejecuté el comando `ninja -C build` y me topé con el siguiente error:

**Nota**: cabe decir que al no tener blueprint-compiler instalado, se me clonó el repo de dicho paquete en la carpeta `subprojects` de Cartero para usarse en la compilación.

```shell
josal@DESKTOP-PUA53LS MINGW64 ~/cartero
$ ninja -C build
ninja: Entering directory `build'
[1/7] Generating data/blueprints with a custom command
FAILED: data/endpoint_pane.ui data/main_window.ui data/key_value_pane.ui data/key_value_row.ui data/response_panel.ui
"C:/msys64/mingw64/bin/python.exe" "C:/msys64/home/josal/cartero/build/subprojects/blueprint-compiler/blueprint-compiler" "batch-compile" "data" "../data" "../data/ui/endpo
int_pane.blp" "../data/ui/main_window.blp" "../data/ui/key_value_pane.blp" "../data/ui/key_value_row.blp" "../data/ui/response_panel.blp"
Traceback (most recent call last):
  File "C:/msys64/home/josal/cartero/build/subprojects/blueprint-compiler/blueprint-compiler", line 38, in <module>
    from blueprintcompiler import main
  File "C:/msys64/home/josal/cartero/subprojects/blueprint-compiler/blueprintcompiler/main.py", line 27, in <module>
    from . import formatter, interactive_port, parser, tokenizer
  File "C:/msys64/home/josal/cartero/subprojects/blueprint-compiler/blueprintcompiler/interactive_port.py", line 25, in <module>
    from . import decompiler, parser, tokenizer
  File "C:/msys64/home/josal/cartero/subprojects/blueprint-compiler/blueprintcompiler/decompiler.py", line 26, in <module>
    from .gir import *
  File "C:/msys64/home/josal/cartero/subprojects/blueprint-compiler/blueprintcompiler/gir.py", line 25, in <module>
    import gi  # type: ignore
    ^^^^^^^^^
ModuleNotFoundError: No module named 'gi'
[4/7] Building translation po/eo/LC_MESSAGES/cartero-eo.mo
ninja: build stopped: subcommand failed.
```

Para solucionar este error, lo que hice fue instalar blueprint-compiler en mi MSYS2 directamente:

```shell
$ pacman -S mingw-w64-x86_64-blueprint-compiler
```

Una vez hecho esto, volví a ejecutar el comando y no me volvió a generar este error y me permitió seguir con la compilación. De aquí viene el segundo paquete que propongo añadir a la lista.

Luego seguí con la ejecución de comandos normales para compilar Cartero y no me generó más problemas, hasta incluso fuí capaz de abrir Cartero correctamente.

Estas son las razones por las que creería yo que sería importante añadir estos dos paquetes en la compilación de Windows. Podré estar equivocado, sin embargo aquí dejo mi pequeño granito de arena para querer aportar al proyecto.
