### PR TITLE
Add Romanian translation for Cartero

### DIFF
--- a/build-aux/macos-build.sh
+++ b/build-aux/macos-build.sh
@@ -159,6 +159,7 @@ done
 mkdir -p "$RESOURCES_ROOT/en.lproj"
 mkdir -p "$RESOURCES_ROOT/es.lproj"
 mkdir -p "$RESOURCES_ROOT/eo.lproj"
+mkdir -p "$RESOURCES_ROOT/ro.lproj"
 
 # Create Info.plist
 cat > "$APP_ROOT/Contents/Info.plist" << EOF

--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -4,3 +4,4 @@
 en
 eo
 es
+ro

--- a/po/ro.po
+++ b/po/ro.po
@@ -1,9 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the cartero package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#, fuzzy
+#  <>, 2024.
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
@@ -11,11 +8,12 @@ msgstr ""
 "POT-Creation-Date: 2024-07-26 21:32+0200\n"
 "PO-Revision-Date: 2024-07-27 15:08+0200\n"
 "Last-Translator: \n"
-"Language-Team: \n"
+"Language-Team: Romanian\n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.4\n"
 
 #: data/cartero.desktop.in:3
@@ -29,7 +27,7 @@ msgstr "Folosește Cartero pentru a face cereri HTTP și a testa API-urile."
 #. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
 #: data/cartero.desktop.in:11
 msgid "Gnome;GTK;HTTP;REST;"
-msgstr "Gnome;GTK;HTTP;REST;"
+msgstr ""
 
 #: data/es.danirod.Cartero.gschema.xml:6
 msgid "Automatically indent new lines for the request body"

