### PR TITLE
Allow to open more than one file at the same time

### DIFF
--- a/src/win.rs
+++ b/src/win.rs
@@ -240,8 +240,10 @@ mod imp {
         async fn trigger_open(&self) -> Result<(), CarteroError> {
             // In order to place the modal, we need a reference to the public type.
             let obj = self.obj();
-            let path = crate::widgets::open_file(&obj).await?;
-            self.add_endpoint(Some(&path)).await;
+            let paths = crate::widgets::open_files(&obj).await?;
+            for path in paths {
+                self.add_endpoint(Some(&path)).await;
+            }
             self.save_visible_tabs();
             Ok(())
         }


### PR DESCRIPTION
It is already possible to open multiple files using the file manager, but it is currently not possible to pick multiple files from the Open dialog.

In this commit I've patched the open_file() method to have a separate open_files() instead that opens multiple files. I am keeping the open_file() around in case I still need it in the future. The win.open action now will invoke open_files() and open every file returned by the function call.