### PR TITLE
ci: fix macos 14 pipeline and add macos 15

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -89,7 +89,7 @@ jobs:
   macos:
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-14, macos-15]
       fail-fast: false
     name: "macOS (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
@@ -106,7 +106,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       name: Upload macOS version
       with:
-        name: es.danirod.Cartero-${{ runner.os }}-${{ runner.arch }}
+        name: es.danirod.Cartero-${{ matrix.os }}-${{ runner.arch }}
         path: build/Cartero-*.dmg
   appimage:
     name: "AppImage (GNU/Linux, glibc 2.38+)"

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -90,6 +90,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
+      fail-fast: false
     name: "macOS (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,6 +19,7 @@ on:
   push:
     branches:
       - trunk
+      - 'fix/*'
       - 'release/*'
 name: Nightly build
 jobs:
@@ -94,7 +95,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
-      run: brew install meson gtk4 gtksourceview5 desktop-file-utils pygobject3 libadwaita adwaita-icon-theme gettext shared-mime-info
+      run: brew unlink pkg-config && brew install pkg-config meson gtk4 gtksourceview5 desktop-file-utils pygobject3 libadwaita adwaita-icon-theme gettext shared-mime-info && brew link pkgconf
     - name: Fix PYTHONPATH for blueprint-compiler
       run: echo "PYTHONPATH=$(brew --prefix)/lib/python3.12/site-packages:$PYTHONPATH" >> $GITHUB_ENV
     - name: Build macOS version

--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -93,7 +93,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies
-      run: brew install meson gtk4 gtksourceview5 desktop-file-utils pygobject3 libadwaita adwaita-icon-theme gettext shared-mime-info
+      run: brew unlink pkg-config && brew install pkg-config meson gtk4 gtksourceview5 desktop-file-utils pygobject3 libadwaita adwaita-icon-theme gettext shared-mime-info && brew link pkgconf
     - name: Fix PYTHONPATH for blueprint-compiler
       run: echo "PYTHONPATH=$(brew --prefix)/lib/python3.12/site-packages:$PYTHONPATH" >> $GITHUB_ENV
     - name: Build macOS version

--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -88,6 +88,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-13, macos-14]
+      fail-fast: false
     name: "macOS (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -87,7 +87,7 @@ jobs:
   macos:
     strategy:
       matrix:
-        os: [macos-13, macos-14]
+        os: [macos-13, macos-14, macos-15]
       fail-fast: false
     name: "macOS (${{ matrix.os }})"
     runs-on: ${{ matrix.os }}
@@ -104,7 +104,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       name: Upload macOS version
       with:
-        name: es.danirod.Cartero-${{ runner.os }}-${{ runner.arch }}
+        name: es.danirod.Cartero-${{ matrix.os }}-${{ runner.arch }}
         path: build/Cartero-*.dmg
   appimage:
     name: "AppImage (GNU/Linux, glibc 2.38+)"


### PR DESCRIPTION
Just fix the pipeline in MacOS 14 and add MacOS 15

<img width="285" alt="Captura de pantalla 2024-11-30 a la(s) 6 16 30 p  m" src="https://github.com/user-attachments/assets/f5982d68-7f7d-4415-8075-d26951ca2ae5">
