### PR TITLE
Include gspawn-win64-helper on Windows

### DIFF
--- a/build-aux/msys-build.sh
+++ b/build-aux/msys-build.sh
@@ -39,6 +39,7 @@ mkdir -p {lib,share}
 cp $(ldd bin/cartero.exe | grep "$MINGW_PREFIX" | awk '{ print $3 }') bin/
 
 cp $MINGW_PREFIX/bin/gdbus.exe bin/
+cp $MINGW_PREFIX/bin/gspawn-win64-helper.exe bin/
 
 cp -RTn $MINGW_PREFIX/lib/gdk-pixbuf-2.0 lib/gdk-pixbuf-2.0
 cp -RTn $MINGW_PREFIX/share/glib-2.0 share/glib-2.0


### PR DESCRIPTION
This executable is used to launch things on GTK for Windows, including links. If the executable is not found, then clicking a link will not have any effect.

Fixes https://github.com/danirod/cartero/issues/43