### PR TITLE
feat. format json on response body tab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "isahc",
  "libadwaita",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "sourceview5",
  "srtemplate",
@@ -1508,6 +1509,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.53",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ glib = "0.19.3"
 gtk = { package = "gtk4", version = "0.8.2", features = ["v4_12"] }
 isahc = "1.7.2"
 serde = { version = "1.0.198", features = ["derive"] }
+serde_json = "1.0.120"
 serde_urlencoded = "0.7.1"
 sourceview5 = "0.8.0"
 srtemplate = { version = "0.3.0", features = [] }

--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -22,6 +22,7 @@ use gtk::gio::{ListModel, ListStore};
 use gtk::glib;
 use gtk::prelude::TextViewExt;
 use gtk::prelude::*;
+use serde_json::Value;
 use sourceview5::prelude::BufferExt;
 use sourceview5::LanguageManager;
 
@@ -258,6 +259,16 @@ impl ResponsePanel {
             .unwrap();
 
         buffer.set_text(&resp.body_str());
+        // Check is response have '{}', this should be a json
+        if resp.body_str().starts_with("{") && resp.body_str().ends_with("}") {
+            // Extract content and assign to variable text,
+            // If no indicate type :Value then fails to compile
+            let text: Value = serde_json::from_str(&resp.body_str()).unwrap();
+            // Format to json usint to_string_pretty from serde_json
+            let json = serde_json::to_string_pretty(&text).unwrap();
+            // Set the formated json to panel
+            buffer.set_text(&json);
+        }
 
         let language = resp
             .headers


### PR DESCRIPTION
First of all, i'm sorry

I need to say that i am not a rust/gtk dev, maybe I shouldn't do this

Sometimes responses json type dont format correctly on body panel
![Captura de pantalla 2024-07-26 a la(s) 12 17 02 a m](https://github.com/user-attachments/assets/ea47e2ba-c8f8-4675-9bae-2fd102c01452)

for that i applied some lines for try render a bit better json values

![Captura de pantalla 2024-07-26 a la(s) 12 16 00 a m](https://github.com/user-attachments/assets/3426d127-60e3-41df-847c-3658bcefec20)

I'm not sure if this help or improve performance with long single line

 - [x] add serde_json dependency
 - [x] format response with to_string_pretty fn
 - [x] set the format to panel

i really apreciate any type of feedback and tips, or if I can help you in other ways i'll do it with pleasure

pd: i like yout content, you do a great job

 