### PR TITLE
Packaging for nix and adding nixos installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,60 @@ executable, but you will still need to use Meson to build the data files
 compiles the data files and copies them in `target/share`, so that during
 application startup those files can be picked.
 
+## Nix/NixOS
+
+Use this approach to install, build or try cartero on a nixos system. Instructions
+assume you're using a flakes nixos system, but you could install it in a regular
+nixos system aswell by importing the derivation and adding the appropiate src attribute
+on it, note that this may require some manual intervation though.
+
+First of all, add cartero to your flake inputs so you can import the package.
+
+```nix
+{
+  inputs = {
+    cartero.url = "github:danirod/cartero";
+  };
+}
+```
+
+Then in your `home.packages` (when using home manager) or
+`environment.systemPackages` (global nix packages), add the
+derivation.
+
+```nix
+environment.systemPackages = [
+  inputs.cartero.packages.x86_64-linux.default
+];
+```
+
+> [!TIP]
+> You can try changing the architecture, not tested in every arch atm though.
+
+Another way is by making a nixpkgs overlay to add cartero and then install it
+easily.
+
+```nix
+nixpkgs.overlays = [
+  (_: final: let
+    inherit (inputs) cartero;
+    inherit (final) system;
+  in {
+    cartero = cartero.packages.${system}.default
+  })
+];
+```
+
+And then in the packages list of your choice.
+
+```nix
+home.packages = with pkgs; [
+  cartero
+];
+```
+
+> [!NOTE] You may need to reboot the system or relogin to be able to see cartero on your launcher
+
 ## Contributing
 
 > 🐛 This project is currently a larva trying to grow. Do you want to get in?

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ First of all, add cartero to your flake inputs so you can import the package.
 }
 ```
 
+> [!WARNING]
+> This examples assume you're passing `inputs` in the `specialAttrs` so you can utilize it
+> in others modules if you're splitting your config in multiple files.
+
 Then in your `home.packages` (when using home manager) or
 `environment.systemPackages` (global nix packages), add the
 derivation.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ First of all, add cartero to your flake inputs so you can import the package.
 ```
 
 > [!WARNING]
-> This examples assume you're passing `inputs` in the `specialAttrs` so you can utilize it
+> This examples assume you're passing `inputs` in the `specialArgs` so you can utilize it
 > in others modules if you're splitting your config in multiple files.
 
 Then in your `home.packages` (when using home manager) or

--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ home.packages = with pkgs; [
 ];
 ```
 
-> [!NOTE] You may need to reboot the system or relogin to be able to see cartero on your launcher
+> [!NOTE]
+> You may need to reboot the system or relogin to be able to see cartero on your launcher
 
 ## Contributing
 

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,62 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.rustPlatform.buildRustPackage rec {
+  pname = "cartero";
+  version = "git";
+
+  src = ./.;
+  cargoLock.lockFile = ./Cargo.lock;
+
+  nativeBuildInputs = with pkgs; [
+    meson
+    ninja
+    cargo
+    rustc
+    pkg-config
+    blueprint-compiler
+    desktop-file-utils
+    gtk4
+    glib
+    wrapGAppsHook
+    hicolor-icon-theme
+  ];
+
+  buildInputs = with pkgs; [
+    gtksourceview5
+    pango
+    gdk-pixbuf
+    openssl_3_3
+    graphene
+    libadwaita
+  ];
+
+  desktopItems = with pkgs; [
+    (makeDesktopItem rec {
+      desktopName = "Cartero";
+      name = lib.toLower desktopName;
+      comment = "Make HTTP requests and test APIs.";
+      exec = "cartero";
+      tryExec = exec;
+      icon = "es.danirod.Cartero.svg";
+      keywords = [ "Gnome" "GTK" "HTTP" "RESET" ];
+      categories = [ "GNOME" "GTK" "Network" "Development" ];
+      terminal = false;
+      type = "Application";
+    })
+  ];
+
+  configurePhase = ''
+    runHook cargoSetupHook
+    runHook mesonConfigurePhase
+  '';
+
+  meta = with pkgs.lib; {
+    description = "Make HTTP requests and test APIs";
+    license = licenses.gpl3Only;
+    mainProgram = "cartero";
+    maintainers = with maintainers; [
+      danirod
+      alphatechnolog
+    ];
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,93 @@
+{
+  description = "Make HTTP requests and test APIs.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem(
+    system: let
+      overlays = [
+        (_: final: {
+          cartero = final.callPackage ./default.nix {
+            pkgs = final;
+          };
+        })
+      ];
+
+      pkgs = import nixpkgs {
+        inherit
+          system
+          overlays
+        ;
+      };
+    in {
+      packages = rec {
+        inherit (pkgs) cartero;
+        default = cartero;
+      };
+
+      devShells = with pkgs; let
+        buildShellRecipe = {
+          LD_LIBRARY_PATH = lib.makeLibraryPath [
+            gtk4
+            libadwaita
+          ];
+
+          buildInputs = [
+            rustc
+            meson
+            ninja
+            cargo
+          ];
+        };
+
+        launchShellRecipe = {
+          buildInputs = [ cartero ];
+        };
+      in rec {
+        # use by default the full dev env.
+        default = mixedShell;
+
+        # a dev shell which helps to only build cartero manually without installing the dependencies.
+        buildingShell = mkShell (buildShellRecipe // {
+          name = "building-shell";
+
+          shellHook = ''
+            echo "> In this shell you should be able to build cartero manually without installing"
+            echo "> the dependencies since they already come installed automatically."
+          '';
+        });
+
+        # useful to test cartero by using nix develop --command cartero
+        launchShell = mkShell (launchShellRecipe // {
+          name = "launch-shell";
+
+          shellHook = ''
+            echo "> Here you can launch cartero by typing \`cartero\` in this interactive shell"
+            echo "> or by using nix develop --command cartero instead"
+          '';
+        });
+
+        # both
+        mixedShell = mkShell {
+          name = "full-dev-env";
+
+          inherit (buildShellRecipe)
+            LD_LIBRARY_PATH
+          ;
+
+          buildInputs = []
+            ++ buildShellRecipe.buildInputs
+            ++ launchShellRecipe.buildInputs;
+
+          shellHook = ''
+            echo "> In this shell you should be able to either build cartero manually without installing"
+            echo "> the dependencies manually, or by running \`cartero\` you could launch a prebuilt version instead"
+          '';
+        };
+      };
+    }
+  );
+}


### PR DESCRIPTION
In this pr am including two main files which are being used by nix to be able to build and install cartero in a nixos (and non nixos systems that use the standalone nix package manager installation). A little bit resume of the changes is:

- `flake.nix`: This file is the entry point for a nixos built system using the flakes way which is an experimental new way of using nix but being pretty much adopted nowadays in the nix ecosystem.
- `default.nix`: The cartero nix derivation. You can think on a derivation as something like a recipe or a makefile which tells nix how to build the application, and also what files/services/configurations it should touch in the system, all of this happen by keeping every binary/library isolated from the real system.

> [!NOTE]
> Instructions to install and use were included in the `README.md` but feel to suggest changes if needed or edit if you want aswell 😁 

![image](https://github.com/user-attachments/assets/124913c5-8cac-42f2-8646-a27304dba8cd)
> Cartero running on nixos with plasma.