### PR TITLE
Add an error pane to display request related errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,6 @@ dependencies = [
  "serde_urlencoded",
  "sourceview5",
  "srtemplate",
- "thiserror",
  "tokio",
  "toml",
  "url 2.5.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ serde_json = "1.0.120"
 serde_urlencoded = "0.7.1"
 sourceview5 = "0.9.1"
 srtemplate = { version = "0.3.0", features = [] }
-thiserror = "1.0.60"
 tokio = { version = "1.37.0", features = ["sync"] }
 toml = "0.8.12"
 url = "2.5.2"

--- a/data/cartero.gresource.xml
+++ b/data/cartero.gresource.xml
@@ -4,6 +4,7 @@
     <file alias="style.css" compressed="true">style.css</file>
     <file alias="gtk/help-overlay.ui" compressed="true" preprocess="xml-stripblanks">gtk/help_overlay.ui</file>
     <file alias="endpoint_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/endpoint_pane.ui</file>
+    <file alias="error_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/error_pane.ui</file>
     <file alias="formdata_payload_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/formdata_payload_pane.ui</file>
     <file alias="key_value_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/key_value_pane.ui</file>
     <file alias="key_value_row.ui" compressed="true" preprocess="xml-stripblanks">ui/key_value_row.ui</file>

--- a/data/meson.build
+++ b/data/meson.build
@@ -19,6 +19,7 @@ blueprint_files = [
   'gtk/help_overlay.blp',
   'ui/code_export_pane.blp',
   'ui/endpoint_pane.blp',
+  'ui/error_pane.blp',
   'ui/export_tab.blp',
   'ui/formdata_payload_pane.blp',
   'ui/key_value_pane.blp',

--- a/data/ui/error_pane.blp
+++ b/data/ui/error_pane.blp
@@ -20,8 +20,8 @@ using Adw 1;
 
 template $CarteroErrorPane: Adw.Bin {
   Adw.StatusPage {
-    icon-name: "network-error-symbolic";
-    title: _("Cannot perform request");
+    icon-name: bind template.icon;
+    title: bind template.title;
     description: bind template.subtitle;
 
     child: Gtk.Label {

--- a/data/ui/error_pane.blp
+++ b/data/ui/error_pane.blp
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024-2025 the Cartero authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Gtk 4.0;
+using Adw 1;
+
+template $CarteroErrorPane: Adw.Bin {
+  Adw.StatusPage {
+    icon-name: "network-error-symbolic";
+    title: _("Cannot perform request");
+    description: bind template.subtitle;
+
+    child: Gtk.Label {
+      label: bind template.extra;
+      selectable: true;
+      visible: bind $extra_visible(template.extra) as <bool>;
+      opacity: 0.80;
+      wrap: true;
+    };
+  }
+}

--- a/data/ui/response_panel.blp
+++ b/data/ui/response_panel.blp
@@ -36,11 +36,13 @@ template $CarteroResponsePanel: Adw.Bin {
 
       child: Adw.StatusPage error_page {
         icon-name: "network-error-symbolic";
-        title: _("Request error");
+        title: _("Cannot perform request");
 
         child: Gtk.Label error_extra {
-          label: "PRUEBA";
+          label: "";
           selectable: true;
+          opacity: 0.75;
+          wrap: true;
         };
       };
     }

--- a/data/ui/response_panel.blp
+++ b/data/ui/response_panel.blp
@@ -34,17 +34,7 @@ template $CarteroResponsePanel: Adw.Bin {
     StackPage {
       name: "error";
 
-      child: Adw.StatusPage error_page {
-        icon-name: "network-error-symbolic";
-        title: _("Cannot perform request");
-
-        child: Gtk.Label error_extra {
-          label: "";
-          selectable: true;
-          opacity: 0.75;
-          wrap: true;
-        };
-      };
+      child: $CarteroErrorPane error_page {};
     }
 
     StackPage {

--- a/data/ui/response_panel.blp
+++ b/data/ui/response_panel.blp
@@ -32,6 +32,20 @@ template $CarteroResponsePanel: Adw.Bin {
     }
 
     StackPage {
+      name: "error";
+
+      child: Adw.StatusPage error_page {
+        icon-name: "network-error-symbolic";
+        title: _("Request error");
+
+        child: Gtk.Label error_extra {
+          label: "PRUEBA";
+          selectable: true;
+        };
+      };
+    }
+
+    StackPage {
       name: "response";
 
       child: Overlay {

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,6 +7,7 @@ data/es.danirod.Cartero.gschema.xml
 data/gtk/help_overlay.blp
 data/ui/code_export_pane.blp
 data/ui/endpoint_pane.blp
+data/ui/error_pane.blp
 data/ui/export_tab.blp
 data/ui/formdata_payload_pane.blp
 data/ui/key_value_pane.blp
@@ -36,6 +37,7 @@ src/objects/mod.rs
 src/widgets/code_view.rs
 src/widgets/dialogs.rs
 src/widgets/endpoint_pane.rs
+src/widgets/error_pane.rs
 src/widgets/export_tab/base.rs
 src/widgets/export_tab/code.rs
 src/widgets/export_tab/mod.rs

--- a/po/ca.po
+++ b/po/ca.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 13:48+0100\n"
+"POT-Creation-Date: 2025-03-11 14:02+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -528,18 +528,26 @@ msgstr ""
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:86 src/error.rs:110
+#: src/error.rs:84
+msgid "There is a network error"
+msgstr ""
+
+#: src/error.rs:85
+msgid "There is an input/output error"
+msgstr ""
+
+#: src/error.rs:111 src/error.rs:135
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "La llista actual d'arxius oberts"
 
-#: src/error.rs:88
+#: src/error.rs:113
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:92
+#: src/error.rs:117
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -633,26 +641,14 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Guardar"
 
-#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
+#: src/widgets/error_pane.rs:93 src/widgets/error_pane.rs:106
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:101
+#: src/widgets/error_pane.rs:99
 #, fuzzy
 msgid "The request failed"
 msgstr "Fes peticions HTTP i testeja APIs"
-
-#: src/widgets/error_pane.rs:103
-msgid "There is an HTTP error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:104
-msgid "There is a network error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:105
-msgid "There is an input/output error"
-msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/ca.po
+++ b/po/ca.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-06 03:50+0100\n"
+"POT-Creation-Date: 2025-03-08 11:15+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -233,7 +233,7 @@ msgstr "Executar aquesta petició HTTP"
 msgid "Parameters"
 msgstr "Paràmetres"
 
-#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:91
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Capçaleres"
 
@@ -241,7 +241,7 @@ msgstr "Capçaleres"
 msgid "Variables"
 msgstr "Variables"
 
-#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:47
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Cos"
 
@@ -492,18 +492,42 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:63 src/error.rs:87
+#: src/error.rs:18
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:19
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:21
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:24
+msgid "The given request body could not be encoded correctly"
+msgstr ""
+
+#: src/error.rs:26
+msgid "The variable '{}' is not defined"
+msgstr ""
+
+#: src/error.rs:30
+msgid "There was a problem with a variable interpolation, review your inputs"
+msgstr ""
+
+#: src/error.rs:57 src/error.rs:81
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "La llista actual d'arxius oberts"
 
-#: src/error.rs:65
+#: src/error.rs:59
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:69
+#: src/error.rs:63
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -521,81 +545,90 @@ msgstr ""
 msgid "Cannot open the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:90
-#: src/widgets/dialogs.rs:113 src/widgets/dialogs.rs:126
+#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:93
+#: src/widgets/dialogs.rs:119 src/widgets/dialogs.rs:135
 #, fuzzy
 msgid "Close"
 msgstr "Tancar pestanya"
 
-#: src/widgets/dialogs.rs:73
+#: src/widgets/dialogs.rs:76
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:74
+#: src/widgets/dialogs.rs:77
 msgid "The requested file was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:104
+#: src/widgets/dialogs.rs:110
 msgid "Cannot save '{}'"
 msgstr ""
 
-#: src/widgets/dialogs.rs:105
+#: src/widgets/dialogs.rs:111
 msgid "Cannot save the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:107
+#: src/widgets/dialogs.rs:113
 msgid ""
 "There was an error during the saving process. Assume that your changes are "
 "still not saved."
 msgstr ""
 
-#: src/widgets/dialogs.rs:121
+#: src/widgets/dialogs.rs:130
 msgid "Could not select a valid file from the file chooser"
 msgstr ""
 
-#: src/widgets/dialogs.rs:135
+#: src/widgets/dialogs.rs:147
 msgid "There are unsaved changes"
 msgstr ""
 
-#: src/widgets/dialogs.rs:137
+#: src/widgets/dialogs.rs:149
 msgid ""
 "Closing this window will lose all unsaved data. Do you really want to "
 "proceed?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:141
+#: src/widgets/dialogs.rs:153
 msgid "Cancel"
 msgstr "Cancel·lar"
 
-#: src/widgets/dialogs.rs:142
+#: src/widgets/dialogs.rs:154
 #, fuzzy
 msgid "Close anyway"
 msgstr "Tancar pestanya"
 
-#: src/widgets/dialogs.rs:165
+#: src/widgets/dialogs.rs:180
 #, fuzzy
 msgid "Save changes in '{}'?"
 msgstr "¿Guardar cambis?"
 
-#: src/widgets/dialogs.rs:166
+#: src/widgets/dialogs.rs:181
 msgid "Save changes?"
 msgstr "¿Guardar cambis?"
 
-#: src/widgets/dialogs.rs:171
+#: src/widgets/dialogs.rs:186
 msgid "There are changes that have not been saved yet. What do you want to do?"
 msgstr "Hi ha canvis que encara no han sigut guardats. ¿Què vols fer?"
 
-#: src/widgets/dialogs.rs:175
+#: src/widgets/dialogs.rs:190
 msgid "_Cancel"
 msgstr "_Cancel·lar"
 
-#: src/widgets/dialogs.rs:176
+#: src/widgets/dialogs.rs:191
 msgid "_Discard"
 msgstr "_Descartar"
 
-#: src/widgets/dialogs.rs:177
+#: src/widgets/dialogs.rs:192
 msgid "_Save"
 msgstr "_Guardar"
+
+#: src/widgets/error_pane.rs:90
+msgid "The request data is not valid"
+msgstr ""
+
+#: src/widgets/error_pane.rs:96
+#, fuzzy
+msgid "The HTTP request failed"
+msgstr "Fes peticions HTTP i testeja APIs"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"
@@ -635,11 +668,11 @@ msgid_plural "{} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/win.rs:689
+#: src/win.rs:685
 msgid "The Cartero authors"
 msgstr "Els autors de Cartero"
 
-#: src/win.rs:690
+#: src/win.rs:686
 msgid "© 2024 the Cartero authors"
 msgstr "© 2024 Els autors de Cartero"
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-08 11:15+0100\n"
+"POT-Creation-Date: 2025-03-11 13:48+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -492,42 +492,54 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:18
-msgid "Cannot recognise the URL"
+#: src/error.rs:16
+msgid "The specified URL is not valid"
+msgstr ""
+
+#: src/error.rs:17
+msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:19
-msgid "The given URL is missing a protocol"
+msgid "The value for header '{}' is not valid"
 msgstr ""
 
-#: src/error.rs:21
-msgid "The protocol {}:// is not supported"
-msgstr ""
-
-#: src/error.rs:24
+#: src/error.rs:22 src/error.rs:56
 msgid "The given request body could not be encoded correctly"
 msgstr ""
 
-#: src/error.rs:26
+#: src/error.rs:51
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:52
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:54
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:57
 msgid "The variable '{}' is not defined"
 msgstr ""
 
-#: src/error.rs:30
+#: src/error.rs:59
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:57 src/error.rs:81
+#: src/error.rs:86 src/error.rs:110
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "La llista actual d'arxius oberts"
 
-#: src/error.rs:59
+#: src/error.rs:88
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:63
+#: src/error.rs:92
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -621,14 +633,26 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Guardar"
 
-#: src/widgets/error_pane.rs:90
+#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:96
+#: src/widgets/error_pane.rs:101
 #, fuzzy
-msgid "The HTTP request failed"
+msgid "The request failed"
 msgstr "Fes peticions HTTP i testeja APIs"
+
+#: src/widgets/error_pane.rs:103
+msgid "There is an HTTP error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:104
+msgid "There is a network error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:105
+msgid "There is an input/output error"
+msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/cartero.pot
+++ b/po/cartero.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 13:48+0100\n"
+"POT-Creation-Date: 2025-03-11 14:02+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -518,17 +518,25 @@ msgstr ""
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:86 src/error.rs:110
+#: src/error.rs:84
+msgid "There is a network error"
+msgstr ""
+
+#: src/error.rs:85
+msgid "There is an input/output error"
+msgstr ""
+
+#: src/error.rs:111 src/error.rs:135
 msgid "The current tab is not associated with a file"
 msgstr ""
 
-#: src/error.rs:88
+#: src/error.rs:113
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:92
+#: src/error.rs:117
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -619,24 +627,12 @@ msgstr ""
 msgid "_Save"
 msgstr ""
 
-#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
+#: src/widgets/error_pane.rs:93 src/widgets/error_pane.rs:106
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:101
+#: src/widgets/error_pane.rs:99
 msgid "The request failed"
-msgstr ""
-
-#: src/widgets/error_pane.rs:103
-msgid "There is an HTTP error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:104
-msgid "There is a network error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:105
-msgid "There is an input/output error"
 msgstr ""
 
 #: src/widgets/export_tab/code.rs:114

--- a/po/cartero.pot
+++ b/po/cartero.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-06 03:50+0100\n"
+"POT-Creation-Date: 2025-03-08 11:15+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -225,7 +225,7 @@ msgstr ""
 msgid "Parameters"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:91
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr ""
 
@@ -233,7 +233,7 @@ msgstr ""
 msgid "Variables"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:47
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr ""
 
@@ -482,17 +482,41 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:63 src/error.rs:87
+#: src/error.rs:18
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:19
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:21
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:24
+msgid "The given request body could not be encoded correctly"
+msgstr ""
+
+#: src/error.rs:26
+msgid "The variable '{}' is not defined"
+msgstr ""
+
+#: src/error.rs:30
+msgid "There was a problem with a variable interpolation, review your inputs"
+msgstr ""
+
+#: src/error.rs:57 src/error.rs:81
 msgid "The current tab is not associated with a file"
 msgstr ""
 
-#: src/error.rs:65
+#: src/error.rs:59
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:69
+#: src/error.rs:63
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -510,77 +534,85 @@ msgstr ""
 msgid "Cannot open the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:90
-#: src/widgets/dialogs.rs:113 src/widgets/dialogs.rs:126
+#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:93
+#: src/widgets/dialogs.rs:119 src/widgets/dialogs.rs:135
 msgid "Close"
 msgstr ""
 
-#: src/widgets/dialogs.rs:73
+#: src/widgets/dialogs.rs:76
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:74
+#: src/widgets/dialogs.rs:77
 msgid "The requested file was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:104
+#: src/widgets/dialogs.rs:110
 msgid "Cannot save '{}'"
 msgstr ""
 
-#: src/widgets/dialogs.rs:105
+#: src/widgets/dialogs.rs:111
 msgid "Cannot save the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:107
+#: src/widgets/dialogs.rs:113
 msgid ""
 "There was an error during the saving process. Assume that your changes are "
 "still not saved."
 msgstr ""
 
-#: src/widgets/dialogs.rs:121
+#: src/widgets/dialogs.rs:130
 msgid "Could not select a valid file from the file chooser"
 msgstr ""
 
-#: src/widgets/dialogs.rs:135
+#: src/widgets/dialogs.rs:147
 msgid "There are unsaved changes"
 msgstr ""
 
-#: src/widgets/dialogs.rs:137
+#: src/widgets/dialogs.rs:149
 msgid ""
 "Closing this window will lose all unsaved data. Do you really want to "
 "proceed?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:141
+#: src/widgets/dialogs.rs:153
 msgid "Cancel"
 msgstr ""
 
-#: src/widgets/dialogs.rs:142
+#: src/widgets/dialogs.rs:154
 msgid "Close anyway"
 msgstr ""
 
-#: src/widgets/dialogs.rs:165
+#: src/widgets/dialogs.rs:180
 msgid "Save changes in '{}'?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:166
+#: src/widgets/dialogs.rs:181
 msgid "Save changes?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:171
+#: src/widgets/dialogs.rs:186
 msgid "There are changes that have not been saved yet. What do you want to do?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:175
+#: src/widgets/dialogs.rs:190
 msgid "_Cancel"
 msgstr ""
 
-#: src/widgets/dialogs.rs:176
+#: src/widgets/dialogs.rs:191
 msgid "_Discard"
 msgstr ""
 
-#: src/widgets/dialogs.rs:177
+#: src/widgets/dialogs.rs:192
 msgid "_Save"
+msgstr ""
+
+#: src/widgets/error_pane.rs:90
+msgid "The request data is not valid"
+msgstr ""
+
+#: src/widgets/error_pane.rs:96
+msgid "The HTTP request failed"
 msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
@@ -621,10 +653,10 @@ msgid_plural "{} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/win.rs:689
+#: src/win.rs:685
 msgid "The Cartero authors"
 msgstr ""
 
-#: src/win.rs:690
+#: src/win.rs:686
 msgid "© 2024 the Cartero authors"
 msgstr ""

--- a/po/cartero.pot
+++ b/po/cartero.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-08 11:15+0100\n"
+"POT-Creation-Date: 2025-03-11 13:48+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -482,41 +482,53 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:18
-msgid "Cannot recognise the URL"
+#: src/error.rs:16
+msgid "The specified URL is not valid"
+msgstr ""
+
+#: src/error.rs:17
+msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:19
-msgid "The given URL is missing a protocol"
+msgid "The value for header '{}' is not valid"
 msgstr ""
 
-#: src/error.rs:21
-msgid "The protocol {}:// is not supported"
-msgstr ""
-
-#: src/error.rs:24
+#: src/error.rs:22 src/error.rs:56
 msgid "The given request body could not be encoded correctly"
 msgstr ""
 
-#: src/error.rs:26
+#: src/error.rs:51
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:52
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:54
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:57
 msgid "The variable '{}' is not defined"
 msgstr ""
 
-#: src/error.rs:30
+#: src/error.rs:59
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:57 src/error.rs:81
+#: src/error.rs:86 src/error.rs:110
 msgid "The current tab is not associated with a file"
 msgstr ""
 
-#: src/error.rs:59
+#: src/error.rs:88
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:63
+#: src/error.rs:92
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -607,12 +619,24 @@ msgstr ""
 msgid "_Save"
 msgstr ""
 
-#: src/widgets/error_pane.rs:90
+#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:96
-msgid "The HTTP request failed"
+#: src/widgets/error_pane.rs:101
+msgid "The request failed"
+msgstr ""
+
+#: src/widgets/error_pane.rs:103
+msgid "There is an HTTP error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:104
+msgid "There is a network error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:105
+msgid "There is an input/output error"
 msgstr ""
 
 #: src/widgets/export_tab/code.rs:114

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 13:48+0100\n"
+"POT-Creation-Date: 2025-03-11 14:02+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: vesp <vesp@post.cz>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartero/cartero/cs/"
@@ -531,18 +531,26 @@ msgstr ""
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:86 src/error.rs:110
+#: src/error.rs:84
+msgid "There is a network error"
+msgstr ""
+
+#: src/error.rs:85
+msgid "There is an input/output error"
+msgstr ""
+
+#: src/error.rs:111 src/error.rs:135
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "Aktuální seznam otevřených souborů"
 
-#: src/error.rs:88
+#: src/error.rs:113
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:92
+#: src/error.rs:117
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -637,26 +645,14 @@ msgstr "Zahodi_t změny"
 msgid "_Save"
 msgstr "_Uložit"
 
-#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
+#: src/widgets/error_pane.rs:93 src/widgets/error_pane.rs:106
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:101
+#: src/widgets/error_pane.rs:99
 #, fuzzy
 msgid "The request failed"
 msgstr "Spouštějte HTTP volání a testujte API"
-
-#: src/widgets/error_pane.rs:103
-msgid "There is an HTTP error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:104
-msgid "There is a network error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:105
-msgid "There is an input/output error"
-msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-06 03:50+0100\n"
+"POT-Creation-Date: 2025-03-08 11:15+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: vesp <vesp@post.cz>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartero/cartero/cs/"
@@ -234,7 +234,7 @@ msgstr "Provést tento HTTP požadavek"
 msgid "Parameters"
 msgstr "Parametry"
 
-#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:91
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Hlavičky"
 
@@ -242,7 +242,7 @@ msgstr "Hlavičky"
 msgid "Variables"
 msgstr "Proměnné"
 
-#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:47
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Tělo"
 
@@ -495,18 +495,42 @@ msgstr "Maximální počet přesměrování"
 msgid "Request timeout"
 msgstr "Časový limit požadavku"
 
-#: src/error.rs:63 src/error.rs:87
+#: src/error.rs:18
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:19
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:21
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:24
+msgid "The given request body could not be encoded correctly"
+msgstr ""
+
+#: src/error.rs:26
+msgid "The variable '{}' is not defined"
+msgstr ""
+
+#: src/error.rs:30
+msgid "There was a problem with a variable interpolation, review your inputs"
+msgstr ""
+
+#: src/error.rs:57 src/error.rs:81
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "Aktuální seznam otevřených souborů"
 
-#: src/error.rs:65
+#: src/error.rs:59
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:69
+#: src/error.rs:63
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -524,82 +548,91 @@ msgstr ""
 msgid "Cannot open the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:90
-#: src/widgets/dialogs.rs:113 src/widgets/dialogs.rs:126
+#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:93
+#: src/widgets/dialogs.rs:119 src/widgets/dialogs.rs:135
 #, fuzzy
 msgid "Close"
 msgstr "Zavřít panel"
 
-#: src/widgets/dialogs.rs:73
+#: src/widgets/dialogs.rs:76
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:74
+#: src/widgets/dialogs.rs:77
 msgid "The requested file was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:104
+#: src/widgets/dialogs.rs:110
 msgid "Cannot save '{}'"
 msgstr ""
 
-#: src/widgets/dialogs.rs:105
+#: src/widgets/dialogs.rs:111
 msgid "Cannot save the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:107
+#: src/widgets/dialogs.rs:113
 msgid ""
 "There was an error during the saving process. Assume that your changes are "
 "still not saved."
 msgstr ""
 
-#: src/widgets/dialogs.rs:121
+#: src/widgets/dialogs.rs:130
 msgid "Could not select a valid file from the file chooser"
 msgstr ""
 
-#: src/widgets/dialogs.rs:135
+#: src/widgets/dialogs.rs:147
 msgid "There are unsaved changes"
 msgstr ""
 
-#: src/widgets/dialogs.rs:137
+#: src/widgets/dialogs.rs:149
 msgid ""
 "Closing this window will lose all unsaved data. Do you really want to "
 "proceed?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:141
+#: src/widgets/dialogs.rs:153
 #, fuzzy
 msgid "Cancel"
 msgstr "_Zrušit"
 
-#: src/widgets/dialogs.rs:142
+#: src/widgets/dialogs.rs:154
 #, fuzzy
 msgid "Close anyway"
 msgstr "Zavřít panel"
 
-#: src/widgets/dialogs.rs:165
+#: src/widgets/dialogs.rs:180
 #, fuzzy
 msgid "Save changes in '{}'?"
 msgstr "Uložit změny?"
 
-#: src/widgets/dialogs.rs:166
+#: src/widgets/dialogs.rs:181
 msgid "Save changes?"
 msgstr "Uložit změny?"
 
-#: src/widgets/dialogs.rs:171
+#: src/widgets/dialogs.rs:186
 msgid "There are changes that have not been saved yet. What do you want to do?"
 msgstr "Máte neuložené změny. Co chcete udělat?"
 
-#: src/widgets/dialogs.rs:175
+#: src/widgets/dialogs.rs:190
 msgid "_Cancel"
 msgstr "_Zrušit"
 
-#: src/widgets/dialogs.rs:176
+#: src/widgets/dialogs.rs:191
 msgid "_Discard"
 msgstr "Zahodi_t změny"
 
-#: src/widgets/dialogs.rs:177
+#: src/widgets/dialogs.rs:192
 msgid "_Save"
 msgstr "_Uložit"
+
+#: src/widgets/error_pane.rs:90
+msgid "The request data is not valid"
+msgstr ""
+
+#: src/widgets/error_pane.rs:96
+#, fuzzy
+msgid "The HTTP request failed"
+msgstr "Spouštějte HTTP volání a testujte API"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"
@@ -640,10 +673,10 @@ msgstr[0] "{} požadavek"
 msgstr[1] "{} požadavky"
 msgstr[2] "{} požadavků"
 
-#: src/win.rs:689
+#: src/win.rs:685
 msgid "The Cartero authors"
 msgstr "Autoři aplikace Cartero"
 
-#: src/win.rs:690
+#: src/win.rs:686
 msgid "© 2024 the Cartero authors"
 msgstr "© 2024 autoři aplikace Cartero"

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-08 11:15+0100\n"
+"POT-Creation-Date: 2025-03-11 13:48+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: vesp <vesp@post.cz>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartero/cartero/cs/"
@@ -495,42 +495,54 @@ msgstr "Maximální počet přesměrování"
 msgid "Request timeout"
 msgstr "Časový limit požadavku"
 
-#: src/error.rs:18
-msgid "Cannot recognise the URL"
+#: src/error.rs:16
+msgid "The specified URL is not valid"
+msgstr ""
+
+#: src/error.rs:17
+msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:19
-msgid "The given URL is missing a protocol"
+msgid "The value for header '{}' is not valid"
 msgstr ""
 
-#: src/error.rs:21
-msgid "The protocol {}:// is not supported"
-msgstr ""
-
-#: src/error.rs:24
+#: src/error.rs:22 src/error.rs:56
 msgid "The given request body could not be encoded correctly"
 msgstr ""
 
-#: src/error.rs:26
+#: src/error.rs:51
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:52
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:54
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:57
 msgid "The variable '{}' is not defined"
 msgstr ""
 
-#: src/error.rs:30
+#: src/error.rs:59
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:57 src/error.rs:81
+#: src/error.rs:86 src/error.rs:110
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "Aktuální seznam otevřených souborů"
 
-#: src/error.rs:59
+#: src/error.rs:88
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:63
+#: src/error.rs:92
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -625,14 +637,26 @@ msgstr "Zahodi_t změny"
 msgid "_Save"
 msgstr "_Uložit"
 
-#: src/widgets/error_pane.rs:90
+#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:96
+#: src/widgets/error_pane.rs:101
 #, fuzzy
-msgid "The HTTP request failed"
+msgid "The request failed"
 msgstr "Spouštějte HTTP volání a testujte API"
+
+#: src/widgets/error_pane.rs:103
+msgid "There is an HTTP error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:104
+msgid "There is a network error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:105
+msgid "There is an input/output error"
+msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/eo.po
+++ b/po/eo.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-06 03:50+0100\n"
+"POT-Creation-Date: 2025-03-08 11:15+0100\n"
 "PO-Revision-Date: 2024-11-04 17:46+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/cartero/"
@@ -224,7 +224,7 @@ msgstr "Sendu ĉi tiun http-peton"
 msgid "Parameters"
 msgstr "Parametroj"
 
-#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:91
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Kapoj"
 
@@ -232,7 +232,7 @@ msgstr "Kapoj"
 msgid "Variables"
 msgstr "Variabloj"
 
-#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:47
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Korpo"
 
@@ -481,17 +481,41 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:63 src/error.rs:87
+#: src/error.rs:18
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:19
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:21
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:24
+msgid "The given request body could not be encoded correctly"
+msgstr ""
+
+#: src/error.rs:26
+msgid "The variable '{}' is not defined"
+msgstr ""
+
+#: src/error.rs:30
+msgid "There was a problem with a variable interpolation, review your inputs"
+msgstr ""
+
+#: src/error.rs:57 src/error.rs:81
 msgid "The current tab is not associated with a file"
 msgstr ""
 
-#: src/error.rs:65
+#: src/error.rs:59
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:69
+#: src/error.rs:63
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -509,78 +533,87 @@ msgstr ""
 msgid "Cannot open the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:90
-#: src/widgets/dialogs.rs:113 src/widgets/dialogs.rs:126
+#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:93
+#: src/widgets/dialogs.rs:119 src/widgets/dialogs.rs:135
 msgid "Close"
 msgstr ""
 
-#: src/widgets/dialogs.rs:73
+#: src/widgets/dialogs.rs:76
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:74
+#: src/widgets/dialogs.rs:77
 msgid "The requested file was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:104
+#: src/widgets/dialogs.rs:110
 msgid "Cannot save '{}'"
 msgstr ""
 
-#: src/widgets/dialogs.rs:105
+#: src/widgets/dialogs.rs:111
 msgid "Cannot save the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:107
+#: src/widgets/dialogs.rs:113
 msgid ""
 "There was an error during the saving process. Assume that your changes are "
 "still not saved."
 msgstr ""
 
-#: src/widgets/dialogs.rs:121
+#: src/widgets/dialogs.rs:130
 msgid "Could not select a valid file from the file chooser"
 msgstr ""
 
-#: src/widgets/dialogs.rs:135
+#: src/widgets/dialogs.rs:147
 msgid "There are unsaved changes"
 msgstr ""
 
-#: src/widgets/dialogs.rs:137
+#: src/widgets/dialogs.rs:149
 msgid ""
 "Closing this window will lose all unsaved data. Do you really want to "
 "proceed?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:141
+#: src/widgets/dialogs.rs:153
 msgid "Cancel"
 msgstr ""
 
-#: src/widgets/dialogs.rs:142
+#: src/widgets/dialogs.rs:154
 msgid "Close anyway"
 msgstr ""
 
-#: src/widgets/dialogs.rs:165
+#: src/widgets/dialogs.rs:180
 msgid "Save changes in '{}'?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:166
+#: src/widgets/dialogs.rs:181
 msgid "Save changes?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:171
+#: src/widgets/dialogs.rs:186
 msgid "There are changes that have not been saved yet. What do you want to do?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:175
+#: src/widgets/dialogs.rs:190
 msgid "_Cancel"
 msgstr ""
 
-#: src/widgets/dialogs.rs:176
+#: src/widgets/dialogs.rs:191
 msgid "_Discard"
 msgstr ""
 
-#: src/widgets/dialogs.rs:177
+#: src/widgets/dialogs.rs:192
 msgid "_Save"
 msgstr ""
+
+#: src/widgets/error_pane.rs:90
+msgid "The request data is not valid"
+msgstr ""
+
+#: src/widgets/error_pane.rs:96
+#, fuzzy
+msgid "The HTTP request failed"
+msgstr "Sendu HTTP-petojn kaj testu retaj API-oj"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"
@@ -620,11 +653,11 @@ msgid_plural "{} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/win.rs:689
+#: src/win.rs:685
 msgid "The Cartero authors"
 msgstr ""
 
-#: src/win.rs:690
+#: src/win.rs:686
 msgid "© 2024 the Cartero authors"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-08 11:15+0100\n"
+"POT-Creation-Date: 2025-03-11 13:48+0100\n"
 "PO-Revision-Date: 2024-11-04 17:46+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/cartero/"
@@ -481,41 +481,53 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:18
-msgid "Cannot recognise the URL"
+#: src/error.rs:16
+msgid "The specified URL is not valid"
+msgstr ""
+
+#: src/error.rs:17
+msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:19
-msgid "The given URL is missing a protocol"
+msgid "The value for header '{}' is not valid"
 msgstr ""
 
-#: src/error.rs:21
-msgid "The protocol {}:// is not supported"
-msgstr ""
-
-#: src/error.rs:24
+#: src/error.rs:22 src/error.rs:56
 msgid "The given request body could not be encoded correctly"
 msgstr ""
 
-#: src/error.rs:26
+#: src/error.rs:51
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:52
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:54
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:57
 msgid "The variable '{}' is not defined"
 msgstr ""
 
-#: src/error.rs:30
+#: src/error.rs:59
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:57 src/error.rs:81
+#: src/error.rs:86 src/error.rs:110
 msgid "The current tab is not associated with a file"
 msgstr ""
 
-#: src/error.rs:59
+#: src/error.rs:88
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:63
+#: src/error.rs:92
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -606,14 +618,26 @@ msgstr ""
 msgid "_Save"
 msgstr ""
 
-#: src/widgets/error_pane.rs:90
+#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:96
+#: src/widgets/error_pane.rs:101
 #, fuzzy
-msgid "The HTTP request failed"
+msgid "The request failed"
 msgstr "Sendu HTTP-petojn kaj testu retaj API-oj"
+
+#: src/widgets/error_pane.rs:103
+msgid "There is an HTTP error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:104
+msgid "There is a network error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:105
+msgid "There is an input/output error"
+msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/eo.po
+++ b/po/eo.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 13:48+0100\n"
+"POT-Creation-Date: 2025-03-11 14:02+0100\n"
 "PO-Revision-Date: 2024-11-04 17:46+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/cartero/"
@@ -517,17 +517,25 @@ msgstr ""
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:86 src/error.rs:110
+#: src/error.rs:84
+msgid "There is a network error"
+msgstr ""
+
+#: src/error.rs:85
+msgid "There is an input/output error"
+msgstr ""
+
+#: src/error.rs:111 src/error.rs:135
 msgid "The current tab is not associated with a file"
 msgstr ""
 
-#: src/error.rs:88
+#: src/error.rs:113
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:92
+#: src/error.rs:117
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -618,26 +626,14 @@ msgstr ""
 msgid "_Save"
 msgstr ""
 
-#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
+#: src/widgets/error_pane.rs:93 src/widgets/error_pane.rs:106
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:101
+#: src/widgets/error_pane.rs:99
 #, fuzzy
 msgid "The request failed"
 msgstr "Sendu HTTP-petojn kaj testu retaj API-oj"
-
-#: src/widgets/error_pane.rs:103
-msgid "There is an HTTP error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:104
-msgid "There is a network error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:105
-msgid "There is an input/output error"
-msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-08 11:15+0100\n"
+"POT-Creation-Date: 2025-03-11 13:48+0100\n"
 "PO-Revision-Date: 2025-03-06 22:02+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -494,35 +494,47 @@ msgstr "Redirecciones máximas"
 msgid "Request timeout"
 msgstr "Tiempo límite de petición"
 
-#: src/error.rs:18
-msgid "Cannot recognise the URL"
-msgstr "No se puede reconocer la URL"
+#: src/error.rs:16
+msgid "The specified URL is not valid"
+msgstr "La URL especificada no es válida"
+
+#: src/error.rs:17
+msgid "The header '{}' is not valid"
+msgstr "La cabecera '{}' no es válida"
 
 #: src/error.rs:19
-msgid "The given URL is missing a protocol"
-msgstr "La URL indicada no tiene un protocolo"
+msgid "The value for header '{}' is not valid"
+msgstr "El valor de la cabecera '{}' no es válido"
 
-#: src/error.rs:21
-msgid "The protocol {}:// is not supported"
-msgstr "El protocolo {}:// no está soportado"
-
-#: src/error.rs:24
+#: src/error.rs:22 src/error.rs:56
 msgid "The given request body could not be encoded correctly"
 msgstr "El cuerpo de petición dado no se pudo codificar correctamente"
 
-#: src/error.rs:26
+#: src/error.rs:51
+msgid "Cannot recognise the URL"
+msgstr "No se puede reconocer la URL"
+
+#: src/error.rs:52
+msgid "The given URL is missing a protocol"
+msgstr "La URL indicada no tiene un protocolo"
+
+#: src/error.rs:54
+msgid "The protocol {}:// is not supported"
+msgstr "El protocolo {}:// no está soportado"
+
+#: src/error.rs:57
 msgid "The variable '{}' is not defined"
 msgstr "La variable '{}' no está definida"
 
-#: src/error.rs:30
+#: src/error.rs:59
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr "Hubo un problema interpolando las variables, revisa las entradas"
 
-#: src/error.rs:57 src/error.rs:81
+#: src/error.rs:86 src/error.rs:110
 msgid "The current tab is not associated with a file"
 msgstr "La pestaña actual no está asociada con un archivo"
 
-#: src/error.rs:59
+#: src/error.rs:88
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
@@ -530,7 +542,7 @@ msgstr ""
 "El archivo ha sido creado con una versión más reciente de este programa; "
 "¡por favor actualiza!"
 
-#: src/error.rs:63
+#: src/error.rs:92
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 "El archivo está corrupto o no contiene datos válidos para esta aplicación"
@@ -628,13 +640,25 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Guardar"
 
-#: src/widgets/error_pane.rs:90
+#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
 msgid "The request data is not valid"
 msgstr "Los datos de la petición no son válidos"
 
-#: src/widgets/error_pane.rs:96
-msgid "The HTTP request failed"
-msgstr "La petición HTTP ha fallado"
+#: src/widgets/error_pane.rs:101
+msgid "The request failed"
+msgstr "La petición ha fallado"
+
+#: src/widgets/error_pane.rs:103
+msgid "There is an HTTP error"
+msgstr "Hay un error HTTP"
+
+#: src/widgets/error_pane.rs:104
+msgid "There is a network error"
+msgstr "Hay un error de red"
+
+#: src/widgets/error_pane.rs:105
+msgid "There is an input/output error"
+msgstr "Hay un error de entrada/salida"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 13:48+0100\n"
+"POT-Creation-Date: 2025-03-11 14:02+0100\n"
 "PO-Revision-Date: 2025-03-06 22:02+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -530,11 +530,19 @@ msgstr "La variable '{}' no está definida"
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr "Hubo un problema interpolando las variables, revisa las entradas"
 
-#: src/error.rs:86 src/error.rs:110
+#: src/error.rs:84
+msgid "There is a network error"
+msgstr "Hay un error de red"
+
+#: src/error.rs:85
+msgid "There is an input/output error"
+msgstr "Hay un error de entrada/salida"
+
+#: src/error.rs:111 src/error.rs:135
 msgid "The current tab is not associated with a file"
 msgstr "La pestaña actual no está asociada con un archivo"
 
-#: src/error.rs:88
+#: src/error.rs:113
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
@@ -542,7 +550,7 @@ msgstr ""
 "El archivo ha sido creado con una versión más reciente de este programa; "
 "¡por favor actualiza!"
 
-#: src/error.rs:92
+#: src/error.rs:117
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 "El archivo está corrupto o no contiene datos válidos para esta aplicación"
@@ -640,25 +648,13 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Guardar"
 
-#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
+#: src/widgets/error_pane.rs:93 src/widgets/error_pane.rs:106
 msgid "The request data is not valid"
 msgstr "Los datos de la petición no son válidos"
 
-#: src/widgets/error_pane.rs:101
+#: src/widgets/error_pane.rs:99
 msgid "The request failed"
 msgstr "La petición ha fallado"
-
-#: src/widgets/error_pane.rs:103
-msgid "There is an HTTP error"
-msgstr "Hay un error HTTP"
-
-#: src/widgets/error_pane.rs:104
-msgid "There is a network error"
-msgstr "Hay un error de red"
-
-#: src/widgets/error_pane.rs:105
-msgid "There is an input/output error"
-msgstr "Hay un error de entrada/salida"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-06 03:50+0100\n"
+"POT-Creation-Date: 2025-03-08 11:15+0100\n"
 "PO-Revision-Date: 2025-03-06 22:02+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -234,7 +234,7 @@ msgstr "Ejecutar esta petición HTTP"
 msgid "Parameters"
 msgstr "Parámetros"
 
-#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:91
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Cabeceras"
 
@@ -242,7 +242,7 @@ msgstr "Cabeceras"
 msgid "Variables"
 msgstr "Variables"
 
-#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:47
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Cuerpo"
 
@@ -494,19 +494,43 @@ msgstr "Redirecciones máximas"
 msgid "Request timeout"
 msgstr "Tiempo límite de petición"
 
-#: src/error.rs:63 src/error.rs:87
+#: src/error.rs:18
+msgid "Cannot recognise the URL"
+msgstr "No se puede reconocer la URL"
+
+#: src/error.rs:19
+msgid "The given URL is missing a protocol"
+msgstr "La URL indicada no tiene un protocolo"
+
+#: src/error.rs:21
+msgid "The protocol {}:// is not supported"
+msgstr "El protocolo {}:// no está soportado"
+
+#: src/error.rs:24
+msgid "The given request body could not be encoded correctly"
+msgstr "El cuerpo de petición dado no se pudo codificar correctamente"
+
+#: src/error.rs:26
+msgid "The variable '{}' is not defined"
+msgstr "La variable '{}' no está definida"
+
+#: src/error.rs:30
+msgid "There was a problem with a variable interpolation, review your inputs"
+msgstr "Hubo un problema interpolando las variables, revisa las entradas"
+
+#: src/error.rs:57 src/error.rs:81
 msgid "The current tab is not associated with a file"
 msgstr "La pestaña actual no está asociada con un archivo"
 
-#: src/error.rs:65
+#: src/error.rs:59
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
-"El archivo ha sido creado con una versión más reciente de este programa; ¡"
-"por favor actualiza!"
+"El archivo ha sido creado con una versión más reciente de este programa; "
+"¡por favor actualiza!"
 
-#: src/error.rs:69
+#: src/error.rs:63
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 "El archivo está corrupto o no contiene datos válidos para esta aplicación"
@@ -527,28 +551,28 @@ msgstr "No se puede abrir '{}'"
 msgid "Cannot open the requested file"
 msgstr "No se puede abrir el archivo solicitado"
 
-#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:90
-#: src/widgets/dialogs.rs:113 src/widgets/dialogs.rs:126
+#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:93
+#: src/widgets/dialogs.rs:119 src/widgets/dialogs.rs:135
 msgid "Close"
 msgstr "Cerrar"
 
-#: src/widgets/dialogs.rs:73
+#: src/widgets/dialogs.rs:76
 msgid "The file '{}' was loaded but had issues"
 msgstr "El archivo '{}' fue cargado pero tenía problemas"
 
-#: src/widgets/dialogs.rs:74
+#: src/widgets/dialogs.rs:77
 msgid "The requested file was loaded but had issues"
 msgstr "El archivo solicitado fue cargado pero tenía problemas"
 
-#: src/widgets/dialogs.rs:104
+#: src/widgets/dialogs.rs:110
 msgid "Cannot save '{}'"
 msgstr "No se puede guardar '{}'"
 
-#: src/widgets/dialogs.rs:105
+#: src/widgets/dialogs.rs:111
 msgid "Cannot save the requested file"
 msgstr "No se puede guardar el archivo solicitado"
 
-#: src/widgets/dialogs.rs:107
+#: src/widgets/dialogs.rs:113
 msgid ""
 "There was an error during the saving process. Assume that your changes are "
 "still not saved."
@@ -556,15 +580,15 @@ msgstr ""
 "Hubo un error durante el proceso de guardado. Asume que tus cambios todavía "
 "no han sido guardados."
 
-#: src/widgets/dialogs.rs:121
+#: src/widgets/dialogs.rs:130
 msgid "Could not select a valid file from the file chooser"
 msgstr "No se pudo seleccionar un archivo válido desde el selector de archivos"
 
-#: src/widgets/dialogs.rs:135
+#: src/widgets/dialogs.rs:147
 msgid "There are unsaved changes"
 msgstr "Hay cambios sin guardar"
 
-#: src/widgets/dialogs.rs:137
+#: src/widgets/dialogs.rs:149
 msgid ""
 "Closing this window will lose all unsaved data. Do you really want to "
 "proceed?"
@@ -572,37 +596,45 @@ msgstr ""
 "Cerrar esta ventana perderá cualquier dato no guardado. ¿De verdad quieres "
 "continuar?"
 
-#: src/widgets/dialogs.rs:141
+#: src/widgets/dialogs.rs:153
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/widgets/dialogs.rs:142
+#: src/widgets/dialogs.rs:154
 msgid "Close anyway"
 msgstr "Cerrar de todos modos"
 
-#: src/widgets/dialogs.rs:165
+#: src/widgets/dialogs.rs:180
 msgid "Save changes in '{}'?"
 msgstr "¿Guardar cambios en '{}'?"
 
-#: src/widgets/dialogs.rs:166
+#: src/widgets/dialogs.rs:181
 msgid "Save changes?"
 msgstr "¿Guardar cambios?"
 
-#: src/widgets/dialogs.rs:171
+#: src/widgets/dialogs.rs:186
 msgid "There are changes that have not been saved yet. What do you want to do?"
 msgstr "Hay cambios que todavía no han sido guardados. ¿Qué quieres hacer?"
 
-#: src/widgets/dialogs.rs:175
+#: src/widgets/dialogs.rs:190
 msgid "_Cancel"
 msgstr "_Cancelar"
 
-#: src/widgets/dialogs.rs:176
+#: src/widgets/dialogs.rs:191
 msgid "_Discard"
 msgstr "_Descartar"
 
-#: src/widgets/dialogs.rs:177
+#: src/widgets/dialogs.rs:192
 msgid "_Save"
 msgstr "_Guardar"
+
+#: src/widgets/error_pane.rs:90
+msgid "The request data is not valid"
+msgstr "Los datos de la petición no son válidos"
+
+#: src/widgets/error_pane.rs:96
+msgid "The HTTP request failed"
+msgstr "La petición HTTP ha fallado"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"
@@ -642,11 +674,11 @@ msgid_plural "{} results"
 msgstr[0] "{} resultado"
 msgstr[1] "{} resultados"
 
-#: src/win.rs:689
+#: src/win.rs:685
 msgid "The Cartero authors"
 msgstr "Los autores de Cartero"
 
-#: src/win.rs:690
+#: src/win.rs:686
 msgid "© 2024 the Cartero authors"
 msgstr "© 2024 los autores de Cartero"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-08 11:15+0100\n"
+"POT-Creation-Date: 2025-03-11 13:48+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: Altero <aurelien.reinert4@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -489,41 +489,53 @@ msgstr "Nombre maximal de redirections"
 msgid "Request timeout"
 msgstr "Délai de requête"
 
-#: src/error.rs:18
-msgid "Cannot recognise the URL"
+#: src/error.rs:16
+msgid "The specified URL is not valid"
+msgstr ""
+
+#: src/error.rs:17
+msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:19
-msgid "The given URL is missing a protocol"
+msgid "The value for header '{}' is not valid"
 msgstr ""
 
-#: src/error.rs:21
-msgid "The protocol {}:// is not supported"
-msgstr ""
-
-#: src/error.rs:24
+#: src/error.rs:22 src/error.rs:56
 msgid "The given request body could not be encoded correctly"
 msgstr ""
 
-#: src/error.rs:26
+#: src/error.rs:51
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:52
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:54
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:57
 msgid "The variable '{}' is not defined"
 msgstr ""
 
-#: src/error.rs:30
+#: src/error.rs:59
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:57 src/error.rs:81
+#: src/error.rs:86 src/error.rs:110
 msgid "The current tab is not associated with a file"
 msgstr ""
 
-#: src/error.rs:59
+#: src/error.rs:88
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:63
+#: src/error.rs:92
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -620,14 +632,26 @@ msgstr "_Abandonner"
 msgid "_Save"
 msgstr "_Enregistrer"
 
-#: src/widgets/error_pane.rs:90
+#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:96
+#: src/widgets/error_pane.rs:101
 #, fuzzy
-msgid "The HTTP request failed"
+msgid "The request failed"
 msgstr "Créer des requêtes HTTP et tester des API"
+
+#: src/widgets/error_pane.rs:103
+msgid "There is an HTTP error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:104
+msgid "There is a network error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:105
+msgid "There is an input/output error"
+msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-06 03:50+0100\n"
+"POT-Creation-Date: 2025-03-08 11:15+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: Altero <aurelien.reinert4@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -227,7 +227,7 @@ msgstr "Exécuter cette requête HTTP"
 msgid "Parameters"
 msgstr "Paramètres"
 
-#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:91
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "En-têtes"
 
@@ -235,7 +235,7 @@ msgstr "En-têtes"
 msgid "Variables"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:47
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Corps"
 
@@ -489,17 +489,41 @@ msgstr "Nombre maximal de redirections"
 msgid "Request timeout"
 msgstr "Délai de requête"
 
-#: src/error.rs:63 src/error.rs:87
+#: src/error.rs:18
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:19
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:21
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:24
+msgid "The given request body could not be encoded correctly"
+msgstr ""
+
+#: src/error.rs:26
+msgid "The variable '{}' is not defined"
+msgstr ""
+
+#: src/error.rs:30
+msgid "There was a problem with a variable interpolation, review your inputs"
+msgstr ""
+
+#: src/error.rs:57 src/error.rs:81
 msgid "The current tab is not associated with a file"
 msgstr ""
 
-#: src/error.rs:65
+#: src/error.rs:59
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:69
+#: src/error.rs:63
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -517,84 +541,93 @@ msgstr ""
 msgid "Cannot open the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:90
-#: src/widgets/dialogs.rs:113 src/widgets/dialogs.rs:126
+#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:93
+#: src/widgets/dialogs.rs:119 src/widgets/dialogs.rs:135
 #, fuzzy
 msgid "Close"
 msgstr "Fermer l'onglet"
 
-#: src/widgets/dialogs.rs:73
+#: src/widgets/dialogs.rs:76
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:74
+#: src/widgets/dialogs.rs:77
 msgid "The requested file was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:104
+#: src/widgets/dialogs.rs:110
 msgid "Cannot save '{}'"
 msgstr ""
 
-#: src/widgets/dialogs.rs:105
+#: src/widgets/dialogs.rs:111
 msgid "Cannot save the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:107
+#: src/widgets/dialogs.rs:113
 msgid ""
 "There was an error during the saving process. Assume that your changes are "
 "still not saved."
 msgstr ""
 
-#: src/widgets/dialogs.rs:121
+#: src/widgets/dialogs.rs:130
 msgid "Could not select a valid file from the file chooser"
 msgstr ""
 
-#: src/widgets/dialogs.rs:135
+#: src/widgets/dialogs.rs:147
 msgid "There are unsaved changes"
 msgstr ""
 
-#: src/widgets/dialogs.rs:137
+#: src/widgets/dialogs.rs:149
 msgid ""
 "Closing this window will lose all unsaved data. Do you really want to "
 "proceed?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:141
+#: src/widgets/dialogs.rs:153
 #, fuzzy
 msgid "Cancel"
 msgstr "_Annuler"
 
-#: src/widgets/dialogs.rs:142
+#: src/widgets/dialogs.rs:154
 #, fuzzy
 msgid "Close anyway"
 msgstr "Fermer l'onglet"
 
-#: src/widgets/dialogs.rs:165
+#: src/widgets/dialogs.rs:180
 #, fuzzy
 msgid "Save changes in '{}'?"
 msgstr "Enregistrer les modifications ?"
 
-#: src/widgets/dialogs.rs:166
+#: src/widgets/dialogs.rs:181
 msgid "Save changes?"
 msgstr "Enregistrer les modifications ?"
 
-#: src/widgets/dialogs.rs:171
+#: src/widgets/dialogs.rs:186
 msgid "There are changes that have not been saved yet. What do you want to do?"
 msgstr ""
 "Certaines modifications n'ont pas encore été enregistrées. Que souhaitez-"
 "vous faire ?"
 
-#: src/widgets/dialogs.rs:175
+#: src/widgets/dialogs.rs:190
 msgid "_Cancel"
 msgstr "_Annuler"
 
-#: src/widgets/dialogs.rs:176
+#: src/widgets/dialogs.rs:191
 msgid "_Discard"
 msgstr "_Abandonner"
 
-#: src/widgets/dialogs.rs:177
+#: src/widgets/dialogs.rs:192
 msgid "_Save"
 msgstr "_Enregistrer"
+
+#: src/widgets/error_pane.rs:90
+msgid "The request data is not valid"
+msgstr ""
+
+#: src/widgets/error_pane.rs:96
+#, fuzzy
+msgid "The HTTP request failed"
+msgstr "Créer des requêtes HTTP et tester des API"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"
@@ -634,10 +667,10 @@ msgid_plural "{} results"
 msgstr[0] "{} résultat"
 msgstr[1] "{} résultats"
 
-#: src/win.rs:689
+#: src/win.rs:685
 msgid "The Cartero authors"
 msgstr "Les auteurs de Cartero"
 
-#: src/win.rs:690
+#: src/win.rs:686
 msgid "© 2024 the Cartero authors"
 msgstr "© 2024 les auteurs de Cartero"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 13:48+0100\n"
+"POT-Creation-Date: 2025-03-11 14:02+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: Altero <aurelien.reinert4@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -525,17 +525,25 @@ msgstr ""
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:86 src/error.rs:110
+#: src/error.rs:84
+msgid "There is a network error"
+msgstr ""
+
+#: src/error.rs:85
+msgid "There is an input/output error"
+msgstr ""
+
+#: src/error.rs:111 src/error.rs:135
 msgid "The current tab is not associated with a file"
 msgstr ""
 
-#: src/error.rs:88
+#: src/error.rs:113
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:92
+#: src/error.rs:117
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -632,26 +640,14 @@ msgstr "_Abandonner"
 msgid "_Save"
 msgstr "_Enregistrer"
 
-#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
+#: src/widgets/error_pane.rs:93 src/widgets/error_pane.rs:106
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:101
+#: src/widgets/error_pane.rs:99
 #, fuzzy
 msgid "The request failed"
 msgstr "Créer des requêtes HTTP et tester des API"
-
-#: src/widgets/error_pane.rs:103
-msgid "There is an HTTP error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:104
-msgid "There is a network error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:105
-msgid "There is an input/output error"
-msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 13:48+0100\n"
+"POT-Creation-Date: 2025-03-11 14:02+0100\n"
 "PO-Revision-Date: 2025-02-01 23:50-0300\n"
 "Last-Translator: john peter <johnppetersa@gmail.com>\n"
 "Language-Team: \n"
@@ -532,18 +532,26 @@ msgstr ""
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:86 src/error.rs:110
+#: src/error.rs:84
+msgid "There is a network error"
+msgstr ""
+
+#: src/error.rs:85
+msgid "There is an input/output error"
+msgstr ""
+
+#: src/error.rs:111 src/error.rs:135
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "A lista atual de arquivos abertos"
 
-#: src/error.rs:88
+#: src/error.rs:113
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:92
+#: src/error.rs:117
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -638,26 +646,14 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Salvar"
 
-#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
+#: src/widgets/error_pane.rs:93 src/widgets/error_pane.rs:106
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:101
+#: src/widgets/error_pane.rs:99
 #, fuzzy
 msgid "The request failed"
 msgstr "Fazer solicitações HTTP e testar APIs"
-
-#: src/widgets/error_pane.rs:103
-msgid "There is an HTTP error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:104
-msgid "There is a network error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:105
-msgid "There is an input/output error"
-msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-08 11:15+0100\n"
+"POT-Creation-Date: 2025-03-11 13:48+0100\n"
 "PO-Revision-Date: 2025-02-01 23:50-0300\n"
 "Last-Translator: john peter <johnppetersa@gmail.com>\n"
 "Language-Team: \n"
@@ -496,42 +496,54 @@ msgstr "Redirecionamentos máximos"
 msgid "Request timeout"
 msgstr "Solicitar tempo limite"
 
-#: src/error.rs:18
-msgid "Cannot recognise the URL"
+#: src/error.rs:16
+msgid "The specified URL is not valid"
+msgstr ""
+
+#: src/error.rs:17
+msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:19
-msgid "The given URL is missing a protocol"
+msgid "The value for header '{}' is not valid"
 msgstr ""
 
-#: src/error.rs:21
-msgid "The protocol {}:// is not supported"
-msgstr ""
-
-#: src/error.rs:24
+#: src/error.rs:22 src/error.rs:56
 msgid "The given request body could not be encoded correctly"
 msgstr ""
 
-#: src/error.rs:26
+#: src/error.rs:51
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:52
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:54
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:57
 msgid "The variable '{}' is not defined"
 msgstr ""
 
-#: src/error.rs:30
+#: src/error.rs:59
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:57 src/error.rs:81
+#: src/error.rs:86 src/error.rs:110
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "A lista atual de arquivos abertos"
 
-#: src/error.rs:59
+#: src/error.rs:88
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:63
+#: src/error.rs:92
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -626,14 +638,26 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Salvar"
 
-#: src/widgets/error_pane.rs:90
+#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:96
+#: src/widgets/error_pane.rs:101
 #, fuzzy
-msgid "The HTTP request failed"
+msgid "The request failed"
 msgstr "Fazer solicitações HTTP e testar APIs"
+
+#: src/widgets/error_pane.rs:103
+msgid "There is an HTTP error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:104
+msgid "There is a network error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:105
+msgid "There is an input/output error"
+msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-06 03:50+0100\n"
+"POT-Creation-Date: 2025-03-08 11:15+0100\n"
 "PO-Revision-Date: 2025-02-01 23:50-0300\n"
 "Last-Translator: john peter <johnppetersa@gmail.com>\n"
 "Language-Team: \n"
@@ -235,7 +235,7 @@ msgstr "Execute esta solicitação HTTP"
 msgid "Parameters"
 msgstr "Parâmetros"
 
-#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:91
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Cabeçalhos"
 
@@ -243,7 +243,7 @@ msgstr "Cabeçalhos"
 msgid "Variables"
 msgstr "Variáveis"
 
-#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:47
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Corpo"
 
@@ -496,18 +496,42 @@ msgstr "Redirecionamentos máximos"
 msgid "Request timeout"
 msgstr "Solicitar tempo limite"
 
-#: src/error.rs:63 src/error.rs:87
+#: src/error.rs:18
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:19
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:21
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:24
+msgid "The given request body could not be encoded correctly"
+msgstr ""
+
+#: src/error.rs:26
+msgid "The variable '{}' is not defined"
+msgstr ""
+
+#: src/error.rs:30
+msgid "There was a problem with a variable interpolation, review your inputs"
+msgstr ""
+
+#: src/error.rs:57 src/error.rs:81
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "A lista atual de arquivos abertos"
 
-#: src/error.rs:65
+#: src/error.rs:59
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:69
+#: src/error.rs:63
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -525,82 +549,91 @@ msgstr ""
 msgid "Cannot open the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:90
-#: src/widgets/dialogs.rs:113 src/widgets/dialogs.rs:126
+#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:93
+#: src/widgets/dialogs.rs:119 src/widgets/dialogs.rs:135
 #, fuzzy
 msgid "Close"
 msgstr "Beche a guia"
 
-#: src/widgets/dialogs.rs:73
+#: src/widgets/dialogs.rs:76
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:74
+#: src/widgets/dialogs.rs:77
 msgid "The requested file was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:104
+#: src/widgets/dialogs.rs:110
 msgid "Cannot save '{}'"
 msgstr ""
 
-#: src/widgets/dialogs.rs:105
+#: src/widgets/dialogs.rs:111
 msgid "Cannot save the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:107
+#: src/widgets/dialogs.rs:113
 msgid ""
 "There was an error during the saving process. Assume that your changes are "
 "still not saved."
 msgstr ""
 
-#: src/widgets/dialogs.rs:121
+#: src/widgets/dialogs.rs:130
 msgid "Could not select a valid file from the file chooser"
 msgstr ""
 
-#: src/widgets/dialogs.rs:135
+#: src/widgets/dialogs.rs:147
 msgid "There are unsaved changes"
 msgstr ""
 
-#: src/widgets/dialogs.rs:137
+#: src/widgets/dialogs.rs:149
 msgid ""
 "Closing this window will lose all unsaved data. Do you really want to "
 "proceed?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:141
+#: src/widgets/dialogs.rs:153
 #, fuzzy
 msgid "Cancel"
 msgstr "_Cancelar"
 
-#: src/widgets/dialogs.rs:142
+#: src/widgets/dialogs.rs:154
 #, fuzzy
 msgid "Close anyway"
 msgstr "Beche a guia"
 
-#: src/widgets/dialogs.rs:165
+#: src/widgets/dialogs.rs:180
 #, fuzzy
 msgid "Save changes in '{}'?"
 msgstr "Salvar mudanças?"
 
-#: src/widgets/dialogs.rs:166
+#: src/widgets/dialogs.rs:181
 msgid "Save changes?"
 msgstr "Salvar mudanças?"
 
-#: src/widgets/dialogs.rs:171
+#: src/widgets/dialogs.rs:186
 msgid "There are changes that have not been saved yet. What do you want to do?"
 msgstr "Existem mudanças que ainda não foram salvas. O que você quer fazer?"
 
-#: src/widgets/dialogs.rs:175
+#: src/widgets/dialogs.rs:190
 msgid "_Cancel"
 msgstr "_Cancelar"
 
-#: src/widgets/dialogs.rs:176
+#: src/widgets/dialogs.rs:191
 msgid "_Discard"
 msgstr "_Descartar"
 
-#: src/widgets/dialogs.rs:177
+#: src/widgets/dialogs.rs:192
 msgid "_Save"
 msgstr "_Salvar"
+
+#: src/widgets/error_pane.rs:90
+msgid "The request data is not valid"
+msgstr ""
+
+#: src/widgets/error_pane.rs:96
+#, fuzzy
+msgid "The HTTP request failed"
+msgstr "Fazer solicitações HTTP e testar APIs"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"
@@ -640,10 +673,10 @@ msgid_plural "{} results"
 msgstr[0] "{} resultado"
 msgstr[1] "{} resultados"
 
-#: src/win.rs:689
+#: src/win.rs:685
 msgid "The Cartero authors"
 msgstr "Os autores de Cartero"
 
-#: src/win.rs:690
+#: src/win.rs:686
 msgid "© 2024 the Cartero authors"
 msgstr "© 2024 Os autores Cartero"

--- a/po/ro.po
+++ b/po/ro.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-06 03:50+0100\n"
+"POT-Creation-Date: 2025-03-08 11:15+0100\n"
 "PO-Revision-Date: 2024-07-30 15:00+0200\n"
 "Last-Translator:  <>\n"
 "Language-Team: Romanian\n"
@@ -223,7 +223,7 @@ msgstr "Executați această cerere HTTP"
 msgid "Parameters"
 msgstr "Parametrii"
 
-#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:91
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Antetele"
 
@@ -231,7 +231,7 @@ msgstr "Antetele"
 msgid "Variables"
 msgstr "Variabilele"
 
-#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:47
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Corpul"
 
@@ -482,18 +482,42 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:63 src/error.rs:87
+#: src/error.rs:18
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:19
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:21
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:24
+msgid "The given request body could not be encoded correctly"
+msgstr ""
+
+#: src/error.rs:26
+msgid "The variable '{}' is not defined"
+msgstr ""
+
+#: src/error.rs:30
+msgid "There was a problem with a variable interpolation, review your inputs"
+msgstr ""
+
+#: src/error.rs:57 src/error.rs:81
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "Lista de fișiere deschise actual"
 
-#: src/error.rs:65
+#: src/error.rs:59
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:69
+#: src/error.rs:63
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -511,82 +535,91 @@ msgstr ""
 msgid "Cannot open the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:90
-#: src/widgets/dialogs.rs:113 src/widgets/dialogs.rs:126
+#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:93
+#: src/widgets/dialogs.rs:119 src/widgets/dialogs.rs:135
 #, fuzzy
 msgid "Close"
 msgstr "Închideți tab-ul"
 
-#: src/widgets/dialogs.rs:73
+#: src/widgets/dialogs.rs:76
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:74
+#: src/widgets/dialogs.rs:77
 msgid "The requested file was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:104
+#: src/widgets/dialogs.rs:110
 msgid "Cannot save '{}'"
 msgstr ""
 
-#: src/widgets/dialogs.rs:105
+#: src/widgets/dialogs.rs:111
 msgid "Cannot save the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:107
+#: src/widgets/dialogs.rs:113
 msgid ""
 "There was an error during the saving process. Assume that your changes are "
 "still not saved."
 msgstr ""
 
-#: src/widgets/dialogs.rs:121
+#: src/widgets/dialogs.rs:130
 msgid "Could not select a valid file from the file chooser"
 msgstr ""
 
-#: src/widgets/dialogs.rs:135
+#: src/widgets/dialogs.rs:147
 msgid "There are unsaved changes"
 msgstr ""
 
-#: src/widgets/dialogs.rs:137
+#: src/widgets/dialogs.rs:149
 msgid ""
 "Closing this window will lose all unsaved data. Do you really want to "
 "proceed?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:141
+#: src/widgets/dialogs.rs:153
 #, fuzzy
 msgid "Cancel"
 msgstr "_Anulați"
 
-#: src/widgets/dialogs.rs:142
+#: src/widgets/dialogs.rs:154
 #, fuzzy
 msgid "Close anyway"
 msgstr "Închideți tab-ul"
 
-#: src/widgets/dialogs.rs:165
+#: src/widgets/dialogs.rs:180
 #, fuzzy
 msgid "Save changes in '{}'?"
 msgstr "Salvați modificările?"
 
-#: src/widgets/dialogs.rs:166
+#: src/widgets/dialogs.rs:181
 msgid "Save changes?"
 msgstr "Salvați modificările?"
 
-#: src/widgets/dialogs.rs:171
+#: src/widgets/dialogs.rs:186
 msgid "There are changes that have not been saved yet. What do you want to do?"
 msgstr "Există modificări care nu au fost salvate încă. Ce doriți să faceți?"
 
-#: src/widgets/dialogs.rs:175
+#: src/widgets/dialogs.rs:190
 msgid "_Cancel"
 msgstr "_Anulați"
 
-#: src/widgets/dialogs.rs:176
+#: src/widgets/dialogs.rs:191
 msgid "_Discard"
 msgstr "_Renunțați"
 
-#: src/widgets/dialogs.rs:177
+#: src/widgets/dialogs.rs:192
 msgid "_Save"
 msgstr "_Salvați"
+
+#: src/widgets/error_pane.rs:90
+msgid "The request data is not valid"
+msgstr ""
+
+#: src/widgets/error_pane.rs:96
+#, fuzzy
+msgid "The HTTP request failed"
+msgstr "Folosește Cartero pentru a face cereri HTTP și a testa API-urile"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"
@@ -626,10 +659,10 @@ msgid_plural "{} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/win.rs:689
+#: src/win.rs:685
 msgid "The Cartero authors"
 msgstr "Autorii Cartero"
 
-#: src/win.rs:690
+#: src/win.rs:686
 msgid "© 2024 the Cartero authors"
 msgstr "© 2024 autorii Cartero"

--- a/po/ro.po
+++ b/po/ro.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 13:48+0100\n"
+"POT-Creation-Date: 2025-03-11 14:02+0100\n"
 "PO-Revision-Date: 2024-07-30 15:00+0200\n"
 "Last-Translator:  <>\n"
 "Language-Team: Romanian\n"
@@ -518,18 +518,26 @@ msgstr ""
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:86 src/error.rs:110
+#: src/error.rs:84
+msgid "There is a network error"
+msgstr ""
+
+#: src/error.rs:85
+msgid "There is an input/output error"
+msgstr ""
+
+#: src/error.rs:111 src/error.rs:135
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "Lista de fișiere deschise actual"
 
-#: src/error.rs:88
+#: src/error.rs:113
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:92
+#: src/error.rs:117
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -624,26 +632,14 @@ msgstr "_Renunțați"
 msgid "_Save"
 msgstr "_Salvați"
 
-#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
+#: src/widgets/error_pane.rs:93 src/widgets/error_pane.rs:106
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:101
+#: src/widgets/error_pane.rs:99
 #, fuzzy
 msgid "The request failed"
 msgstr "Folosește Cartero pentru a face cereri HTTP și a testa API-urile"
-
-#: src/widgets/error_pane.rs:103
-msgid "There is an HTTP error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:104
-msgid "There is a network error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:105
-msgid "There is an input/output error"
-msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/ro.po
+++ b/po/ro.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-08 11:15+0100\n"
+"POT-Creation-Date: 2025-03-11 13:48+0100\n"
 "PO-Revision-Date: 2024-07-30 15:00+0200\n"
 "Last-Translator:  <>\n"
 "Language-Team: Romanian\n"
@@ -482,42 +482,54 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:18
-msgid "Cannot recognise the URL"
+#: src/error.rs:16
+msgid "The specified URL is not valid"
+msgstr ""
+
+#: src/error.rs:17
+msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:19
-msgid "The given URL is missing a protocol"
+msgid "The value for header '{}' is not valid"
 msgstr ""
 
-#: src/error.rs:21
-msgid "The protocol {}:// is not supported"
-msgstr ""
-
-#: src/error.rs:24
+#: src/error.rs:22 src/error.rs:56
 msgid "The given request body could not be encoded correctly"
 msgstr ""
 
-#: src/error.rs:26
+#: src/error.rs:51
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:52
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:54
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:57
 msgid "The variable '{}' is not defined"
 msgstr ""
 
-#: src/error.rs:30
+#: src/error.rs:59
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:57 src/error.rs:81
+#: src/error.rs:86 src/error.rs:110
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "Lista de fișiere deschise actual"
 
-#: src/error.rs:59
+#: src/error.rs:88
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:63
+#: src/error.rs:92
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -612,14 +624,26 @@ msgstr "_Renunțați"
 msgid "_Save"
 msgstr "_Salvați"
 
-#: src/widgets/error_pane.rs:90
+#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:96
+#: src/widgets/error_pane.rs:101
 #, fuzzy
-msgid "The HTTP request failed"
+msgid "The request failed"
 msgstr "Folosește Cartero pentru a face cereri HTTP și a testa API-urile"
+
+#: src/widgets/error_pane.rs:103
+msgid "There is an HTTP error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:104
+msgid "There is a network error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:105
+msgid "There is an input/output error"
+msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-08 11:15+0100\n"
+"POT-Creation-Date: 2025-03-11 13:48+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -494,42 +494,54 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:18
-msgid "Cannot recognise the URL"
+#: src/error.rs:16
+msgid "The specified URL is not valid"
+msgstr ""
+
+#: src/error.rs:17
+msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:19
-msgid "The given URL is missing a protocol"
+msgid "The value for header '{}' is not valid"
 msgstr ""
 
-#: src/error.rs:21
-msgid "The protocol {}:// is not supported"
-msgstr ""
-
-#: src/error.rs:24
+#: src/error.rs:22 src/error.rs:56
 msgid "The given request body could not be encoded correctly"
 msgstr ""
 
-#: src/error.rs:26
+#: src/error.rs:51
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:52
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:54
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:57
 msgid "The variable '{}' is not defined"
 msgstr ""
 
-#: src/error.rs:30
+#: src/error.rs:59
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:57 src/error.rs:81
+#: src/error.rs:86 src/error.rs:110
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "Текущий список открытых файлов"
 
-#: src/error.rs:59
+#: src/error.rs:88
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:63
+#: src/error.rs:92
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -624,14 +636,26 @@ msgstr "_Отменить"
 msgid "_Save"
 msgstr "_Сохранить"
 
-#: src/widgets/error_pane.rs:90
+#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:96
+#: src/widgets/error_pane.rs:101
 #, fuzzy
-msgid "The HTTP request failed"
+msgid "The request failed"
 msgstr "Выполняйте HTTP-запросы и тестируйте API"
+
+#: src/widgets/error_pane.rs:103
+msgid "There is an HTTP error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:104
+msgid "There is a network error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:105
+msgid "There is an input/output error"
+msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 13:48+0100\n"
+"POT-Creation-Date: 2025-03-11 14:02+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -530,18 +530,26 @@ msgstr ""
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:86 src/error.rs:110
+#: src/error.rs:84
+msgid "There is a network error"
+msgstr ""
+
+#: src/error.rs:85
+msgid "There is an input/output error"
+msgstr ""
+
+#: src/error.rs:111 src/error.rs:135
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "Текущий список открытых файлов"
 
-#: src/error.rs:88
+#: src/error.rs:113
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:92
+#: src/error.rs:117
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -636,26 +644,14 @@ msgstr "_Отменить"
 msgid "_Save"
 msgstr "_Сохранить"
 
-#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
+#: src/widgets/error_pane.rs:93 src/widgets/error_pane.rs:106
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:101
+#: src/widgets/error_pane.rs:99
 #, fuzzy
 msgid "The request failed"
 msgstr "Выполняйте HTTP-запросы и тестируйте API"
-
-#: src/widgets/error_pane.rs:103
-msgid "There is an HTTP error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:104
-msgid "There is a network error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:105
-msgid "There is an input/output error"
-msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-06 03:50+0100\n"
+"POT-Creation-Date: 2025-03-08 11:15+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -235,7 +235,7 @@ msgstr "Выполнить этот HTTP-запрос"
 msgid "Parameters"
 msgstr "Параметры"
 
-#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:91
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Заголовки"
 
@@ -243,7 +243,7 @@ msgstr "Заголовки"
 msgid "Variables"
 msgstr "Переменные"
 
-#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:47
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Тело"
 
@@ -494,18 +494,42 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:63 src/error.rs:87
+#: src/error.rs:18
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:19
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:21
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:24
+msgid "The given request body could not be encoded correctly"
+msgstr ""
+
+#: src/error.rs:26
+msgid "The variable '{}' is not defined"
+msgstr ""
+
+#: src/error.rs:30
+msgid "There was a problem with a variable interpolation, review your inputs"
+msgstr ""
+
+#: src/error.rs:57 src/error.rs:81
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "Текущий список открытых файлов"
 
-#: src/error.rs:65
+#: src/error.rs:59
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:69
+#: src/error.rs:63
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -523,82 +547,91 @@ msgstr ""
 msgid "Cannot open the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:90
-#: src/widgets/dialogs.rs:113 src/widgets/dialogs.rs:126
+#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:93
+#: src/widgets/dialogs.rs:119 src/widgets/dialogs.rs:135
 #, fuzzy
 msgid "Close"
 msgstr "Закрыть вкладку"
 
-#: src/widgets/dialogs.rs:73
+#: src/widgets/dialogs.rs:76
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:74
+#: src/widgets/dialogs.rs:77
 msgid "The requested file was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:104
+#: src/widgets/dialogs.rs:110
 msgid "Cannot save '{}'"
 msgstr ""
 
-#: src/widgets/dialogs.rs:105
+#: src/widgets/dialogs.rs:111
 msgid "Cannot save the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:107
+#: src/widgets/dialogs.rs:113
 msgid ""
 "There was an error during the saving process. Assume that your changes are "
 "still not saved."
 msgstr ""
 
-#: src/widgets/dialogs.rs:121
+#: src/widgets/dialogs.rs:130
 msgid "Could not select a valid file from the file chooser"
 msgstr ""
 
-#: src/widgets/dialogs.rs:135
+#: src/widgets/dialogs.rs:147
 msgid "There are unsaved changes"
 msgstr ""
 
-#: src/widgets/dialogs.rs:137
+#: src/widgets/dialogs.rs:149
 msgid ""
 "Closing this window will lose all unsaved data. Do you really want to "
 "proceed?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:141
+#: src/widgets/dialogs.rs:153
 #, fuzzy
 msgid "Cancel"
 msgstr "_Отмена"
 
-#: src/widgets/dialogs.rs:142
+#: src/widgets/dialogs.rs:154
 #, fuzzy
 msgid "Close anyway"
 msgstr "Закрыть вкладку"
 
-#: src/widgets/dialogs.rs:165
+#: src/widgets/dialogs.rs:180
 #, fuzzy
 msgid "Save changes in '{}'?"
 msgstr "Сохранить изменения?"
 
-#: src/widgets/dialogs.rs:166
+#: src/widgets/dialogs.rs:181
 msgid "Save changes?"
 msgstr "Сохранить изменения?"
 
-#: src/widgets/dialogs.rs:171
+#: src/widgets/dialogs.rs:186
 msgid "There are changes that have not been saved yet. What do you want to do?"
 msgstr "Есть несохраненные изменения. Что вы хотите сделать?"
 
-#: src/widgets/dialogs.rs:175
+#: src/widgets/dialogs.rs:190
 msgid "_Cancel"
 msgstr "_Отмена"
 
-#: src/widgets/dialogs.rs:176
+#: src/widgets/dialogs.rs:191
 msgid "_Discard"
 msgstr "_Отменить"
 
-#: src/widgets/dialogs.rs:177
+#: src/widgets/dialogs.rs:192
 msgid "_Save"
 msgstr "_Сохранить"
+
+#: src/widgets/error_pane.rs:90
+msgid "The request data is not valid"
+msgstr ""
+
+#: src/widgets/error_pane.rs:96
+#, fuzzy
+msgid "The HTTP request failed"
+msgstr "Выполняйте HTTP-запросы и тестируйте API"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"
@@ -639,10 +672,10 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/win.rs:689
+#: src/win.rs:685
 msgid "The Cartero authors"
 msgstr "Авторы Cartero"
 
-#: src/win.rs:690
+#: src/win.rs:686
 msgid "© 2024 the Cartero authors"
 msgstr "© 2024 Авторы Cartero"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 13:48+0100\n"
+"POT-Creation-Date: 2025-03-11 14:02+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartero/cartero/ta/"
@@ -527,18 +527,26 @@ msgstr ""
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:86 src/error.rs:110
+#: src/error.rs:84
+msgid "There is a network error"
+msgstr ""
+
+#: src/error.rs:85
+msgid "There is an input/output error"
+msgstr ""
+
+#: src/error.rs:111 src/error.rs:135
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "திறந்த கோப்புகளின் தற்போதைய பட்டியல்"
 
-#: src/error.rs:88
+#: src/error.rs:113
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:92
+#: src/error.rs:117
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -633,26 +641,14 @@ msgstr "_ டிச்கார்ட்"
 msgid "_Save"
 msgstr "_சேவ்"
 
-#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
+#: src/widgets/error_pane.rs:93 src/widgets/error_pane.rs:106
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:101
+#: src/widgets/error_pane.rs:99
 #, fuzzy
 msgid "The request failed"
 msgstr "HTTP கோரிக்கைகளைச் செய்து பநிஇ களை சோதனை செய்யுங்கள்"
-
-#: src/widgets/error_pane.rs:103
-msgid "There is an HTTP error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:104
-msgid "There is a network error"
-msgstr ""
-
-#: src/widgets/error_pane.rs:105
-msgid "There is an input/output error"
-msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-06 03:50+0100\n"
+"POT-Creation-Date: 2025-03-08 11:15+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartero/cartero/ta/"
@@ -233,7 +233,7 @@ msgstr "இந்த HTTP கோரிக்கையை இயக்கவு�
 msgid "Parameters"
 msgstr "அளவுருக்கள்"
 
-#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:91
+#: data/ui/endpoint_pane.blp:124 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "தலைப்பிகளுக்கு"
 
@@ -241,7 +241,7 @@ msgstr "தலைப்பிகளுக்கு"
 msgid "Variables"
 msgstr "மாறிகள்"
 
-#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:47
+#: data/ui/endpoint_pane.blp:166 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "உடல்"
 
@@ -491,18 +491,42 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:63 src/error.rs:87
+#: src/error.rs:18
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:19
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:21
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:24
+msgid "The given request body could not be encoded correctly"
+msgstr ""
+
+#: src/error.rs:26
+msgid "The variable '{}' is not defined"
+msgstr ""
+
+#: src/error.rs:30
+msgid "There was a problem with a variable interpolation, review your inputs"
+msgstr ""
+
+#: src/error.rs:57 src/error.rs:81
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "திறந்த கோப்புகளின் தற்போதைய பட்டியல்"
 
-#: src/error.rs:65
+#: src/error.rs:59
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:69
+#: src/error.rs:63
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -520,82 +544,91 @@ msgstr ""
 msgid "Cannot open the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:90
-#: src/widgets/dialogs.rs:113 src/widgets/dialogs.rs:126
+#: src/widgets/dialogs.rs:59 src/widgets/dialogs.rs:93
+#: src/widgets/dialogs.rs:119 src/widgets/dialogs.rs:135
 #, fuzzy
 msgid "Close"
 msgstr "தாவலை மூடு"
 
-#: src/widgets/dialogs.rs:73
+#: src/widgets/dialogs.rs:76
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:74
+#: src/widgets/dialogs.rs:77
 msgid "The requested file was loaded but had issues"
 msgstr ""
 
-#: src/widgets/dialogs.rs:104
+#: src/widgets/dialogs.rs:110
 msgid "Cannot save '{}'"
 msgstr ""
 
-#: src/widgets/dialogs.rs:105
+#: src/widgets/dialogs.rs:111
 msgid "Cannot save the requested file"
 msgstr ""
 
-#: src/widgets/dialogs.rs:107
+#: src/widgets/dialogs.rs:113
 msgid ""
 "There was an error during the saving process. Assume that your changes are "
 "still not saved."
 msgstr ""
 
-#: src/widgets/dialogs.rs:121
+#: src/widgets/dialogs.rs:130
 msgid "Could not select a valid file from the file chooser"
 msgstr ""
 
-#: src/widgets/dialogs.rs:135
+#: src/widgets/dialogs.rs:147
 msgid "There are unsaved changes"
 msgstr ""
 
-#: src/widgets/dialogs.rs:137
+#: src/widgets/dialogs.rs:149
 msgid ""
 "Closing this window will lose all unsaved data. Do you really want to "
 "proceed?"
 msgstr ""
 
-#: src/widgets/dialogs.rs:141
+#: src/widgets/dialogs.rs:153
 #, fuzzy
 msgid "Cancel"
 msgstr "_CANCEL"
 
-#: src/widgets/dialogs.rs:142
+#: src/widgets/dialogs.rs:154
 #, fuzzy
 msgid "Close anyway"
 msgstr "தாவலை மூடு"
 
-#: src/widgets/dialogs.rs:165
+#: src/widgets/dialogs.rs:180
 #, fuzzy
 msgid "Save changes in '{}'?"
 msgstr "மாற்றங்களைச் சேமிக்கவா?"
 
-#: src/widgets/dialogs.rs:166
+#: src/widgets/dialogs.rs:181
 msgid "Save changes?"
 msgstr "மாற்றங்களைச் சேமிக்கவா?"
 
-#: src/widgets/dialogs.rs:171
+#: src/widgets/dialogs.rs:186
 msgid "There are changes that have not been saved yet. What do you want to do?"
 msgstr "இன்னும் சேமிக்கப்படாத மாற்றங்கள் உள்ளன. நீங்கள் என்ன செய்ய விரும்புகிறீர்கள்?"
 
-#: src/widgets/dialogs.rs:175
+#: src/widgets/dialogs.rs:190
 msgid "_Cancel"
 msgstr "_CANCEL"
 
-#: src/widgets/dialogs.rs:176
+#: src/widgets/dialogs.rs:191
 msgid "_Discard"
 msgstr "_ டிச்கார்ட்"
 
-#: src/widgets/dialogs.rs:177
+#: src/widgets/dialogs.rs:192
 msgid "_Save"
 msgstr "_சேவ்"
+
+#: src/widgets/error_pane.rs:90
+msgid "The request data is not valid"
+msgstr ""
+
+#: src/widgets/error_pane.rs:96
+#, fuzzy
+msgid "The HTTP request failed"
+msgstr "HTTP கோரிக்கைகளைச் செய்து பநிஇ களை சோதனை செய்யுங்கள்"
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"
@@ -635,10 +668,10 @@ msgid_plural "{} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/win.rs:689
+#: src/win.rs:685
 msgid "The Cartero authors"
 msgstr "கார்டெரோ ஆசிரியர்கள்"
 
-#: src/win.rs:690
+#: src/win.rs:686
 msgid "© 2024 the Cartero authors"
 msgstr "© 2024 கார்டெரோ ஆசிரியர்கள்"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-08 11:15+0100\n"
+"POT-Creation-Date: 2025-03-11 13:48+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartero/cartero/ta/"
@@ -491,42 +491,54 @@ msgstr ""
 msgid "Request timeout"
 msgstr ""
 
-#: src/error.rs:18
-msgid "Cannot recognise the URL"
+#: src/error.rs:16
+msgid "The specified URL is not valid"
+msgstr ""
+
+#: src/error.rs:17
+msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:19
-msgid "The given URL is missing a protocol"
+msgid "The value for header '{}' is not valid"
 msgstr ""
 
-#: src/error.rs:21
-msgid "The protocol {}:// is not supported"
-msgstr ""
-
-#: src/error.rs:24
+#: src/error.rs:22 src/error.rs:56
 msgid "The given request body could not be encoded correctly"
 msgstr ""
 
-#: src/error.rs:26
+#: src/error.rs:51
+msgid "Cannot recognise the URL"
+msgstr ""
+
+#: src/error.rs:52
+msgid "The given URL is missing a protocol"
+msgstr ""
+
+#: src/error.rs:54
+msgid "The protocol {}:// is not supported"
+msgstr ""
+
+#: src/error.rs:57
 msgid "The variable '{}' is not defined"
 msgstr ""
 
-#: src/error.rs:30
+#: src/error.rs:59
 msgid "There was a problem with a variable interpolation, review your inputs"
 msgstr ""
 
-#: src/error.rs:57 src/error.rs:81
+#: src/error.rs:86 src/error.rs:110
 #, fuzzy
 msgid "The current tab is not associated with a file"
 msgstr "திறந்த கோப்புகளின் தற்போதைய பட்டியல்"
 
-#: src/error.rs:59
+#: src/error.rs:88
 msgid ""
 "This file was created with a newer version of this application; please "
 "update!"
 msgstr ""
 
-#: src/error.rs:63
+#: src/error.rs:92
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
@@ -621,14 +633,26 @@ msgstr "_ டிச்கார்ட்"
 msgid "_Save"
 msgstr "_சேவ்"
 
-#: src/widgets/error_pane.rs:90
+#: src/widgets/error_pane.rs:95 src/widgets/error_pane.rs:112
 msgid "The request data is not valid"
 msgstr ""
 
-#: src/widgets/error_pane.rs:96
+#: src/widgets/error_pane.rs:101
 #, fuzzy
-msgid "The HTTP request failed"
+msgid "The request failed"
 msgstr "HTTP கோரிக்கைகளைச் செய்து பநிஇ களை சோதனை செய்யுங்கள்"
+
+#: src/widgets/error_pane.rs:103
+msgid "There is an HTTP error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:104
+msgid "There is a network error"
+msgstr ""
+
+#: src/widgets/error_pane.rs:105
+msgid "There is an input/output error"
+msgstr ""
 
 #: src/widgets/export_tab/code.rs:114
 msgid "Content copied to the clipboard"

--- a/src/client/isahc_conv.rs
+++ b/src/client/isahc_conv.rs
@@ -18,6 +18,7 @@
 use crate::{
     app::CarteroApplication,
     entities::{RequestMethod, ResponseData},
+    error::RequestBuildError,
 };
 
 use super::{BoundRequest, RequestError};
@@ -30,7 +31,6 @@ use isahc::{
 };
 use std::{
     io::Read,
-    str::FromStr,
     time::{Duration, Instant},
 };
 use url::Url;
@@ -50,46 +50,43 @@ impl From<&RequestMethod> for isahc::http::Method {
     }
 }
 
-impl TryFrom<BoundRequest> for isahc::Request<Vec<u8>> {
-    type Error = RequestError;
+pub fn build_request(req: &BoundRequest) -> Result<isahc::Request<Vec<u8>>, RequestBuildError> {
+    let url = Url::parse(&req.url).map_err(|pe| RequestBuildError::InvalidUrl(pe))?;
+    let mut builder = isahc::Request::builder()
+        .uri(url.as_str())
+        .method(&req.method);
 
-    fn try_from(req: BoundRequest) -> Result<Self, Self::Error> {
-        let url = Url::parse(&req.url).map_err(|_| RequestError::InvalidUrl)?;
-        let mut builder = isahc::Request::builder()
-            .uri(url.as_str())
-            .method(&req.method);
+    let app = CarteroApplication::default();
+    let settings = app.settings();
 
-        let app = CarteroApplication::default();
-        let settings = app.settings();
-
-        if settings.boolean("validate-tls") {
-            builder = builder.ssl_options(SslOption::NONE);
-        } else {
-            builder = builder.ssl_options(SslOption::DANGER_ACCEPT_INVALID_CERTS);
-        }
-
-        if settings.boolean("follow-redirects") {
-            let count = settings.uint("maximum-redirects");
-            builder = builder.redirect_policy(isahc::config::RedirectPolicy::Limit(count));
-        } else {
-            builder = builder.redirect_policy(isahc::config::RedirectPolicy::None);
-        }
-
-        let timeout = settings.double("request-timeout");
-        builder = builder.timeout(Duration::from_secs_f64(timeout));
-
-        let Some(headers) = builder.headers_mut() else {
-            return Err(RequestError::InvalidHeaders);
-        };
-        for (h, v) in &req.headers {
-            let key = HeaderName::from_str(h)?;
-            let value = HeaderValue::from_str(v)?;
-            headers.insert(key, value);
-        }
-        let body = req.body.unwrap_or_default();
-        let req = builder.body(body)?;
-        Ok(req)
+    if settings.boolean("validate-tls") {
+        builder = builder.ssl_options(SslOption::NONE);
+    } else {
+        builder = builder.ssl_options(SslOption::DANGER_ACCEPT_INVALID_CERTS);
     }
+
+    if settings.boolean("follow-redirects") {
+        let count = settings.uint("maximum-redirects");
+        builder = builder.redirect_policy(isahc::config::RedirectPolicy::Limit(count));
+    } else {
+        builder = builder.redirect_policy(isahc::config::RedirectPolicy::None);
+    }
+
+    let timeout = settings.double("request-timeout");
+    builder = builder.timeout(Duration::from_secs_f64(timeout));
+
+    let headers = builder.headers_mut().unwrap();
+    for (h, v) in &req.headers {
+        let key = HeaderName::try_from(h)
+            .map_err(|_| RequestBuildError::InvalidHeaderName(h.to_string()))?;
+        let value = HeaderValue::try_from(v)
+            .map_err(|_| RequestBuildError::InvalidHeaderValue(h.to_string()))?;
+        headers.insert(key, value);
+    }
+    let body = req.body.clone().unwrap_or_default();
+    builder
+        .body(body)
+        .map_err(|_| RequestBuildError::InvalidBodyEncoding)
 }
 
 impl TryFrom<&mut isahc::Response<Body>> for ResponseData {

--- a/src/client/isahc_conv.rs
+++ b/src/client/isahc_conv.rs
@@ -81,6 +81,16 @@ pub fn build_request(req: &BoundRequest) -> Result<isahc::Request<Vec<u8>>, Requ
             .map_err(|_| RequestBuildError::InvalidHeaderName(h.to_string()))?;
         let value = HeaderValue::try_from(v)
             .map_err(|_| RequestBuildError::InvalidHeaderValue(h.to_string()))?;
+
+        /*
+         * Double check that it's actually a valid value. It might be broken and it's only
+         * being reported via an expect() and when it's too late to catch the panic:
+         * https://docs.rs/crate/isahc/1.7.2/source/src/parsing.rs#60-62
+         */
+        value
+            .to_str()
+            .map_err(|_| RequestBuildError::InvalidHeaderValue(h.to_string()))?;
+
         headers.insert(key, value);
     }
     let body = req.body.clone().unwrap_or_default();

--- a/src/client/isahc_conv.rs
+++ b/src/client/isahc_conv.rs
@@ -18,10 +18,10 @@
 use crate::{
     app::CarteroApplication,
     entities::{RequestMethod, ResponseData},
-    error::RequestBuildError,
+    error::{RequestBuildError, RequestError},
 };
 
-use super::{BoundRequest, RequestError};
+use super::BoundRequest;
 use futures_lite::io::AsyncReadExt;
 use gtk::prelude::SettingsExt;
 use isahc::{
@@ -116,7 +116,8 @@ impl TryFrom<&mut isahc::Response<Body>> for ResponseData {
         let body = {
             let mut buffer = Vec::new();
             let body = value.body_mut();
-            body.read_to_end(&mut buffer)?;
+            body.read_to_end(&mut buffer)
+                .map_err(|e| RequestError::IOError(e))?;
             buffer
         };
         Ok(ResponseData {
@@ -146,7 +147,9 @@ pub async fn extract_isahc_response(
     let body = {
         let mut buffer = Vec::new();
         let body = value.body_mut();
-        body.read_to_end(&mut buffer).await?;
+        body.read_to_end(&mut buffer)
+            .await
+            .map_err(|e| RequestError::IOError(e))?;
         buffer
     };
     let duration = start.elapsed();

--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -100,7 +100,7 @@ pub enum RequestError {
     #[error("Invalid payload state")]
     InvalidPayload,
 
-    #[error("Illegal header")]
+    #[error("Illegal header: {0}")]
     InvalidHeaderName(#[from] InvalidHeaderName),
 
     #[error("Illegal header value")]

--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -15,7 +15,6 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use isahc::http::header::{InvalidHeaderName, InvalidHeaderValue};
 use std::collections::HashMap;
 use thiserror::Error;
 use url::Url;
@@ -88,43 +87,14 @@ impl TryFrom<EndpointData> for BoundRequest {
 
 #[derive(Error, Debug)]
 pub enum RequestError {
-    #[error("Illegal HTTP verb")]
-    InvalidHttpVerb,
-
-    #[error("Invalid URL")]
-    InvalidUrl,
-
-    #[error("Invalid headers state")]
-    InvalidHeaders,
-
-    #[error("Invalid payload state")]
-    InvalidPayload,
-
-    #[error("Illegal header: {0}")]
-    InvalidHeaderName(#[from] InvalidHeaderName),
-
-    #[error("Illegal header value")]
-    InvalidHeaderValue(#[from] InvalidHeaderValue),
-
-    #[error("Request error")]
+    #[error(transparent)]
     NetworkError(#[from] isahc::error::Error),
 
-    #[error("HTTP error")]
+    #[error(transparent)]
     HttpError(#[from] isahc::http::Error),
 
-    #[error("Unknown I/O error")]
+    #[error(transparent)]
     IOError(#[from] std::io::Error),
-}
-
-impl RequestError {
-    pub fn inner_error(&self) -> String {
-        match self {
-            Self::NetworkError(isahc) => isahc.to_string(),
-            Self::HttpError(isahc) => isahc.to_string(),
-            Self::IOError(io) => io.to_string(),
-            _ => self.to_string(),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -116,6 +116,17 @@ pub enum RequestError {
     IOError(#[from] std::io::Error),
 }
 
+impl RequestError {
+    pub fn inner_error(&self) -> String {
+        match self {
+            Self::NetworkError(isahc) => isahc.to_string(),
+            Self::HttpError(isahc) => isahc.to_string(),
+            Self::IOError(io) => io.to_string(),
+            _ => self.to_string(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -16,7 +16,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use std::collections::HashMap;
-use thiserror::Error;
 use url::Url;
 
 use crate::{
@@ -83,18 +82,6 @@ impl TryFrom<EndpointData> for BoundRequest {
             body: body.content,
         })
     }
-}
-
-#[derive(Error, Debug)]
-pub enum RequestError {
-    #[error(transparent)]
-    NetworkError(#[from] isahc::error::Error),
-
-    #[error(transparent)]
-    HttpError(#[from] isahc::http::Error),
-
-    #[error(transparent)]
-    IOError(#[from] std::io::Error),
 }
 
 #[cfg(test)]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -19,5 +19,6 @@ mod isahc_conv;
 mod local;
 mod request_bodies;
 
+pub use isahc_conv::build_request;
 pub use isahc_conv::extract_isahc_response;
 pub use local::*;

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,6 +72,31 @@ impl From<SrTemplateError> for RequestPreconditionError {
     }
 }
 
+#[derive(Debug)]
+pub enum RequestError {
+    NetworkError(isahc::error::Error),
+    IOError(std::io::Error),
+}
+
+impl std::fmt::Display for RequestError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::NetworkError(_) => gettext("There is a network error"),
+            Self::IOError(_) => gettext("There is an input/output error"),
+        };
+        write!(f, "{}", message)
+    }
+}
+
+impl std::error::Error for RequestError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::NetworkError(e) => Some(e),
+            Self::IOError(e) => Some(e),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum FileLoadError {
     AnonymousPane,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,26 +1,33 @@
+use crate::i18n::i18n_f;
 use gettextrs::gettext;
 use srtemplate::SrTemplateError;
-use thiserror::Error;
 
-#[derive(Debug, Eq, PartialEq, Error)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum RequestPreconditionError {
-    #[error("Cannot parse the URL, check for typos")]
     UrlBadParse,
-
-    #[error("URL is missing a protocol")]
     MissingProtocol,
-
-    #[error("Protocol {0}:// is not supported")]
     UnsupportedProtocol(String),
-
-    #[error("Payload could not be encoded")]
     EncodingError,
-
-    #[error("Variable {0} not found")]
     VariableNotFound(String),
-
-    #[error("String interpolation error, review variables")]
     BadInterpolation,
+}
+
+impl std::fmt::Display for RequestPreconditionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::UrlBadParse => gettext("Cannot recognise the URL"),
+            Self::MissingProtocol => gettext("The given URL is missing a protocol"),
+            Self::UnsupportedProtocol(proto) => {
+                i18n_f("The protocol {}:// is not supported", &[&proto])
+            }
+            Self::EncodingError => gettext("The given request body could not be encoded correctly"),
+            Self::VariableNotFound(var) => i18n_f("The variable '{}' is not defined", &[&var]),
+            Self::BadInterpolation => {
+                gettext("There was a problem with a variable interpolation, review your inputs")
+            }
+        };
+        write!(f, "{}", message)
+    }
 }
 
 impl From<SrTemplateError> for RequestPreconditionError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,23 +2,6 @@ use gettextrs::gettext;
 use srtemplate::SrTemplateError;
 use thiserror::Error;
 
-use crate::client::RequestError;
-
-#[derive(Debug, Error)]
-pub enum CarteroError {
-    #[error("Internal error")]
-    InternalError,
-
-    #[error("DNS error")]
-    Dns,
-
-    #[error("HTTP request error")]
-    Request(#[from] RequestError),
-
-    #[error(transparent)]
-    PreconditionError(#[from] RequestPreconditionError),
-}
-
 #[derive(Debug, Eq, PartialEq, Error)]
 pub enum RequestPreconditionError {
     #[error("Cannot parse the URL, check for typos")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,39 @@ use gettextrs::gettext;
 use srtemplate::SrTemplateError;
 
 #[derive(Debug, Eq, PartialEq)]
+pub enum RequestBuildError {
+    InvalidUrl(url::ParseError),
+    InvalidHeaderName(String),
+    InvalidHeaderValue(String),
+    InvalidBodyEncoding,
+}
+
+impl std::fmt::Display for RequestBuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::InvalidUrl(_) => gettext("The specified URL is not valid"),
+            Self::InvalidHeaderName(name) => i18n_f("The header '{}' is not valid", &[&name]),
+            Self::InvalidHeaderValue(name) => {
+                i18n_f("The value for header '{}' is not valid", &[name])
+            }
+            Self::InvalidBodyEncoding => {
+                gettext("The given request body could not be encoded correctly")
+            }
+        };
+        write!(f, "{}", message)
+    }
+}
+
+impl std::error::Error for RequestBuildError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::InvalidUrl(pe) => Some(pe),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
 pub enum RequestPreconditionError {
     UrlBadParse,
     MissingProtocol,

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -41,9 +41,9 @@ mod imp {
     use url::Url;
 
     use crate::app::CarteroApplication;
-    use crate::client::{BoundRequest, RequestError};
+    use crate::client::BoundRequest;
     use crate::entities::{EndpointData, KeyValue, RequestExportType, ResponseData};
-    use crate::error::RequestPreconditionError;
+    use crate::error::{RequestError, RequestPreconditionError};
     use crate::objects::KeyValueItem;
     use crate::widgets::{
         ExportTab, ExportType, ItemPane, KeyValuePane, MethodDropdown, PayloadTab, ResponsePanel,

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -481,6 +481,11 @@ impl EndpointPane {
         imp.extract_endpoint()
     }
 
+    pub fn show_error(&self, error: CarteroError) {
+        let imp = self.imp();
+        imp.response.show_error(error);
+    }
+
     /// Executes an HTTP request based on the current contents of the pane.
     ///
     /// TODO: Should actually the EndpointPane do the requests? This method

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -23,7 +23,7 @@ use gtk::{glib, prelude::WidgetExt};
 
 use crate::{
     entities::EndpointData,
-    error::{CarteroError, FileSaveError},
+    error::FileSaveError,
     file::{EndpointLoadResult, FileLoadResult},
 };
 
@@ -42,8 +42,8 @@ mod imp {
 
     use crate::app::CarteroApplication;
     use crate::client::{BoundRequest, RequestError};
-    use crate::entities::{EndpointData, KeyValue, RequestExportType};
-    use crate::error::{CarteroError, RequestPreconditionError};
+    use crate::entities::{EndpointData, KeyValue, RequestExportType, ResponseData};
+    use crate::error::RequestPreconditionError;
     use crate::objects::KeyValueItem;
     use crate::widgets::{
         ExportTab, ExportType, ItemPane, KeyValuePane, MethodDropdown, PayloadTab, ResponsePanel,
@@ -420,38 +420,53 @@ mod imp {
             }
         }
 
-        /// Executes an HTTP request based on the current contents of the pane.
-        pub(super) async fn perform_request(&self) -> Result<(), CarteroError> {
+        fn bind_request(&self) -> Result<BoundRequest, RequestPreconditionError> {
             let request = self.extract_endpoint();
             let request = BoundRequest::try_from(request);
 
             // A special case before giving up: if the protocol is not specified, add it.
-            if let Err(RequestPreconditionError::MissingProtocol) = request {
-                // The URL is not considered an absolute URL, missing protocol.
-                let url_field = self.request_url.text().to_string();
-                let url_field = format!("http://{}", url_field);
-                self.request_url.set_text(&url_field);
-
-                // Now try again.
-                return std::boxed::Box::pin(self.perform_request()).await;
-            }
-
             match request {
-                Ok(request) => {
-                    // Execute the request.
-                    let request_obj = isahc::Request::try_from(request)?;
-                    let start = Instant::now();
-                    let mut response_obj = request_obj
-                        .send_async()
-                        .await
-                        .map_err(RequestError::NetworkError)?;
-                    let response =
-                        crate::client::extract_isahc_response(&mut response_obj, &start).await?;
-                    self.response.assign_from_response(&response);
-                    Ok(())
+                Err(RequestPreconditionError::MissingProtocol) => {
+                    // The URL is not considered an absolute URL, missing protocol.
+                    let url_field = self.request_url.text().to_string();
+                    let url_field = format!("http://{}", url_field);
+                    self.request_url.set_text(&url_field);
+
+                    // Now try again. If it fails again, just bail with the original error.
+                    let request = self.extract_endpoint();
+                    BoundRequest::try_from(request)
                 }
-                Err(e) => Err(CarteroError::from(e)),
+                any => any,
             }
+        }
+
+        async fn execute_request(
+            &self,
+            request: BoundRequest,
+        ) -> Result<ResponseData, RequestError> {
+            let request_obj = isahc::Request::try_from(request)?;
+            let start = Instant::now();
+            let mut response_obj = request_obj
+                .send_async()
+                .await
+                .map_err(RequestError::NetworkError)?;
+            let response = crate::client::extract_isahc_response(&mut response_obj, &start).await?;
+            Ok(response)
+        }
+
+        /// Executes an HTTP request based on the current contents of the pane.
+        pub(super) async fn perform_request(&self) {
+            let bind_request = match self.bind_request() {
+                Ok(bind) => bind,
+                Err(e) => {
+                    self.response.show_precondition_error(e);
+                    return;
+                }
+            };
+            match self.execute_request(bind_request).await {
+                Ok(data) => self.response.assign_from_response(&data),
+                Err(e) => self.response.show_request_error(e),
+            };
         }
     }
 }
@@ -481,32 +496,22 @@ impl EndpointPane {
         imp.extract_endpoint()
     }
 
-    pub fn show_error(&self, error: CarteroError) {
-        let imp = self.imp();
-        imp.response.show_error(error);
-    }
-
     /// Executes an HTTP request based on the current contents of the pane.
     ///
     /// TODO: Should actually the EndpointPane do the requests? This method
     /// will probably change once collections are correctly implemented,
     /// since the EndpointPane would be probably bound to an Endpoint object.
-    pub async fn perform_request(&self) -> Result<(), CarteroError> {
+    pub async fn perform_request(&self) {
         self.set_sensitive(false);
         let imp = self.imp();
         imp.response.set_spinning(true);
 
-        let result = catch_unwind(AssertUnwindSafe(move || {
+        let _ = catch_unwind(AssertUnwindSafe(move || {
             block_on(async { imp.perform_request().await })
         }));
 
         imp.response.set_spinning(false);
         self.set_sensitive(true);
-
-        match result {
-            Ok(inner) => inner,
-            Err(_) => Err(CarteroError::InternalError),
-        }
     }
 
     pub fn file(&self) -> Option<gtk::gio::File> {

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -442,15 +442,14 @@ mod imp {
 
         async fn execute_request(
             &self,
-            request: BoundRequest,
+            request: isahc::http::Request<Vec<u8>>,
         ) -> Result<ResponseData, RequestError> {
-            let request_obj = isahc::Request::try_from(request)?;
             let start = Instant::now();
-            let mut response_obj = request_obj
+            let mut response = request
                 .send_async()
                 .await
                 .map_err(RequestError::NetworkError)?;
-            let response = crate::client::extract_isahc_response(&mut response_obj, &start).await?;
+            let response = crate::client::extract_isahc_response(&mut response, &start).await?;
             Ok(response)
         }
 
@@ -463,7 +462,16 @@ mod imp {
                     return;
                 }
             };
-            match self.execute_request(bind_request).await {
+
+            let client_obj = match crate::client::build_request(&bind_request) {
+                Ok(request) => request,
+                Err(e) => {
+                    self.response.show_request_build_error(e);
+                    return;
+                }
+            };
+
+            match self.execute_request(client_obj).await {
                 Ok(data) => self.response.assign_from_response(&data),
                 Err(e) => self.response.show_request_error(e),
             };

--- a/src/widgets/error_pane.rs
+++ b/src/widgets/error_pane.rs
@@ -17,12 +17,13 @@
 
 use adw::prelude::*;
 use adw::subclass::prelude::*;
+use gettextrs::gettext;
 use glib::subclass::InitializingObject;
 use glib::Properties;
 use gtk::CompositeTemplate;
 use std::cell::RefCell;
 
-use crate::error::CarteroError;
+use crate::{client::RequestError, error::RequestPreconditionError};
 
 mod imp {
     use super::*;
@@ -31,6 +32,12 @@ mod imp {
     #[template(resource = "/es/danirod/Cartero/error_pane.ui")]
     #[properties(wrapper_type = super::ErrorPane)]
     pub struct ErrorPane {
+        #[property(get, set)]
+        icon: RefCell<String>,
+
+        #[property(get, set)]
+        title: RefCell<String>,
+
         #[property(get, set)]
         subtitle: RefCell<String>,
 
@@ -78,19 +85,16 @@ glib::wrapper! {
 }
 
 impl ErrorPane {
-    pub fn set_error(&self, error: CarteroError) {
-        // TODO: internationalize (let's wait until I have errors sorted out)
-        let message = match &error {
-            CarteroError::Request(inner) => inner.to_string(),
-            _ => error.to_string(),
-        };
-        self.set_subtitle(message.as_ref());
+    pub fn set_precondition_error(&self, error: RequestPreconditionError) {
+        self.set_icon("dialog-warning-symbolic");
+        self.set_title(gettext("The request data is not valid"));
+        self.set_subtitle(error.to_string());
+    }
 
-        let extra = match &error {
-            CarteroError::Request(inner) => inner.inner_error(),
-            _ => String::from(""),
-        };
-        self.set_extra(extra.as_ref());
+    pub fn set_request_error(&self, error: RequestError) {
+        self.set_icon("network-error-symbolic");
+        self.set_title(gettext("The HTTP request failed"));
+        self.set_subtitle(error.to_string());
     }
 }
 

--- a/src/widgets/error_pane.rs
+++ b/src/widgets/error_pane.rs
@@ -22,8 +22,13 @@ use glib::subclass::InitializingObject;
 use glib::Properties;
 use gtk::CompositeTemplate;
 use std::cell::RefCell;
+use std::error::Error;
+use url::ParseError;
 
-use crate::{client::RequestError, error::RequestPreconditionError};
+use crate::{
+    client::RequestError,
+    error::{RequestBuildError, RequestPreconditionError},
+};
 
 mod imp {
     use super::*;
@@ -96,10 +101,43 @@ impl ErrorPane {
         self.set_title(gettext("The HTTP request failed"));
         self.set_subtitle(error.to_string());
     }
+
+    pub fn set_request_build_error(&self, error: RequestBuildError) {
+        self.set_icon("dialog-warning-symbolic");
+        self.set_title(gettext("The request data is not valid"));
+        self.set_subtitle(error.to_string());
+
+        self.set_extra("");
+        if let Some(error) = error.source() {
+            if let Some(pe) = error.downcast_ref::<ParseError>() {
+                self.set_extra(i18n_url_parse_error(pe).unwrap_or_default());
+            }
+        }
+    }
 }
 
 impl Default for ErrorPane {
     fn default() -> Self {
         glib::Object::new()
+    }
+}
+
+fn i18n_url_parse_error(pe: &ParseError) -> Option<String> {
+    match pe {
+        ParseError::EmptyHost
+        | ParseError::IdnaError
+        | ParseError::InvalidDomainCharacter
+        | ParseError::SetHostOnCannotBeABaseUrl => {
+            Some(gettext("The host is missing or malformed"))
+        }
+        ParseError::InvalidPort => Some(gettext("The specified port number is not valid")),
+        ParseError::InvalidIpv4Address | ParseError::InvalidIpv6Address => {
+            Some(gettext("The IP specified is not valid"))
+        }
+        ParseError::RelativeUrlWithCannotBeABaseBase | ParseError::RelativeUrlWithoutBase => {
+            Some(gettext("Relative URL cannot be solved"))
+        }
+        ParseError::Overflow => Some(gettext("The specified URL is too long for this program")),
+        _ => None,
     }
 }

--- a/src/widgets/error_pane.rs
+++ b/src/widgets/error_pane.rs
@@ -24,10 +24,7 @@ use gtk::CompositeTemplate;
 use std::cell::RefCell;
 use std::error::Error;
 
-use crate::{
-    client::RequestError,
-    error::{RequestBuildError, RequestPreconditionError},
-};
+use crate::error::{RequestBuildError, RequestError, RequestPreconditionError};
 
 mod imp {
     use super::*;
@@ -93,28 +90,21 @@ impl ErrorPane {
         self.set_icon("dialog-warning-symbolic");
         self.set_title(gettext("The request data is not valid"));
         self.set_subtitle(error.to_string());
+        self.set_extra("");
     }
 
     pub fn set_request_error(&self, error: RequestError) {
         self.set_icon("network-error-symbolic");
         self.set_title(gettext("The request failed"));
-        self.set_subtitle(match error {
-            RequestError::HttpError(_) => gettext("There is an HTTP error"),
-            RequestError::NetworkError(_) => gettext("There is a network error"),
-            RequestError::IOError(_) => gettext("There is an input/output error"),
-        });
-        self.set_extra(error.to_string());
+        self.set_subtitle(error.to_string());
+        self.set_extra(error.source().map(|e| e.to_string()).unwrap_or_default());
     }
 
     pub fn set_request_build_error(&self, error: RequestBuildError) {
         self.set_icon("dialog-warning-symbolic");
         self.set_title(gettext("The request data is not valid"));
         self.set_subtitle(error.to_string());
-
-        match error.source() {
-            None => self.set_extra(""),
-            Some(error) => self.set_extra(error.to_string()),
-        };
+        self.set_extra(error.source().map(|e| e.to_string()).unwrap_or_default());
     }
 }
 

--- a/src/widgets/error_pane.rs
+++ b/src/widgets/error_pane.rs
@@ -23,7 +23,6 @@ use glib::Properties;
 use gtk::CompositeTemplate;
 use std::cell::RefCell;
 use std::error::Error;
-use url::ParseError;
 
 use crate::{
     client::RequestError,
@@ -98,8 +97,13 @@ impl ErrorPane {
 
     pub fn set_request_error(&self, error: RequestError) {
         self.set_icon("network-error-symbolic");
-        self.set_title(gettext("The HTTP request failed"));
-        self.set_subtitle(error.to_string());
+        self.set_title(gettext("The request failed"));
+        self.set_subtitle(match error {
+            RequestError::HttpError(_) => gettext("There is an HTTP error"),
+            RequestError::NetworkError(_) => gettext("There is a network error"),
+            RequestError::IOError(_) => gettext("There is an input/output error"),
+        });
+        self.set_extra(error.to_string());
     }
 
     pub fn set_request_build_error(&self, error: RequestBuildError) {
@@ -107,37 +111,15 @@ impl ErrorPane {
         self.set_title(gettext("The request data is not valid"));
         self.set_subtitle(error.to_string());
 
-        self.set_extra("");
-        if let Some(error) = error.source() {
-            if let Some(pe) = error.downcast_ref::<ParseError>() {
-                self.set_extra(i18n_url_parse_error(pe).unwrap_or_default());
-            }
-        }
+        match error.source() {
+            None => self.set_extra(""),
+            Some(error) => self.set_extra(error.to_string()),
+        };
     }
 }
 
 impl Default for ErrorPane {
     fn default() -> Self {
         glib::Object::new()
-    }
-}
-
-fn i18n_url_parse_error(pe: &ParseError) -> Option<String> {
-    match pe {
-        ParseError::EmptyHost
-        | ParseError::IdnaError
-        | ParseError::InvalidDomainCharacter
-        | ParseError::SetHostOnCannotBeABaseUrl => {
-            Some(gettext("The host is missing or malformed"))
-        }
-        ParseError::InvalidPort => Some(gettext("The specified port number is not valid")),
-        ParseError::InvalidIpv4Address | ParseError::InvalidIpv6Address => {
-            Some(gettext("The IP specified is not valid"))
-        }
-        ParseError::RelativeUrlWithCannotBeABaseBase | ParseError::RelativeUrlWithoutBase => {
-            Some(gettext("Relative URL cannot be solved"))
-        }
-        ParseError::Overflow => Some(gettext("The specified URL is too long for this program")),
-        _ => None,
     }
 }

--- a/src/widgets/error_pane.rs
+++ b/src/widgets/error_pane.rs
@@ -1,0 +1,101 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use adw::prelude::*;
+use adw::subclass::prelude::*;
+use glib::subclass::InitializingObject;
+use glib::Properties;
+use gtk::CompositeTemplate;
+use std::cell::RefCell;
+
+use crate::error::CarteroError;
+
+mod imp {
+    use super::*;
+
+    #[derive(Default, Properties, CompositeTemplate)]
+    #[template(resource = "/es/danirod/Cartero/error_pane.ui")]
+    #[properties(wrapper_type = super::ErrorPane)]
+    pub struct ErrorPane {
+        #[property(get, set)]
+        subtitle: RefCell<String>,
+
+        #[property(get, set)]
+        extra: RefCell<String>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for ErrorPane {
+        const NAME: &'static str = "CarteroErrorPane";
+        type Type = super::ErrorPane;
+        type ParentType = adw::Bin;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+            klass.bind_template_callbacks();
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for ErrorPane {}
+
+    impl WidgetImpl for ErrorPane {}
+
+    impl BinImpl for ErrorPane {}
+
+    #[gtk::template_callbacks]
+    impl ErrorPane {
+        #[template_callback]
+        fn extra_visible(&self) -> bool {
+            let extra = self.extra.borrow();
+            !extra.is_empty()
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct ErrorPane(ObjectSubclass<imp::ErrorPane>)
+        @extends gtk::Widget, adw::Bin,
+        @implements gtk::Buildable;
+}
+
+impl ErrorPane {
+    pub fn set_error(&self, error: CarteroError) {
+        // TODO: internationalize (let's wait until I have errors sorted out)
+        let message = match &error {
+            CarteroError::Request(inner) => inner.to_string(),
+            _ => error.to_string(),
+        };
+        self.set_subtitle(message.as_ref());
+
+        let extra = match &error {
+            CarteroError::Request(inner) => inner.inner_error(),
+            _ => String::from(""),
+        };
+        self.set_extra(extra.as_ref());
+    }
+}
+
+impl Default for ErrorPane {
+    fn default() -> Self {
+        glib::Object::new()
+    }
+}

--- a/src/widgets/export_tab/service.rs
+++ b/src/widgets/export_tab/service.rs
@@ -19,7 +19,7 @@ use serde_json::{Error, Value};
 
 use crate::client::BoundRequest;
 use crate::entities::{EndpointData, RequestPayload};
-use crate::error::CarteroError;
+use crate::error::RequestPreconditionError;
 
 pub struct CodeExportService {
     endpoint_data: EndpointData,
@@ -30,7 +30,7 @@ impl CodeExportService {
         Self { endpoint_data }
     }
 
-    pub fn generate(&self) -> Result<String, CarteroError> {
+    pub fn generate(&self) -> Result<String, RequestPreconditionError> {
         let bound_request = BoundRequest::try_from(self.endpoint_data.clone())?;
         let mut command = "curl".to_string();
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 the Cartero authors
+// Copyright 2024-2025 the Cartero authors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -18,6 +18,7 @@
 mod code_view;
 pub mod dialogs;
 mod endpoint_pane;
+mod error_pane;
 mod export_tab;
 mod file_dialogs;
 mod item_pane;
@@ -31,6 +32,7 @@ mod search_box;
 
 pub use code_view::CodeView;
 pub use endpoint_pane::EndpointPane;
+pub use error_pane::ErrorPane;
 pub use export_tab::*;
 pub use file_dialogs::*;
 pub use item_pane::ItemPane;

--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -26,16 +26,19 @@ use serde_json::Value;
 use sourceview5::prelude::BufferExt;
 use sourceview5::LanguageManager;
 
+use crate::client::RequestError;
 use crate::entities::ResponseData;
+use crate::error::CarteroError;
 use crate::objects::KeyValueItem;
 use glib::subclass::types::ObjectSubclassIsExt;
 
 mod imp {
     use std::cell::RefCell;
 
+    use crate::error::CarteroError;
     use crate::widgets::{CodeView, ResponseHeaders, SearchBox};
-    use adw::prelude::*;
     use adw::subclass::bin::BinImpl;
+    use adw::{prelude::*, StatusPage};
     use glib::object::Cast;
     use glib::subclass::InitializingObject;
     use glib::Properties;
@@ -52,6 +55,10 @@ mod imp {
     pub struct ResponsePanel {
         #[template_child]
         stack: TemplateChild<gtk::Stack>,
+        #[template_child]
+        error_page: TemplateChild<StatusPage>,
+        #[template_child]
+        error_extra: TemplateChild<Label>,
         #[template_child]
         pub response_headers: TemplateChild<ResponseHeaders>,
         #[template_child]
@@ -147,6 +154,14 @@ mod imp {
             self.search_revealer.set_visible(false);
             self.response_body.grab_focus();
         }
+
+        pub(super) fn show_error(&self, error: CarteroError) {
+            // TODO: Internationalize
+            let message = error.to_string();
+            self.error_page.set_description(Some(&message));
+            self.error_extra.set_visible(false);
+            self.stack.set_visible_child_name("error");
+        }
     }
 }
 
@@ -183,6 +198,11 @@ fn format_bytes(count: usize) -> String {
 impl ResponsePanel {
     pub fn new() -> Self {
         Object::builder().build()
+    }
+
+    pub fn show_error(&self, error: CarteroError) {
+        let imp = self.imp();
+        imp.show_error(error);
     }
 
     pub fn start_request(&self) {

--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -157,9 +157,23 @@ mod imp {
 
         pub(super) fn show_error(&self, error: CarteroError) {
             // TODO: Internationalize
-            let message = error.to_string();
+            println!("{error:?}");
+            let message = match &error {
+                CarteroError::Request(inner) => inner.to_string(),
+                _ => error.to_string(),
+            };
+
+            match &error {
+                CarteroError::Request(inner) => {
+                    self.error_extra.set_visible(true);
+                    self.error_extra.set_label(&inner.inner_error());
+                }
+                _ => {
+                    self.error_extra.set_visible(false);
+                }
+            }
+
             self.error_page.set_description(Some(&message));
-            self.error_extra.set_visible(false);
             self.stack.set_visible_child_name("error");
         }
     }

--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -28,7 +28,7 @@ use sourceview5::LanguageManager;
 
 use crate::client::RequestError;
 use crate::entities::ResponseData;
-use crate::error::RequestPreconditionError;
+use crate::error::{RequestBuildError, RequestPreconditionError};
 use crate::objects::KeyValueItem;
 use glib::subclass::types::ObjectSubclassIsExt;
 
@@ -36,7 +36,7 @@ mod imp {
     use std::cell::RefCell;
 
     use crate::client::RequestError;
-    use crate::error::RequestPreconditionError;
+    use crate::error::{RequestBuildError, RequestPreconditionError};
     use crate::widgets::{CodeView, ErrorPane, ResponseHeaders, SearchBox};
     use adw::prelude::*;
     use adw::subclass::bin::BinImpl;
@@ -163,6 +163,11 @@ mod imp {
             self.stack.set_visible_child_name("error");
         }
 
+        pub(super) fn show_request_build_error(&self, error: RequestBuildError) {
+            self.error_page.set_request_build_error(error);
+            self.stack.set_visible_child_name("error");
+        }
+
         pub(super) fn show_response(&self) {
             self.stack.set_visible_child_name("response");
         }
@@ -207,6 +212,11 @@ impl ResponsePanel {
     pub fn show_precondition_error(&self, error: RequestPreconditionError) {
         let imp = self.imp();
         imp.show_precondition_error(error);
+    }
+
+    pub fn show_request_build_error(&self, error: RequestBuildError) {
+        let imp = self.imp();
+        imp.show_request_build_error(error);
     }
 
     pub fn show_request_error(&self, error: RequestError) {

--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -26,17 +26,15 @@ use serde_json::Value;
 use sourceview5::prelude::BufferExt;
 use sourceview5::LanguageManager;
 
-use crate::client::RequestError;
 use crate::entities::ResponseData;
-use crate::error::{RequestBuildError, RequestPreconditionError};
+use crate::error::{RequestBuildError, RequestError, RequestPreconditionError};
 use crate::objects::KeyValueItem;
 use glib::subclass::types::ObjectSubclassIsExt;
 
 mod imp {
     use std::cell::RefCell;
 
-    use crate::client::RequestError;
-    use crate::error::{RequestBuildError, RequestPreconditionError};
+    use crate::error::{RequestBuildError, RequestError, RequestPreconditionError};
     use crate::widgets::{CodeView, ErrorPane, ResponseHeaders, SearchBox};
     use adw::prelude::*;
     use adw::subclass::bin::BinImpl;

--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -26,15 +26,17 @@ use serde_json::Value;
 use sourceview5::prelude::BufferExt;
 use sourceview5::LanguageManager;
 
+use crate::client::RequestError;
 use crate::entities::ResponseData;
-use crate::error::CarteroError;
+use crate::error::RequestPreconditionError;
 use crate::objects::KeyValueItem;
 use glib::subclass::types::ObjectSubclassIsExt;
 
 mod imp {
     use std::cell::RefCell;
 
-    use crate::error::CarteroError;
+    use crate::client::RequestError;
+    use crate::error::RequestPreconditionError;
     use crate::widgets::{CodeView, ErrorPane, ResponseHeaders, SearchBox};
     use adw::prelude::*;
     use adw::subclass::bin::BinImpl;
@@ -115,7 +117,6 @@ mod imp {
         }
 
         fn set_spinning(&self, spinning: bool) {
-            self.stack.set_visible_child_name("response");
             let widget: &gtk::Widget = if spinning {
                 self.spinner.upcast_ref()
             } else {
@@ -152,9 +153,18 @@ mod imp {
             self.response_body.grab_focus();
         }
 
-        pub(super) fn show_error(&self, error: CarteroError) {
-            self.error_page.set_error(error);
+        pub(super) fn show_precondition_error(&self, error: RequestPreconditionError) {
+            self.error_page.set_precondition_error(error);
             self.stack.set_visible_child_name("error");
+        }
+
+        pub(super) fn show_request_error(&self, error: RequestError) {
+            self.error_page.set_request_error(error);
+            self.stack.set_visible_child_name("error");
+        }
+
+        pub(super) fn show_response(&self) {
+            self.stack.set_visible_child_name("response");
         }
     }
 }
@@ -194,9 +204,14 @@ impl ResponsePanel {
         Object::builder().build()
     }
 
-    pub fn show_error(&self, error: CarteroError) {
+    pub fn show_precondition_error(&self, error: RequestPreconditionError) {
         let imp = self.imp();
-        imp.show_error(error);
+        imp.show_precondition_error(error);
+    }
+
+    pub fn show_request_error(&self, error: RequestError) {
+        let imp = self.imp();
+        imp.show_request_error(error);
     }
 
     pub fn start_request(&self) {
@@ -283,5 +298,7 @@ impl ResponsePanel {
             Some(language) => buffer.set_language(Some(&language)),
             None => buffer.set_language(None),
         };
+
+        imp.show_response();
     }
 }

--- a/src/widgets/response_panel.rs
+++ b/src/widgets/response_panel.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 the Cartero authors
+// Copyright 2024-2025 the Cartero authors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -26,7 +26,6 @@ use serde_json::Value;
 use sourceview5::prelude::BufferExt;
 use sourceview5::LanguageManager;
 
-use crate::client::RequestError;
 use crate::entities::ResponseData;
 use crate::error::CarteroError;
 use crate::objects::KeyValueItem;
@@ -36,9 +35,9 @@ mod imp {
     use std::cell::RefCell;
 
     use crate::error::CarteroError;
-    use crate::widgets::{CodeView, ResponseHeaders, SearchBox};
+    use crate::widgets::{CodeView, ErrorPane, ResponseHeaders, SearchBox};
+    use adw::prelude::*;
     use adw::subclass::bin::BinImpl;
-    use adw::{prelude::*, StatusPage};
     use glib::object::Cast;
     use glib::subclass::InitializingObject;
     use glib::Properties;
@@ -56,9 +55,7 @@ mod imp {
         #[template_child]
         stack: TemplateChild<gtk::Stack>,
         #[template_child]
-        error_page: TemplateChild<StatusPage>,
-        #[template_child]
-        error_extra: TemplateChild<Label>,
+        error_page: TemplateChild<ErrorPane>,
         #[template_child]
         pub response_headers: TemplateChild<ResponseHeaders>,
         #[template_child]
@@ -156,24 +153,7 @@ mod imp {
         }
 
         pub(super) fn show_error(&self, error: CarteroError) {
-            // TODO: Internationalize
-            println!("{error:?}");
-            let message = match &error {
-                CarteroError::Request(inner) => inner.to_string(),
-                _ => error.to_string(),
-            };
-
-            match &error {
-                CarteroError::Request(inner) => {
-                    self.error_extra.set_visible(true);
-                    self.error_extra.set_label(&inner.inner_error());
-                }
-                _ => {
-                    self.error_extra.set_visible(false);
-                }
-            }
-
-            self.error_page.set_description(Some(&message));
+            self.error_page.set_error(error);
             self.stack.set_visible_child_name("error");
         }
     }

--- a/src/win.rs
+++ b/src/win.rs
@@ -15,9 +15,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use crate::{
-    app::CarteroApplication, error::CarteroError, file::FileLoadFailure, widgets::ItemPane,
-};
+use crate::{app::CarteroApplication, file::FileLoadFailure, widgets::ItemPane};
 use glib::subclass::types::ObjectSubclassIsExt;
 use glib::Object;
 use gtk::{gio, glib};
@@ -36,9 +34,9 @@ mod imp {
     use gtk::prelude::*;
     use indexmap::IndexMap;
 
+    use crate::app::CarteroApplication;
     use crate::error::FileSaveError;
     use crate::file::{FileLoadFailure, FileLoadResult};
-    use crate::{app::CarteroApplication, error::CarteroError};
     use crate::{config, widgets::*};
     use glib::subclass::InitializingObject;
     use gtk::{CompositeTemplate, TemplateChild};
@@ -523,11 +521,6 @@ mod imp {
             }
         }
 
-        pub(super) fn toast_error(&self, error: CarteroError) {
-            let toast = adw::Toast::new(&error.to_string());
-            self.toaster.add_toast(toast);
-        }
-
         pub(super) fn toast_message(&self, msg: &str) {
             let toast = adw::Toast::new(msg);
             self.toaster.add_toast(toast);
@@ -620,9 +613,7 @@ mod imp {
                             async move {
                                 if let Some(pane) = window.current_pane().and_then(|e| e.endpoint())
                                 {
-                                    if let Err(e) = pane.perform_request().await {
-                                        pane.show_error(e);
-                                    }
+                                    pane.perform_request().await;
                                 }
                             }
                         ));
@@ -782,11 +773,6 @@ impl CarteroWindow {
     ) {
         let imp = self.imp();
         imp.report_open_endpoints_errors(opened).await
-    }
-
-    pub fn toast_error(&self, e: CarteroError) {
-        let imp = self.imp();
-        imp.toast_error(e);
     }
 
     pub fn toast_message(&self, msg: &str) {

--- a/src/win.rs
+++ b/src/win.rs
@@ -621,7 +621,7 @@ mod imp {
                                 if let Some(pane) = window.current_pane().and_then(|e| e.endpoint())
                                 {
                                     if let Err(e) = pane.perform_request().await {
-                                        window.toast_error(e);
+                                        pane.show_error(e);
                                     }
                                 }
                             }


### PR DESCRIPTION
# Motivation

Cartero is using notification toasts currently to show errors. However, these have a bad UX because they are very subtle and they dissappear automatically after a few seconds, so they are difficult to detect.

Even worse, currently the string presented as a toast is currently a generic message. It's not even translated, and for wrapped errors, the inner cause ("the host could not be resolved") is swallowed and replaced by some generic message like ("HTTP error"), so this is actually not disclosing properly the reason why the request failed.

# Changes made

This pull request introduces a new pane to present network and request errors.

Visually, when the request fails, the response panel is replaced by a full screen error message that displays the source of an error, and if appliable, some extra information. In the following example, the error pane is reporting an SSL error:

![A request to https://expired.badssl.com shows the error message 'The request failed', 'There is a network error', 'The server certificate could not be validated'](https://github.com/user-attachments/assets/22b2d960-3985-413e-9d37-1f53597c067d)

In the following example, an undefined variable is being used as part of the request URL, and the name of the variable is reported as an error:

![A request with the URL set to http://{{HOST}}. The error reports 'the variable HOST is not defined'.](https://github.com/user-attachments/assets/3f962f14-257c-466e-8a45-3f3fbc9b70f5)

In the following exmple, a header with characters outside the ASCII subset is being used, which according to the HTTP spec is not correct:

![A request with a header using Chinese characters. The error message says "The request data is not valid, the header '哈罗世界' is not valid"](https://github.com/user-attachments/assets/985f531a-7440-440e-ad80-8eb4b9d37a40)

Internally, this pull request also continues the work started by #141 and #148 by continuing to remove keys from CarteroError, which is now completely removed from the code in this PR, fixing #139.

Currently the following new error types are defined:

* RequestBuildError: used to report errors that happen after validating the request (so it's not the input data). For instance, the header has an invalid character or the body cannot be decoded. However, I think that these should also be validation errors so maybe these are merged with RequestPreconditionError in the future to create a common error type to indicate that the request object cannot be built.

* RequestError: it's not exactly a new error type, but it has been moved from the client mod to the error mod, and has been pruned from any non-related error. This is a wrapper for NetworkError (DNS errors, server certificate errors...) and IOError (mostly errors encoding or decoding the payload).

---

_This text was not written by an AI. Learn to think and to reason is important._