--- a/po/ro.po
+++ b/po/ro.po
@@ -1,0 +1,306 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the cartero package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: cartero\n"
+"Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
+"POT-Creation-Date: 2024-07-26 21:32+0200\n"
+"PO-Revision-Date: 2024-07-27 15:08+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4.4\n"
+
+#: data/cartero.desktop.in:3
+msgid "Cartero"
+msgstr "Cartero"
+
+#: data/cartero.desktop.in:4
+msgid "Make HTTP requests and test APIs."
+msgstr "Folosește Cartero pentru a face cereri HTTP și a testa API-urile."
+
+#. Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+#: data/cartero.desktop.in:11
+msgid "Gnome;GTK;HTTP;REST;"
+msgstr "Gnome;GTK;HTTP;REST;"
+
+#: data/es.danirod.Cartero.gschema.xml:6
+msgid "Automatically indent new lines for the request body"
+msgstr "Indentează automat noile linii pentru corpul cererii"
+
+#: data/es.danirod.Cartero.gschema.xml:10
+msgid "Wrap the body content"
+msgstr "Înfășoară conținutul corpului"
+
+#: data/es.danirod.Cartero.gschema.xml:14
+msgid "Whether to indent the request body with spaces or tabs"
+msgstr "Dacă să indenteze corpul cererii cu spații sau cu taburi"
+
+#: data/es.danirod.Cartero.gschema.xml:18
+msgid "Show line numbers in the request and response bodies"
+msgstr "Arată numerele de linie în corpurile cererii și răspunsului"
+
+#: data/es.danirod.Cartero.gschema.xml:22
+msgid "How many characters to pad when indenting the request body"
+msgstr "Câte caractere să se adauge la indentarea corpului cererii"
+
+#: data/es.danirod.Cartero.gschema.xml:27
+msgid "How large should new windows be"
+msgstr "Mărimea pe care ar trebui să o aibă ferestrele noi"
+
+#: data/es.danirod.Cartero.gschema.xml:31
+msgid "How tall should new windows be"
+msgstr "Înălțimea pe care ar trebui să o aibă ferestrele noi"
+
+#: data/es.danirod.Cartero.gschema.xml:35
+msgid "Whether the application should open maximized"
+msgstr "Dacă aplicația ar trebui să se deschidă maximizată"
+
+#: data/es.danirod.Cartero.gschema.xml:39
+msgid "The position of the split between two windows"
+msgstr "Poziția despărțirii dintre două ferestre"
+
+#: data/es.danirod.Cartero.gschema.xml:43
+msgid "The current list of opened files"
+msgstr "Lista de fișiere deschise actual"
+
+#: data/es.danirod.Cartero.gschema.xml:47
+msgid "The last location where a file was opened"
+msgstr "Ultima locație unde a fost deschis un fișier"
+
+#: data/es.danirod.Cartero.gschema.xml:51
+msgid "The last location where a file was saved"
+msgstr "Ultima locație unde a fost salvat un fișier"
+
+#: data/ui/endpoint_pane.blp:59
+msgid "Request URL"
+msgstr "URL-ul cererii"
+
+#: data/ui/endpoint_pane.blp:69
+msgid "Send"
+msgstr "Trimiteți"
+
+#: data/ui/endpoint_pane.blp:70
+msgid "Execute this HTTP request"
+msgstr "Executați această cerere HTTP"
+
+#: data/ui/endpoint_pane.blp:103
+msgid "Parameters"
+msgstr "Parametrii"
+
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:47
+msgid "Headers"
+msgstr "Antetele"
+
+#: data/ui/endpoint_pane.blp:145
+msgid "Variables"
+msgstr "Variabilele"
+
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:68
+msgid "Body"
+msgstr "Corpul"
+
+#: data/ui/key_value_row.blp:40
+msgid "Name"
+msgstr "Numele"
+
+#: data/ui/key_value_row.blp:50
+msgid "Value"
+msgstr "Valoarea"
+
+#: data/ui/key_value_row.blp:61
+msgid "Actions"
+msgstr "Acțiunile"
+
+#: data/ui/key_value_row.blp:74
+msgid "Toggle secret"
+msgstr "Comutați secretul"
+
+#: data/ui/key_value_row.blp:81
+msgid "Delete"
+msgstr "Ștergeți"
+
+#: data/ui/main_window.blp:41 data/ui/main_window_no_csd.blp:39
+msgid "New"
+msgstr "Nou"
+
+#: data/ui/main_window.blp:52 data/ui/main_window.blp:63
+#: data/ui/main_window_no_csd.blp:50 data/ui/main_window_no_csd.blp:61
+#: src/widgets/file_dialogs.rs:31
+msgid "Open"
+msgstr "Deschideți"
+
+#: data/ui/main_window.blp:71 data/ui/main_window_no_csd.blp:69
+#: src/widgets/file_dialogs.rs:72
+msgid "Save"
+msgstr "Salvați"
+
+#: data/ui/main_window.blp:95 data/ui/main_window_no_csd.blp:102
+msgid "Welcome to Cartero"
+msgstr "Bun venit în Cartero"
+
+#: data/ui/main_window.blp:96 data/ui/main_window_no_csd.blp:103
+msgid "Create or open a request and start testing APIs now."
+msgstr "Creați sau deschideți o cerere și începeți testarea API-urilor acum."
+
+#: data/ui/main_window.blp:115 data/ui/main_window.blp:149
+#: data/ui/main_window_no_csd.blp:122 data/ui/main_window_no_csd.blp:156
+msgid "New tab"
+msgstr "Tab nou"
+
+#: data/ui/main_window.blp:128 data/ui/main_window.blp:154
+#: data/ui/main_window_no_csd.blp:135 data/ui/main_window_no_csd.blp:161
+msgid "Open request..."
+msgstr "Deschideți cererea..."
+
+#: data/ui/main_window.blp:159 data/ui/main_window_no_csd.blp:166
+#: src/widgets/file_dialogs.rs:73
+msgid "Save request"
+msgstr "Salvați cererea"
+
+#: data/ui/main_window.blp:164 data/ui/main_window_no_csd.blp:171
+msgid "Save request as..."
+msgstr "Salvați cererea ca..."
+
+#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:176
+msgid "Close tab"
+msgstr "Închideți tab-ul"
+
+#: data/ui/main_window.blp:176 data/ui/main_window_no_csd.blp:183
+msgid "Body appearance"
+msgstr "Aspectul corpului"
+
+#: data/ui/main_window.blp:180 data/ui/main_window_no_csd.blp:187
+msgid "Wrap content"
+msgstr "Înveliți conținutul"
+
+#: data/ui/main_window.blp:185 data/ui/main_window_no_csd.blp:192
+msgid "Show line numbers"
+msgstr "Afișați numerele de linie"
+
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:199
+msgid "Automatic indentation"
+msgstr "Indentarea automată"
+
+#: data/ui/main_window.blp:197 data/ui/main_window_no_csd.blp:204
+msgid "Indent with spaces"
+msgstr "Indentăm cu spații"
+
+#: data/ui/main_window.blp:203 data/ui/main_window_no_csd.blp:210
+msgid "Indent with tabs"
+msgstr "Indentăm cu taburi"
+
+#: data/ui/main_window.blp:209 data/ui/main_window_no_csd.blp:216
+msgid "Spaces per tab"
+msgstr "Spații pe tab"
+
+#: data/ui/main_window.blp:212 data/ui/main_window_no_csd.blp:219
+msgid "2"
+msgstr "2"
+
+#: data/ui/main_window.blp:218 data/ui/main_window_no_csd.blp:225
+msgid "4"
+msgstr "4"
+
+#: data/ui/main_window.blp:224 data/ui/main_window_no_csd.blp:231
+msgid "8"
+msgstr "8"
+
+#: data/ui/main_window.blp:235 data/ui/main_window_no_csd.blp:242
+msgid "Keyboard shortcuts"
+msgstr "Scurtături de tastatură"
+
+#: data/ui/main_window.blp:240 data/ui/main_window_no_csd.blp:247
+msgid "About Cartero"
+msgstr "Despre Cartero"
+
+#: data/ui/main_window.blp:245 data/ui/main_window_no_csd.blp:252
+msgid "Quit"
+msgstr "Ieșiți"
+
+#: data/ui/method_dropdown.blp:30
+msgid "Request method"
+msgstr "Metoda cererii"
+
+#: data/ui/payload_tab.blp:35
+msgid "Body type"
+msgstr "Tipul corpului"
+
+#: data/ui/payload_tab.blp:81
+msgid "(none)"
+msgstr "(niciunul)"
+
+#: data/ui/payload_tab.blp:82
+msgid "URL Encoded"
+msgstr "Codat URL"
+
+#: data/ui/payload_tab.blp:83
+msgid "Multipart Form Data"
+msgstr "Date de formă multipart"
+
+#: data/ui/payload_tab.blp:86
+msgid "Raw"
+msgstr "Brut"
+
+#: data/ui/response_panel.blp:29
+msgid "Ready to request"
+msgstr "Gata să cererea"
+
+#: data/ui/response_panel.blp:30
+msgid "Use the Send button to send a network request and it will show here."
+msgstr "Folosiți butonul Trimiteți pentru a trimite o cerere de rețea și va apărea aici."
+
+#: data/ui/save_dialog.blp:22
+msgid "Save changes?"
+msgstr "Salvați modificările?"
+
+#: data/ui/save_dialog.blp:23
+msgid "There are changes that have not been saved yet. What do you want to do?"
+msgstr "Există modificări care nu au fost salvate încă. Ce doriți să faceți?"
+
+#: data/ui/save_dialog.blp:28
+msgid "_Cancel"
+msgstr "_Anulați"
+
+#: data/ui/save_dialog.blp:29
+msgid "_Discard"
+msgstr "_Renunțați"
+
+#: data/ui/save_dialog.blp:30
+msgid "_Save"
+msgstr "_Salvați"
+
+#: src/widgets/file_dialogs.rs:18
+msgid "Request (.cartero)"
+msgstr "Cerere (.cartero)"
+
+#: src/widgets/file_dialogs.rs:20
+msgid "Request"
+msgstr "Cerere"
+
+#: src/widgets/file_dialogs.rs:32
+msgid "Open request"
+msgstr "Deschideți cererea"
+
+#: src/widgets/item_pane.rs:83
+msgid "(untitled)"
+msgstr "(fără titlu)"
+
+#: src/win.rs:102
+msgid "Draft"
+msgstr "Proiect"
+
+#: src/win.rs:498
+msgid "The Cartero authors"
+msgstr "Autorii Cartero"
+
+#: src/win.rs:499
+msgid "© 2024 the Cartero authors"
+msgstr "© 2024 autorii Cartero"


### PR DESCRIPTION
This pull request adds a new Romanian translation for Cartero, making the application more accessible to Romanian-speaking users.

The following files have been updated:
- build-aux/macos-build.sh
- po/LINGUAS

Additionally, a new file po/ro.po has been created, containing the Romanian translation for Cartero.

Please review and merge this pull request to include the Romanian translation. 