### PR TITLE
Fix word wraping on long lines without spaces

### DIFF
--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -118,7 +118,7 @@ mod imp {
                 .mapping(|variant, _| {
                     let enabled = variant.get::<bool>().expect("The variant is not a boolean");
                     let mode = match enabled {
-                        true => WrapMode::Word,
+                        true => WrapMode::WordChar,
                         false => WrapMode::None,
                     };
                     Some(mode.to_value())


### PR DESCRIPTION
As described in https://github.com/danirod/cartero/issues/67, by default if a long line has no spaces, a Gtk TextView cannot find a break point for the word wrapping. The solution is to use WordChar, which uses characters as a fallback if a line has no spaces and it cannot physically break by word.