### PR TITLE
Fix locales with special dialogs

### DIFF
--- a/build-aux/macos-build.sh
+++ b/build-aux/macos-build.sh
@@ -50,6 +50,11 @@ glib-compile-schemas "$RESOURCES_ROOT/share/glib-2.0/schemas"
 gtk4-update-icon-cache -q -t -f "$RESOURCES_ROOT/share/icons/hicolor"
 gtk4-update-icon-cache -q -t -f "$RESOURCES_ROOT/share/icons/Adwaita"
 
+# Add extra locales
+for lang in $(cat "po/LINGUAS" | grep -v '^#\|en'); do
+        cp -f $(brew --prefix)/share/locale/$lang/LC_MESSAGES/{gdk-pixbuf,gettext-runtime,glib20,gtk40,gtksourceview-5,libadwaita,shared-mime-info}.mo "$RESOURCES_ROOT/share/locale/$lang/LC_MESSAGES"
+done
+
 # Mangle bin directory
 mv "$RESOURCES_ROOT/bin" "$APP_ROOT/Contents/MacOS"
 

--- a/build-aux/msys-build.sh
+++ b/build-aux/msys-build.sh
@@ -33,6 +33,8 @@ ninja -C build
 rm -rf $PWD/build/cartero-win32
 DESTDIR=$PWD/build/cartero-win32 ninja -C build install
 
+CARTERO_ROOT_DIR="$PWD"
+
 cd $PWD/build/cartero-win32
 mkdir -p {lib,share}
 
@@ -46,6 +48,10 @@ cp -RTn $MINGW_PREFIX/share/glib-2.0 share/glib-2.0
 cp -RTn $MINGW_PREFIX/share/icons/Adwaita share/icons/Adwaita
 cp -RTn $MINGW_PREFIX/share/icons/hicolor share/icons/hicolor
 cp -RTn $MINGW_PREFIX/share/gtksourceview-5 share/gtksourceview-5
