### PR TITLE
Nix packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,8 @@ First of all, add cartero to your flake inputs so you can import the package.
 > This examples assume you're passing `inputs` in the `specialArgs` so you can utilize it
 > in others modules if you're splitting your config in multiple files.
 
-Then in your `home.packages` (when using home manager) or
-`environment.systemPackages` (global nix packages), add the
-derivation.
+Then in your `home.packages` (when using home manager) or `environment.systemPackages`
+(global nix packages), add the derivation.
 
 ```nix
 environment.systemPackages = [

--- a/default.nix
+++ b/default.nix
@@ -16,6 +16,7 @@ pkgs.rustPlatform.buildRustPackage rec {
     blueprint-compiler
     desktop-file-utils
     gtk4
+    shared-mime-info
     glib
     wrapGAppsHook
     hicolor-icon-theme


### PR DESCRIPTION
This pull request fixes a recent error when building cartero for nix which mostly implies adding a newer dependency in the packaging process... newer cartero versions requires update-mime-database binary to be found which werent included previously in the nix package.

Btw note this is my first time doing a rebase and still am not fully sure if i did it the right way but seemed to work alright, and the version of cartero that i built now was 0.1 so ig it went ok? lmk your thoughts :)