### PR TITLE
Ergonomic changes to the request panel

### DIFF
--- a/data/ui/endpoint_pane.blp
+++ b/data/ui/endpoint_pane.blp
@@ -58,6 +58,7 @@ template $CarteroEndpointPane: Adw.BreakpointBin {
           hexpand: true;
           placeholder-text: _("Request URL");
           changed => $on_url_changed() swapped;
+          activate => $on_url_activated() swapped;
         }
 
         Button send {

--- a/data/ui/response_panel.blp
+++ b/data/ui/response_panel.blp
@@ -44,27 +44,6 @@ template $CarteroResponsePanel: Adw.Bin {
 
           NotebookPage {
             tab: Label {
-              label: _("Headers");
-            };
-
-            child: ScrolledWindow {
-              hexpand: true;
-              vexpand: true;
-
-              Adw.Clamp {
-                styles [
-                  "background"
-                ]
-
-                maximum-size: 720;
-
-                $CarteroResponseHeaders response_headers {}
-              }
-            };
-          }
-
-          NotebookPage {
-            tab: Label {
               label: _("Body");
             };
 
@@ -82,6 +61,27 @@ template $CarteroResponsePanel: Adw.Bin {
                 editable: false;
 
                 buffer: GtkSource.Buffer {};
+              }
+            };
+          }
+
+          NotebookPage {
+            tab: Label {
+              label: _("Headers");
+            };
+
+            child: ScrolledWindow {
+              hexpand: true;
+              vexpand: true;
+
+              Adw.Clamp {
+                styles [
+                  "background"
+                ]
+
+                maximum-size: 720;
+
+                $CarteroResponseHeaders response_headers {}
               }
             };
           }

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -225,6 +225,11 @@ mod imp {
             self.update_send_button_sensitivity();
         }
 
+        #[template_callback]
+        fn on_url_activated(&self) {
+            let _ = self.obj().activate_action("win.request", None);
+        }
+
         /// Sets the value of every widget in the pane into whatever is set by the given endpoint.
         pub fn assign_request(&self, endpoint: &EndpointData) {
             self.request_url.buffer().set_text(endpoint.url.clone());


### PR DESCRIPTION
* It is now possible to submit a request pressing the Enter key right on the request URL entry. (It will always be possible to send a request by pressing Ctrl+Enter or Cmd+Enter at any time.) - Fixes #48, #49, #51

* The body page is now the default page in the response panel notebook as it is probably more useful than the headers page, which is now the second page in the notebook.