### PR TITLE
Fix/wrong colors status labels & nix buildingShell devShell not allowing to build cartero due to missing dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -33,13 +33,32 @@
           LD_LIBRARY_PATH = lib.makeLibraryPath [
             gtk4
             libadwaita
+            glib
           ];
 
-          buildInputs = [
-            rustc
+          nativeBuildInputs = [
             meson
             ninja
             cargo
+            rustc
+            rustfmt
+            pkg-config
+            blueprint-compiler
+            desktop-file-utils
+            gtk4
+            shared-mime-info
+            glib
+            wrapGAppsHook
+            hicolor-icon-theme
+          ];
+
+          buildInputs = [
+            gtksourceview5
+            pango
+            gdk-pixbuf
+            openssl_3_3
+            graphene
+            libadwaita
           ];
         };
 

--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -251,8 +251,8 @@ impl ResponsePanel {
         // This will stop classes with higher priorities to override the currently
         // needed one by resetting the classes, see [this](https://github.com/danirod/cartero/issues/83).
         let possible_classes = vec!["success", "warning", "error", "neutral"];
-        for x in possible_classes {
-            imp.status_code.remove_css_class(x);
+        for css_class in possible_classes {
+            imp.status_code.remove_css_class(css_class);
         }
 
         imp.status_code.add_css_class(&status_color);

--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -247,6 +247,14 @@ impl ResponsePanel {
             500..=599 => "error",
             _ => "neutral",
         };
+
+        // This will stop classes with higher priorities to override the currently
+        // needed one by resetting the classes, see [this](https://github.com/danirod/cartero/issues/83).
+        let possible_classes = vec!["success", "warning", "error", "neutral"];
+        for x in possible_classes {
+            imp.status_code.remove_css_class(x);
+        }
+
         imp.status_code.add_css_class(&status_color);
 
         let duration = format!("{} s", resp.seconds());


### PR DESCRIPTION
This pull request addresses #83 where all the problem itself is being detailed, but in resume it's just that when cartero gets a non success status on a request (e.g: 400, 500), it will change the label to red/yellow depending, which is ok, but after that if you get again a 200 status, it won't just update its color to green again, which was being caused because the warning or error classes were overriding the success one since nothing was cleaning them up resulting in a label with every class, and the one with the most level of priority was the one that was overriding every other one.

What this PR does is cleaning all the classes if found before adding the new class to the label, which seems to do the trick, but im open to any change or any suggestion to improve the code :grin:

Another thing this pull request does is to fix the devShell which wasn't being able to manually let me build cartero for dev purposes, which was being caused by glib not being pulled and others, this pr addresses that one too.