### PR TITLE
Add dynamic color for status code

### DIFF
--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -237,9 +237,16 @@ impl ResponsePanel {
         let model = store.upcast::<ListModel>();
         imp.response_headers.set_headers(Some(&model));
 
-        let status = format!("HTTP {}", resp.status_code);
+        let status = format!("• HTTP {}", resp.status_code);
         imp.status_code.set_text(&status);
         imp.status_code.set_visible(true);
+        let status_color = match resp.status_code {
+            200..=299 => "success",
+            400..=499 => "warning",
+            500..=599 => "error",
+            _ => "neutral",
+        };
+        imp.status_code.add_css_class(&status_color);
 
         let duration = format!("{} s", resp.seconds());
         imp.duration.set_text(&duration);


### PR DESCRIPTION
Color label status code

green for 200's
![imagen](https://github.com/user-attachments/assets/2a2afa68-93b2-4b7f-ab07-619850900cad)

yellow for 400's
![imagen](https://github.com/user-attachments/assets/03097e55-94fb-431d-bec8-12aef7184a3a)

red for 500's
![imagen](https://github.com/user-attachments/assets/7b181c11-94bb-44a8-8157-f3a9c75ec922)

https://github.com/danirod/cartero/issues/39
