### PR TITLE
Package a valid AppImage for Ubuntu 22.04 and Debian 12

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -109,11 +109,13 @@ jobs:
         name: es.danirod.Cartero-${{ matrix.os }}-${{ runner.arch }}
         path: build/Cartero-*.dmg
   appimage:
-    name: "AppImage (GNU/Linux, glibc 2.38+)"
-    runs-on: ubuntu-24.04
+    name: "AppImage (GNU/Linux)"
+    runs-on: ubuntu-22.04
     steps:
     - name: Install dependencies
-      run: sudo apt update && sudo apt install -y --no-install-recommends gettext meson libgtk-4-dev libadwaita-1-dev libgtksourceview-5-dev desktop-file-utils xvfb libfuse2 libgtk-4-bin librsvg2-common
+      run: |
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        brew install meson gtk4 gtksourceview5 desktop-file-utils pygobject3 libadwaita adwaita-icon-theme gettext shared-mime-info
     - uses: actions/checkout@v4
     - name: Build
       run: build-aux/appimage-build.sh devel

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -114,14 +114,14 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        apt install --no-install-recommends libfuse2
+        sudo apt install --no-install-recommends libfuse2
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         brew install meson gtk4 gtksourceview5 desktop-file-utils pygobject3 libadwaita adwaita-icon-theme gettext shared-mime-info
     - uses: actions/checkout@v4
     - name: Build
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
-        export VENDOR_BASE=/home/linuxbrew/.linuxbrew
+        export VENDOR_BASE="$(brew --prefix)"
         build-aux/appimage-build.sh devel
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -118,7 +118,9 @@ jobs:
         brew install meson gtk4 gtksourceview5 desktop-file-utils pygobject3 libadwaita adwaita-icon-theme gettext shared-mime-info
     - uses: actions/checkout@v4
     - name: Build
-      run: build-aux/appimage-build.sh devel
+      run: |
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        build-aux/appimage-build.sh devel
     - name: Upload
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -122,6 +122,7 @@ jobs:
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         export VENDOR_BASE="$(brew --prefix)"
+        export LD_LIBRARY_PATH="$(brew --prefix)/lib"
         build-aux/appimage-build.sh devel
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -114,6 +114,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
+        apt install --no-install-recommends libfuse2
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         brew install meson gtk4 gtksourceview5 desktop-file-utils pygobject3 libadwaita adwaita-icon-theme gettext shared-mime-info
     - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -121,6 +121,7 @@ jobs:
     - name: Build
       run: |
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        export VENDOR_BASE=/home/linuxbrew/.linuxbrew
         build-aux/appimage-build.sh devel
     - name: Upload
       uses: actions/upload-artifact@v4

--- a/build-aux/appimage-build.sh
+++ b/build-aux/appimage-build.sh
@@ -143,6 +143,11 @@ echo 'export FONTCONFIG_PATH=/etc/fonts' >> AppDir/apprun-hooks/linuxdeploy-plug
 echo 'export XKB_CONFIG_ROOT=/usr/share/X11/xkb' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 echo 'export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 
+# Bypass AppRun.wrapped
+rm AppDir/AppRun.wrapped
+sed -i '/exec/d' AppDir/AppRun
+echo 'exec "$this_dir"/usr/bin/cartero "$@"' >> AppDir/AppRun
+
 # Check for symlinks in /lib (specifically when built in CI)
 for f in $(find AppDir/usr/lib -type l); do
   cp --remove-destination $(readlink -e "$f") "$f"

--- a/build-aux/appimage-build.sh
+++ b/build-aux/appimage-build.sh
@@ -123,7 +123,8 @@ echo 'export GSETTINGS_SCHEMA_DIR="$APPDIR/usr/share/glib-2.0/schemas"' >> AppDi
 echo 'export GI_TYPELIB_PATH="$APPDIR/usr/lib/girepository-1.0"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 echo 'export GTK_EXE_PREFIX="$APPDIR/usr"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 echo 'export GTK_PATH="$APPDIR/usr/lib/gtk-4.0"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
-echo 'export GDK_PIXBUF_MODULE_FILE="$APPDIR/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.s
+echo 'export GDK_PIXBUF_MODULE_FILE="$APPDIR/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+echo 'export FONTCONFIG_PATH=/etc/fonts' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 
 # Check for symlinks in /lib (specifically when built in CI)
 for f in $(find AppDir/usr/lib -type l); do