+
+for lang in $(cat "$CARTERO_ROOT_DIR/po/LINGUAS" | grep -v '^#\|en'); do
+        cp -f $MINGW_PREFIX/share/locale/$lang/LC_MESSAGES/{gdk-pixbuf,gettext-runtime,glib20,gtk40,gtksourceview-5,libadwaita,shared-mime-info}.mo share/locale/$lang/LC_MESSAGES
+done
 
 cp $(ldd lib/gdk-pixbuf-2.0/2.10.0/loaders/*.dll | grep "$MINGW_PREFIX" | awk '{ print $3 }' | sort | uniq) bin/
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -4,6 +4,7 @@ data/cartero.appdata.xml.in.in
 data/cartero.desktop.in.in
 data/es.danirod.Cartero.gschema.xml
 
+data/gtk/help_overlay.blp
 data/ui/endpoint_pane.blp
 data/ui/formdata_payload_pane.blp
 data/ui/key_value_pane.blp

--- a/po/cartero.pot
+++ b/po/cartero.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2024-07-30 16:10+0200\n"
+"POT-Creation-Date: 2024-08-05 17:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -115,6 +115,61 @@ msgstr ""
 
 #: data/es.danirod.Cartero.gschema.xml:51
 msgid "The last location where a file was saved"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:26
+msgctxt "shortcuts window"
+msgid "General shortcuts"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:29
+msgctxt "shortcuts window"
+msgid "Show Keyboard Shortcuts"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:34
+msgctxt "shortcuts window"
+msgid "Quit"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:40
+msgctxt "shortcuts window"
+msgid "Tab operations"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:43
+msgctxt "shortcuts window"
+msgid "New request tab"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:48
+msgctxt "shortcuts window"
+msgid "Open request"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:53
+msgctxt "shortcuts window"
+msgid "Save request"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:58
+msgctxt "shortcuts window"
+msgid "Save request as"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:63
+msgctxt "shortcuts window"
+msgid "Close request tab"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:69
+msgctxt "shortcuts window"
+msgid "Request operations"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:72
+msgctxt "shortcuts window"
+msgid "Send request"
 msgstr ""
 
 #: data/ui/endpoint_pane.blp:59

--- a/po/en.po
+++ b/po/en.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2024-07-30 16:10+0200\n"
+"POT-Creation-Date: 2024-08-05 17:30+0200\n"
 "PO-Revision-Date: 2024-06-22 13:31+0200\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -116,6 +116,61 @@ msgstr ""
 
 #: data/es.danirod.Cartero.gschema.xml:51
 msgid "The last location where a file was saved"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:26
+msgctxt "shortcuts window"
+msgid "General shortcuts"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:29
+msgctxt "shortcuts window"
+msgid "Show Keyboard Shortcuts"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:34
+msgctxt "shortcuts window"
+msgid "Quit"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:40
+msgctxt "shortcuts window"
+msgid "Tab operations"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:43
+msgctxt "shortcuts window"
+msgid "New request tab"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:48
+msgctxt "shortcuts window"
+msgid "Open request"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:53
+msgctxt "shortcuts window"
+msgid "Save request"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:58
+msgctxt "shortcuts window"
+msgid "Save request as"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:63
+msgctxt "shortcuts window"
+msgid "Close request tab"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:69
+msgctxt "shortcuts window"
+msgid "Request operations"
+msgstr ""
+
+#: data/gtk/help_overlay.blp:72
+msgctxt "shortcuts window"
+msgid "Send request"
 msgstr ""
 
 #: data/ui/endpoint_pane.blp:59

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2024-07-30 16:10+0200\n"
+"POT-Creation-Date: 2024-08-05 17:30+0200\n"
 "PO-Revision-Date: 2024-07-30 15:26+0200\n"
 "Last-Translator:  <>\n"
 "Language-Team: Spanish\n"
@@ -123,6 +123,61 @@ msgstr "La última ubicación donde se abrió un archivo"
 #: data/es.danirod.Cartero.gschema.xml:51
 msgid "The last location where a file was saved"
 msgstr "La última ubicación donde se guardó un archivo"
+
+#: data/gtk/help_overlay.blp:26
+msgctxt "shortcuts window"
+msgid "General shortcuts"
+msgstr "Atajos generales"
+
+#: data/gtk/help_overlay.blp:29
+msgctxt "shortcuts window"
+msgid "Show Keyboard Shortcuts"
+msgstr "Mostrar atajos de teclado"
+
+#: data/gtk/help_overlay.blp:34
+msgctxt "shortcuts window"
+msgid "Quit"
+msgstr "Salir"
+
+#: data/gtk/help_overlay.blp:40
+msgctxt "shortcuts window"
+msgid "Tab operations"
+msgstr "Operaciones de pestaña"
+
+#: data/gtk/help_overlay.blp:43
+msgctxt "shortcuts window"
+msgid "New request tab"
+msgstr "Nueva pestaña de petición"
+
+#: data/gtk/help_overlay.blp:48
+msgctxt "shortcuts window"
+msgid "Open request"
+msgstr "Abrir petición"
+
+#: data/gtk/help_overlay.blp:53
+msgctxt "shortcuts window"
+msgid "Save request"
+msgstr "Guardar petición"
+
+#: data/gtk/help_overlay.blp:58
+msgctxt "shortcuts window"
+msgid "Save request as"
+msgstr "Guardar petición como"
+
+#: data/gtk/help_overlay.blp:63
+msgctxt "shortcuts window"
+msgid "Close request tab"
+msgstr "Cerrar pestaña de petición"
+
+#: data/gtk/help_overlay.blp:69
+msgctxt "shortcuts window"
+msgid "Request operations"
+msgstr "Operaciones de petición"
+
+#: data/gtk/help_overlay.blp:72
+msgctxt "shortcuts window"
+msgid "Send request"
+msgstr "Enviar petición"
 
 #: data/ui/endpoint_pane.blp:59
 msgid "Request URL"

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,10 +109,11 @@ fn main() -> glib::ExitCode {
     init_glib();
     init_gio_resources();
 
-    // This is dirty, but because adw_init() calls bindtextdomain() and uses a hardcoded static path,
-    // I need to actually re-bind libadwaita against my own localedir on Windows so that it can use
-    // a path relative to the application executable again.
-    #[cfg(target_os = "windows")]
+    // This is dirty, but because adw_init() calls bindtextdomain() and uses a hardcoded static
+    // path, I need to actually re-bind libadwaita against my own localedir on platforms where the
+    // datadir is not fixed, so that it can use a path relative to the application executable
+    // again.
+    #[cfg(any(target_os = "windows", target_os = "macos"))]
     {
         adw::init().expect("Failed to initialize system runtimes");
         let localedir = app_rel_path("share/locale");

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,16 @@ fn main() -> glib::ExitCode {
     init_glib();
     init_gio_resources();
 
+    // This is dirty, but because adw_init() calls bindtextdomain() and uses a hardcoded static path,
+    // I need to actually re-bind libadwaita against my own localedir on Windows so that it can use
+    // a path relative to the application executable again.
+    #[cfg(target_os = "windows")]
+    {
+        adw::init().expect("Failed to initialize system runtimes");
+        let localedir = app_rel_path("share/locale");
+        gettextrs::bindtextdomain("libadwaita", localedir).expect("Unable to bind the text domain");
+    }
+
     let app = CarteroApplication::new();
     app.run()
 }


### PR DESCRIPTION
Some dialogs were not being translated and in this PR I add fixes for that.

- The AboutDialog is an Adwaita system dialog, but it wasn't being localized on Windows or macOS (https://github.com/danirod/cartero/issues/56). This was not happening on GNU/Linux and on macOS if libadwaita is still installed via Homebrew. It turns out that if you have dependencies with locale files, you have to distribute them with your app, otherwise the strings will not be present.
- While I'm on this, it seems that I forgot to add the shortcuts dialog to the POTFILES.in file, so the strings in that file were never proposed for localization. This PR also adds the file to the POTFILES and provides strings in Spanish.