--- a/build-aux/appimage-build.sh
+++ b/build-aux/appimage-build.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+# I don't know what I am doing, but here are some notes.
+#
+# The way this script works is by using Linuxdeploy and the GTK plugin, and then manually
+# copying and relocating a shitton of libraries that Linuxdeploy-GTK doesn't pack but that
+# are actually required as transitive dependencies. Additionally, I patch the Linuxdeploy
+# GTK hook, make some cleanup... at this point, what's even the point on using Linuxdeploy
+# if I already know what do I have to do based on what I do for macOS, for example?
+#
+# TODO: Remove Linuxdeploy, manually copy and relocate with patchelf every required
+# dependency just like I do to relocate the macOS version of Cartero.
+
 set -e
 cd "$(dirname "$0")/.."
 
@@ -26,17 +37,40 @@ case "$1" in
     ;;
 esac
 
+# This script is currently only tested for GitHub Actions.
+if [ -z "$GITHUB_ACTIONS" ]; then
+  echo "WARNING! This script has only been tested to run in GitHub Actions and"
+  echo "it is used to build the stable and nightly versions in a well known"
+  echo "environment. Running this script to create an AppImage on your computer"
+  echo "is currently NOT supported and not guaranteed to work."
+  echo
+  echo "You should read the contents of the shell script at least once before"
+  echo "running it to know what it does. I cannot help with this script because"
+  echo "I don't have a clue about the inners of AppImage and its build tools."
+  echo
+  echo "Do you have that knowledge and know how to properly pack GTK4 + Libadwaita"
+  echo "apps in a way that actually works with older versions of libc6 without"
+  echo "having to use weird tricks? Please help me! Your inputs are appreciated"
+  echo "Send patches or comments to https://github.com/danirod/cartero"
+  echo
+  echo "Last chance. Press Ctrl-C to quit the script, or Enter to start."
+  read -r
+fi
+
 meson setup build --prefix="/" $MESON_FLAGS
 ninja -C build
 DESTDIR=$PWD/build/appimagetool/AppDir/usr ninja -C build install
 
 cd build/appimagetool
 
+# Apparently AppImage calls this metainfo rather than appinfo
+cp -r AppDir/usr/share/appdata AppDir/usr/share/metainfo
+
 # Vendor extra files
 if [ -d $VENDOR_BASE/share/icons/Adwaita ]; then
   mkdir -p AppDir/usr/share/icons
   echo "$VENDOR_BASE/share/icons/Adwaita -> AppDir/usr/share/icons"
-  cp -r $VENDOR_BASE/share/icons/Adwaita AppDir/usr/share/icons
+  cp -rL $VENDOR_BASE/share/icons/Adwaita AppDir/usr/share/icons
   gtk4-update-icon-cache -q -t -f AppDir/usr/share/icons/Adwaita
 else
   echo "Warning: cannot vendor Adwaita icons"
@@ -44,16 +78,23 @@ fi
 if [ -d $VENDOR_BASE/share/themes/Adwaita ]; then
   mkdir -p AppDir/usr/share/themes
   echo "$VENDOR_BASE/share/themes/Adwaita -> AppDir/usr/share/themes"
-  cp -r $VENDOR_BASE/share/themes/Adwaita AppDir/usr/share/themes
+  cp -rL $VENDOR_BASE/share/themes/Adwaita AppDir/usr/share/themes
 else
   echo "Warning: cannot vendor Adwaita themes"
 fi
 if [ -d $VENDOR_BASE/share/gtksourceview-5 ]; then
   echo "$VENDOR_BASE/share/gtksourceview-5 -> AppDir/usr/share/"
-  cp -r $VENDOR_BASE/share/gtksourceview-5 AppDir/usr/share/
+  cp -rL $VENDOR_BASE/share/gtksourceview-5 AppDir/usr/share/
 else
   echo "Warning: cannot vendor GtkSourceView 5 data files"
 fi
+if [ -d $VENDOR_BASE/share/glib-2.0/schemas ]; then
+  echo "$VENDOR_BASE/share/glib-2.0/schemas -> AppDir/usr/share/"
+  cp -rL $VENDOR_BASE/share/glib-2.0/schemas/org.gtk.* AppDir/usr/share/glib-2.0/schemas
+else
+  echo "Warning: cannot deploy extra GTK schemas"
+fi
+glib-compile-schemas AppDir/usr/share/glib-2.0/schemas
 gtk4-update-icon-cache -q -t -f AppDir/usr/share/icons/hicolor
 
 # Start packaging process
@@ -68,10 +109,70 @@ export DEPLOY_GTK_VERSION=4
   --executable AppDir/usr/bin/cartero \
   --icon-file "$ICON_PATH" \
   --desktop-file "$DESKTOP_PATH"
-  
-# Patch the hook in order to support Adwaita theme.
+
+# Patch the hook file
+# TODO: Why do I even try? Just make my own!
 sed -i '/GTK_THEME/d' AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 sed -i '/GDK_BACKEND/d' AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+sed -i '/GSETTINGS_SCHEMA_DIR/d' AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+sed -i '/GI_TYPELIB_PATH/d' AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+sed -i '/GTK_EXE_PREFIX/d' AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+sed -i '/GTK_PATH/d' AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+sed -i '/GDK_PIXBUF_MODULE_FILE/d' AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+echo 'export GSETTINGS_SCHEMA_DIR="$APPDIR/usr/share/glib-2.0/schemas"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+echo 'export GI_TYPELIB_PATH="$APPDIR/usr/lib/girepository-1.0"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+echo 'export GTK_EXE_PREFIX="$APPDIR/usr"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+echo 'export GTK_PATH="$APPDIR/usr/lib/gtk-4.0"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+echo 'export GDK_PIXBUF_MODULE_FILE="$APPDIR/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.s
+
+# Check for symlinks in /lib (specifically when built in CI)
+for f in $(find AppDir/usr/lib -type l); do
+  cp --remove-destination $(readlink -e "$f") "$f"
+done
+
+# Prepare to use patchelf
+echo "Unpacking patchelf..."
+./linuxdeploy-x86_64.AppImage --appimage-extract
+mv squashfs-root linuxdeploy-root
+PATCHELF=linuxdeploy-root/usr/bin/patchelf
+
+# gdk-pixbuf-2.0
+echo "Preparing GDK pixbuf cache..."
+if [ -d $VENDOR_BASE/lib/gdk-pixbuf-2.0 ]; then
+  for f in $VENDOR_BASE/lib/gdk-pixbuf-2.0/2.10.0/loaders/*.so; do
+    loader=$(basename "$f")
+    chmod u+w AppDir/usr/lib/$loader
+    $PATCHELF --set-rpath '$ORIGIN' AppDir/usr/lib/$loader
+  done
+  mkdir -p AppDir/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders
+  GDK_PIXBUF_MODULEDIR="$VENDOR_BASE/lib/gdk-pixbuf-2.0/2.10.0/loaders" gdk-pixbuf-query-loaders | sed "s|\".*/lib/gdk-pixbuf-2.0/2.10.0/loaders/|\"|" > AppDir/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
+fi
+
+# Provide additional libraries
+echo "Linking extra libraries..."
+REQUIRES_MORE_DEPS=1
+while [ $REQUIRES_MORE_DEPS -eq 1 ]; do
+	# Unset the variable in case this is the last iteration
+	REQUIRES_MORE_DEPS=0
+
+for lib in AppDir/usr/lib/*.so AppDir/usr/lib/*.so.*; do
+  # Process this dependency.
+  for dep in $($PATCHELF --print-needed $lib); do
+    if ! [ -f AppDir/usr/lib/$dep ] && [ -f $VENDOR_BASE/lib/$dep ]; then
+      echo "$dep is missing from the distribution ($lib)"
+      cp $VENDOR_BASE/lib/$dep AppDir/usr/lib
+      chmod u+w AppDir/usr/lib/$dep
+      $PATCHELF --set-rpath '$ORIGIN' AppDir/usr/lib/$dep
+      $PATCHELF --replace-needed $dep $dep $lib
+      REQUIRES_MORE_DEPS=1
+    fi
+  done
+  done
+done
+
+# Remove linuxbrew stuff if present
+[ -d AppDir/home ] && rm -rf AppDir/home
+[ -d AppDir/usr/home ] && rm -rf AppDir/usr/home
 
 # Recompile with the changes.
 ./appimagetool-x86_64.AppImage AppDir

--- a/build-aux/appimage-build.sh
+++ b/build-aux/appimage-build.sh
@@ -3,6 +3,12 @@
 set -e
 cd "$(dirname "$0")/.."
 
+# Vendor base is the directory where the datafiles to copy are expected to be, such
+# as the GtkSourceView themes or the Adwaita icons. This is set to /usr in case you
+# are building for yourself. Set to a different value if running in a special
+# environment (icon theme is installed to /usr/local or you are running Linuxbrew).
+VENDOR_BASE=${VENDOR_BASE:=/usr}
+
 case "$1" in
   devel)
     MESON_FLAGS="-Dprofile=development"
@@ -27,21 +33,24 @@ DESTDIR=$PWD/build/appimagetool/AppDir/usr ninja -C build install
 cd build/appimagetool
 
 # Vendor extra files
-if [ -d /usr/share/icons/Adwaita ]; then
+if [ -d $VENDOR_BASE/share/icons/Adwaita ]; then
   mkdir -p AppDir/usr/share/icons
-  cp -rv /usr/share/icons/Adwaita AppDir/usr/share/icons
+  echo "$VENDOR_BASE/share/icons/Adwaita -> AppDir/usr/share/icons"
+  cp -r $VENDOR_BASE/share/icons/Adwaita AppDir/usr/share/icons
   gtk4-update-icon-cache -q -t -f AppDir/usr/share/icons/Adwaita
 else
   echo "Warning: cannot vendor Adwaita icons"
 fi
-if [ -d /usr/share/themes/Adwaita ]; then
+if [ -d $VENDOR_BASE/share/themes/Adwaita ]; then
   mkdir -p AppDir/usr/share/themes
-  cp -rv /usr/share/themes/Adwaita AppDir/usr/share/themes
+  echo "$VENDOR_BASE/share/themes/Adwaita -> AppDir/usr/share/themes"
+  cp -r $VENDOR_BASE/share/themes/Adwaita AppDir/usr/share/themes
 else
   echo "Warning: cannot vendor Adwaita themes"
 fi
-if [ -d /usr/share/gtksourceview-5 ]; then
-  cp -rv /usr/share/gtksourceview-5 AppDir/usr/share/
+if [ -d $VENDOR_BASE/share/gtksourceview-5 ]; then
+  echo "$VENDOR_BASE/share/gtksourceview-5 -> AppDir/usr/share/"
+  cp -r $VENDOR_BASE/share/gtksourceview-5 AppDir/usr/share/
 else
   echo "Warning: cannot vendor GtkSourceView 5 data files"
 fi

--- a/build-aux/appimage-build.sh
+++ b/build-aux/appimage-build.sh
@@ -23,11 +23,13 @@ VENDOR_BASE=${VENDOR_BASE:=/usr}
 case "$1" in
   devel)
     MESON_FLAGS="-Dprofile=development"
+    APP_NAME="es.danirod.Cartero.Devel"
     ICON_PATH="AppDir/usr/share/icons/hicolor/scalable/apps/es.danirod.Cartero.Devel.svg"
     DESKTOP_PATH="AppDir/usr/share/applications/es.danirod.Cartero.Devel.desktop"
     ;;
   stable)
     MESON_FLAGS="-Dprofile=default"
+    APP_NAME="es.danirod.Cartero"
     ICON_PATH="AppDir/usr/share/icons/hicolor/scalable/apps/es.danirod.Cartero.svg"
     DESKTOP_PATH="AppDir/usr/share/applications/es.danirod.Cartero.desktop"
     ;;
@@ -65,6 +67,19 @@ cd build/appimagetool
 
 # Apparently AppImage calls this metainfo rather than appinfo
 cp -r AppDir/usr/share/appdata AppDir/usr/share/metainfo
+
+# Prepare icon
+LARGE_ICON_PATH="$ICON_PATH"
+if command -v rsvg-convert 2>&1 >/dev/null; then
+  # rsvg-convert exists. Let's convert the SVG icon to PNG, because apparently
+  # the SVG implementation in KDE is more limited than rsvg and the icon does
+  # not display properly.
+  for size in 16 24 32 48 64 96 128 256 512; do
+    mkdir -p AppDir/usr/share/icons/hicolor/${size}x${size}/apps/
+    rsvg-convert -w $size -h $size -f png -o AppDir/usr/share/icons/hicolor/${size}x${size}/apps/$APP_NAME.png $ICON_PATH
+  done
+  LARGE_ICON_PATH="AppDir/usr/share/icons/hicolor/512x512/apps/$APP_NAME.png"
+fi
 
 # Vendor extra files
 if [ -d $VENDOR_BASE/share/icons/Adwaita ]; then
@@ -125,6 +140,8 @@ echo 'export GTK_EXE_PREFIX="$APPDIR/usr"' >> AppDir/apprun-hooks/linuxdeploy-pl
 echo 'export GTK_PATH="$APPDIR/usr/lib/gtk-4.0"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 echo 'export GDK_PIXBUF_MODULE_FILE="$APPDIR/usr/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache"' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 echo 'export FONTCONFIG_PATH=/etc/fonts' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+echo 'export XKB_CONFIG_ROOT=/usr/share/X11/xkb' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
+echo 'export QT_XKB_CONFIG_ROOT=/usr/share/X11/xkb' >> AppDir/apprun-hooks/linuxdeploy-plugin-gtk.sh
 
 # Check for symlinks in /lib (specifically when built in CI)
 for f in $(find AppDir/usr/lib -type l); do


### PR DESCRIPTION
GitHub Actions should come with Linuxbrew.

Since Linuxbrew makes easy to install foreign recipes (such as compiling new versions of dependencies on older versions of an OS, or even downloading bottles), this PR will switch the compilation environment for the AppImage to Homebrew on Ubuntu 22.04.

Ubuntu 22.04 actually packs an older version of glibc than Debian 12, so since Linuxbrew may actually install a version of the dependencies that is compiled against an old version of glibc, this should create an AppImage that actually expects an old version of glibc and thus works on Ubuntu 22.04 and Debian 12.