### PR TITLE
Convert native Rust structs and enums to GObject types

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -57,13 +57,13 @@ jobs:
       - name: cargo-fmt
         run: meson devenv -C build cargo fmt --manifest-path=../Cargo.toml --check --all
       - name: cargo-test
-        run: xvfb-run meson devenv -C build cargo test --manifest-path=../Cargo.toml
+        run: xvfb-run meson devenv -C build cargo test --workspace --manifest-path=../Cargo.toml
       - name: cargo-clippy
-        run: meson devenv -C build cargo clippy --manifest-path=../Cargo.toml
+        run: meson devenv -C build cargo clippy --workspace --manifest-path=../Cargo.toml
       - name: cargo-deny
         run: |
           cargo install --locked cargo-deny
-          meson devenv -C build cargo deny --manifest-path=../Cargo.toml check licenses
+          meson devenv -C build cargo deny --workspace --manifest-path=../Cargo.toml check licenses
       - name: glib-schema
         run: glib-compile-schemas --dry-run --strict data
       - name: glib-desktop

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cartero_objects"
+version = "0.3.0"
+dependencies = [
+ "gio",
+ "glib",
+]
+
+[[package]]
 name = "castaway"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = ["crates/*"]
 [workspace.package]
 edition = "2021"
 version = "0.3.0"
+license = "GPL-3.0-or-later"
 
 [workspace.dependencies]
 glib = { version = "0.20.9", features = ["v2_72"] }
@@ -13,6 +14,7 @@ gio = { version = "0.20.9", features = ["v2_72"] }
 name = "cartero"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [features]
 default = ["csd"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,18 @@
+[workspace]
+members = ["crates/*"]
+
+[workspace.package]
+edition = "2021"
+version = "0.3.0"
+
+[workspace.dependencies]
+glib = { version = "0.20.9", features = ["v2_72"] }
+gio = { version = "0.20.9", features = ["v2_72"] }
+
 [package]
 name = "cartero"
-version = "0.3.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [features]
 default = ["csd"]
@@ -17,7 +28,7 @@ formatx = "0.2.3"
 formdata = "0.13.0"
 futures-lite = "2.6.0"
 gettext-rs = { version = "0.7.2", features = ["gettext-system"] }
-glib = { version = "0.20.9", features = ["v2_72"] }
+glib.workspace = true
 gtk = { package = "gtk4", version = "0.9.6", features = ["v4_12"] }
 indexmap = "2.8.0"
 isahc = "1.7.2"

--- a/crates/cartero-objects/Cargo.toml
+++ b/crates/cartero-objects/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cartero_objects"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 glib.workspace = true

--- a/crates/cartero-objects/Cargo.toml
+++ b/crates/cartero-objects/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cartero_objects"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+glib.workspace = true
+gio.workspace = true

--- a/crates/cartero-objects/src/field.rs
+++ b/crates/cartero-objects/src/field.rs
@@ -1,0 +1,101 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::prelude::*;
+use glib::subclass::prelude::*;
+
+glib::wrapper! {
+    pub struct Field(ObjectSubclass<imp::Field>);
+}
+
+mod imp {
+    use std::cell::RefCell;
+
+    use super::*;
+    use glib::Properties;
+
+    #[derive(Properties)]
+    #[properties(wrapper_type = super::Field)]
+    pub struct Field {
+        #[property(get, set)]
+        key: RefCell<String>,
+
+        #[property(get, set)]
+        value: RefCell<String>,
+
+        #[property(get, set, default = true)]
+        active: RefCell<bool>,
+
+        #[property(get, set, default = false)]
+        masked: RefCell<bool>,
+    }
+
+    impl Default for Field {
+        fn default() -> Self {
+            Self {
+                key: Default::default(),
+                value: Default::default(),
+                active: true.into(),
+                masked: false.into(),
+            }
+        }
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for Field {
+        const NAME: &'static str = "CarteroField";
+        type Type = super::Field;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for Field {}
+}
+
+#[cfg(test)]
+mod tests {
+
+    use glib::Object;
+
+    use crate::utils::test::assert_emits_signal;
+
+    use super::*;
+
+    #[test]
+    pub fn test_valid_builder() {
+        let field: Field = Object::builder()
+            .property("key", "User-Agent")
+            .property("value", "Mozilla/5.0")
+            .build();
+        assert_eq!(field.key(), "User-Agent");
+        assert_eq!(field.value(), "Mozilla/5.0");
+        assert!(field.active());
+        assert!(!field.masked());
+    }
+
+    #[test]
+    pub fn test_notifies_changes() {
+        let field: Field = Object::builder()
+            .property("key", "User-Agent")
+            .property("value", "Mozilla/5.0")
+            .build();
+
+        assert_emits_signal(&field, "notify", || field.set_key("Accept"));
+        assert_emits_signal(&field, "notify", || field.set_value("text/html"));
+        assert_emits_signal(&field, "notify", || field.set_active(false));
+        assert_emits_signal(&field, "notify", || field.set_masked(true));
+    }
+}

--- a/crates/cartero-objects/src/field_table.rs
+++ b/crates/cartero-objects/src/field_table.rs
@@ -1,0 +1,165 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gio::prelude::ListModelExt;
+use glib::subclass::prelude::*;
+use glib::{prelude::*, Object};
+
+use crate::field::Field;
+
+glib::wrapper! {
+    pub struct FieldTable(ObjectSubclass<imp::FieldTable>) @implements gio::ListModel;
+}
+
+impl Default for FieldTable {
+    fn default() -> Self {
+        Object::builder().build()
+    }
+}
+
+impl FieldTable {
+    pub fn insert(&self, field: &Field) {
+        {
+            let mut fields = self.imp().fields.borrow_mut();
+            fields.push(field.clone());
+        }
+        let len = { self.imp().fields.borrow().len() };
+        self.items_changed(len as u32, 0, 1);
+    }
+
+    pub fn remove(&self, pos: u32) {
+        {
+            let mut fields = self.imp().fields.borrow_mut();
+            // Panics in case of out of bounds.
+            fields.remove(pos as usize);
+        }
+        // If we reach here, we survived delete.
+        self.items_changed(pos, 1, 0);
+    }
+}
+
+mod imp {
+    use gio::subclass::prelude::ListModelImpl;
+
+    use super::*;
+    use std::cell::RefCell;
+
+    #[derive(Default)]
+    pub struct FieldTable {
+        pub(super) fields: RefCell<Vec<Field>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for FieldTable {
+        const NAME: &'static str = "CarteroFieldTable";
+        type Type = super::FieldTable;
+        type Interfaces = (gio::ListModel,);
+    }
+
+    impl ObjectImpl for FieldTable {}
+
+    impl ListModelImpl for FieldTable {
+        fn item_type(&self) -> glib::Type {
+            Field::static_type()
+        }
+
+        fn n_items(&self) -> u32 {
+            self.fields.borrow().len() as u32
+        }
+
+        fn item(&self, position: u32) -> Option<glib::Object> {
+            let fields = self.fields.borrow();
+            fields.get(position as usize).map(|f| f.clone().upcast())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[test]
+    pub fn test_valid_builder() {
+        let table: FieldTable = Object::builder().build();
+        assert_eq!(table.n_items(), 0);
+    }
+
+    #[test]
+    pub fn test_insert_get_remove() {
+        let field: Field = Object::builder()
+            .property("key", "User-Agent")
+            .property("value", "Mozilla/5.0")
+            .build();
+        let field2: Field = Object::builder()
+            .property("key", "Content-Type")
+            .property("value", "text/html")
+            .build();
+        let table: FieldTable = Object::builder().build();
+        let inserts = Arc::new(Mutex::new(Vec::new()));
+        let local_inserts = inserts.clone();
+        table.connect_items_changed(move |_, pos, removed, added| {
+            let mut vector = local_inserts.lock().unwrap();
+            vector.push((pos, removed, added));
+        });
+
+        {
+            table.insert(&field);
+            assert_eq!(table.n_items(), 1);
+            let (pos, removed, added) = inserts.lock().unwrap().last().unwrap().to_owned();
+            assert_eq!(pos, 1);
+            assert_eq!(removed, 0);
+            assert_eq!(added, 1);
+        }
+
+        {
+            table.insert(&field2);
+            assert_eq!(table.n_items(), 2);
+            let (pos, removed, added) = inserts.lock().unwrap().last().unwrap().to_owned();
+            assert_eq!(pos, 2);
+            assert_eq!(removed, 0);
+            assert_eq!(added, 1);
+        }
+
+        {
+            assert!(table
+                .item(0)
+                .is_some_and(|f| f.downcast::<Field>().is_ok_and(|f| f == field)));
+            assert!(table
+                .item(1)
+                .is_some_and(|f| f.downcast::<Field>().is_ok_and(|f| f == field2)));
+            assert!(table.item(2).is_none());
+        }
+
+        {
+            table.remove(0);
+            assert_eq!(table.n_items(), 1);
+            let (pos, removed, added) = inserts.lock().unwrap().last().unwrap().to_owned();
+            assert_eq!(pos, 0);
+            assert_eq!(removed, 1);
+            assert_eq!(added, 0);
+        }
+
+        {
+            assert!(table
+                .item(0)
+                .is_some_and(|f| f.downcast::<Field>().is_ok_and(|f| f == field2)));
+            assert!(table.item(1).is_none());
+        }
+    }
+}

--- a/crates/cartero-objects/src/lib.rs
+++ b/crates/cartero-objects/src/lib.rs
@@ -1,0 +1,47 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+mod field;
+mod field_table;
+mod request;
+mod request_authentication;
+mod request_authentication_basic;
+mod request_authentication_bearer;
+mod request_authentication_data;
+mod request_body;
+mod request_body_data;
+mod request_body_multipart;
+mod request_body_raw;
+mod request_body_urlencoded;
+mod request_method;
+mod response;
+mod utils;
+
+pub use crate::field::*;
+pub use crate::field_table::*;
+pub use crate::request::*;
+pub use crate::request_authentication::*;
+pub use crate::request_authentication_basic::*;
+pub use crate::request_authentication_bearer::*;
+pub use crate::request_authentication_data::*;
+pub use crate::request_body::*;
+pub use crate::request_body_data::*;
+pub use crate::request_body_multipart::*;
+pub use crate::request_body_raw::*;
+pub use crate::request_body_urlencoded::*;
+pub use crate::request_method::*;
+pub use crate::response::*;

--- a/crates/cartero-objects/src/request.rs
+++ b/crates/cartero-objects/src/request.rs
@@ -1,0 +1,73 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::subclass::prelude::*;
+use glib::{prelude::*, Object};
+
+glib::wrapper! {
+    pub struct Request(ObjectSubclass<imp::Request>);
+}
+
+impl Default for Request {
+    fn default() -> Self {
+        Object::builder().build()
+    }
+}
+
+mod imp {
+    use std::cell::RefCell;
+
+    use glib::Properties;
+
+    use crate::{field_table::FieldTable, RequestAuthentication, RequestBody, RequestMethod};
+
+    use super::*;
+
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::Request)]
+    pub struct Request {
+        #[property(get, set, builder(RequestMethod::default()))]
+        method: RefCell<RequestMethod>,
+
+        #[property(get, set)]
+        url: RefCell<String>,
+
+        #[property(get, set)]
+        params: RefCell<FieldTable>,
+
+        #[property(get, set)]
+        headers: RefCell<FieldTable>,
+
+        #[property(get, set)]
+        variables: RefCell<FieldTable>,
+
+        #[property(get)]
+        authentication: RefCell<RequestAuthentication>,
+
+        #[property(get)]
+        body: RefCell<RequestBody>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for Request {
+        const NAME: &'static str = "CarteroRequest";
+        type Type = super::Request;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for Request {}
+}

--- a/crates/cartero-objects/src/request_authentication.rs
+++ b/crates/cartero-objects/src/request_authentication.rs
@@ -1,0 +1,183 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::subclass::prelude::*;
+use glib::{prelude::*, Object};
+
+use crate::{RequestAuthenticationBasic, RequestAuthenticationBearer};
+
+glib::wrapper! {
+    pub struct RequestAuthentication(ObjectSubclass<imp::RequestAuthentication>);
+}
+
+impl Default for RequestAuthentication {
+    fn default() -> Self {
+        Object::builder().build()
+    }
+}
+
+impl RequestAuthentication {
+    pub fn new() -> Self {
+        Object::builder()
+            .property("auth-type", RequestAuthenticationType::None)
+            .build()
+    }
+
+    pub fn basic_auth(&self) -> Option<RequestAuthenticationBasic> {
+        if self.auth_type() == RequestAuthenticationType::BasicAuth {
+            self.auth_data()
+                .and_downcast::<RequestAuthenticationBasic>()
+        } else {
+            None
+        }
+    }
+
+    pub fn bearer_token(&self) -> Option<RequestAuthenticationBearer> {
+        if self.auth_type() == RequestAuthenticationType::BearerToken {
+            self.auth_data()
+                .and_downcast::<RequestAuthenticationBearer>()
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Copy, Clone, Default, PartialEq, Eq, glib::Enum)]
+#[enum_type(name = "CarteroRequestAuthenticationType")]
+pub enum RequestAuthenticationType {
+    #[default]
+    #[enum_value(name = "NONE", nick = "None")]
+    None,
+    #[enum_value(name = "INHERIT", nick = "Inherit")]
+    Inherit,
+    #[enum_value(name = "BASIC_AUTHENTICATION", nick = "Basic Authentication")]
+    BasicAuth,
+    #[enum_value(name = "BEARER_TOKEN", nick = "Bearer Token")]
+    BearerToken,
+}
+
+mod imp {
+    use std::cell::RefCell;
+
+    use glib::Properties;
+
+    use crate::{
+        RequestAuthenticationBasic, RequestAuthenticationBearer, RequestAuthenticationData,
+    };
+
+    use super::*;
+
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::RequestAuthentication)]
+    pub struct RequestAuthentication {
+        #[property(get, set, name = "auth-type", builder(RequestAuthenticationType::None))]
+        auth_type: RefCell<RequestAuthenticationType>,
+
+        #[property(get, name = "auth-data", nullable)]
+        auth_data: RefCell<Option<RequestAuthenticationData>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for RequestAuthentication {
+        const NAME: &'static str = "CarteroRequestAuthorization";
+        type Type = super::RequestAuthentication;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for RequestAuthentication {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            self.obj().connect_auth_type_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |auth| {
+                    let next = match auth.auth_type() {
+                        RequestAuthenticationType::None => None,
+                        RequestAuthenticationType::Inherit => None,
+                        RequestAuthenticationType::BasicAuth => Some(
+                            RequestAuthenticationBasic::default()
+                                .upcast::<RequestAuthenticationData>(),
+                        ),
+                        RequestAuthenticationType::BearerToken => Some(
+                            RequestAuthenticationBearer::default()
+                                .upcast::<RequestAuthenticationData>(),
+                        ),
+                    };
+                    imp.auth_data.replace(next);
+                    auth.notify_auth_data();
+                }
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::test::assert_emits_signal;
+
+    use super::*;
+
+    #[test]
+    pub fn no_authentication() {
+        let authentication = RequestAuthentication::new();
+        assert_emits_signal(&authentication, "notify::auth-data", || {
+            authentication.set_auth_type(RequestAuthenticationType::None)
+        });
+        assert!(authentication.basic_auth().is_none());
+        assert!(authentication.bearer_token().is_none());
+    }
+
+    #[test]
+    pub fn inherit_authentication() {
+        let authentication = RequestAuthentication::new();
+        assert_emits_signal(&authentication, "notify::auth-data", || {
+            authentication.set_auth_type(RequestAuthenticationType::Inherit)
+        });
+        assert!(authentication.basic_auth().is_none());
+        assert!(authentication.bearer_token().is_none());
+    }
+
+    #[test]
+    pub fn basic_auth() {
+        let authentication = RequestAuthentication::new();
+        assert_emits_signal(&authentication, "notify::auth-data", || {
+            authentication.set_auth_type(RequestAuthenticationType::BasicAuth)
+        });
+        let basic_auth = authentication.basic_auth().unwrap();
+        basic_auth.set_username("admin");
+        basic_auth.set_password("1234");
+        assert!(authentication
+            .basic_auth()
+            .is_some_and(|a| a.username() == "admin" && a.password() == "1234"));
+        assert!(authentication.bearer_token().is_none());
+    }
+
+    #[test]
+    pub fn bearer_auth() {
+        let authentication = RequestAuthentication::new();
+        assert_emits_signal(&authentication, "notify::auth-data", || {
+            authentication.set_auth_type(RequestAuthenticationType::BearerToken)
+        });
+        let bearer_token = authentication.bearer_token().unwrap();
+        bearer_token.set_token("55aa55aa");
+        assert!(authentication.basic_auth().is_none());
+        assert!(authentication
+            .bearer_token()
+            .is_some_and(|ba| ba.token() == "55aa55aa"));
+    }
+}

--- a/crates/cartero-objects/src/request_authentication_basic.rs
+++ b/crates/cartero-objects/src/request_authentication_basic.rs
@@ -1,0 +1,62 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::subclass::prelude::*;
+use glib::{prelude::*, Object};
+
+glib::wrapper! {
+    pub struct RequestAuthenticationBasic(ObjectSubclass<imp::RequestAuthenticationBasic>)
+        @extends crate::RequestAuthenticationData;
+}
+
+impl Default for RequestAuthenticationBasic {
+    fn default() -> Self {
+        Object::builder().build()
+    }
+}
+
+mod imp {
+    use std::cell::RefCell;
+
+    use glib::Properties;
+
+    use crate::RequestAuthenticationDataImpl;
+
+    use super::*;
+
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::RequestAuthenticationBasic)]
+    pub struct RequestAuthenticationBasic {
+        #[property(get, set)]
+        username: RefCell<String>,
+
+        #[property(get, set)]
+        password: RefCell<String>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for RequestAuthenticationBasic {
+        const NAME: &'static str = "CarteroRequestAuthorizationBasic";
+        type Type = super::RequestAuthenticationBasic;
+        type ParentType = crate::RequestAuthenticationData;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for RequestAuthenticationBasic {}
+
+    impl RequestAuthenticationDataImpl for RequestAuthenticationBasic {}
+}

--- a/crates/cartero-objects/src/request_authentication_bearer.rs
+++ b/crates/cartero-objects/src/request_authentication_bearer.rs
@@ -1,0 +1,59 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::subclass::prelude::*;
+use glib::{prelude::*, Object};
+
+glib::wrapper! {
+    pub struct RequestAuthenticationBearer(ObjectSubclass<imp::RequestAuthenticationBearer>)
+        @extends crate::RequestAuthenticationData;
+}
+
+impl Default for RequestAuthenticationBearer {
+    fn default() -> Self {
+        Object::builder().build()
+    }
+}
+
+mod imp {
+    use std::cell::RefCell;
+
+    use glib::Properties;
+
+    use crate::RequestAuthenticationDataImpl;
+
+    use super::*;
+
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::RequestAuthenticationBearer)]
+    pub struct RequestAuthenticationBearer {
+        #[property(get, set)]
+        token: RefCell<String>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for RequestAuthenticationBearer {
+        const NAME: &'static str = "CarteroRequestAuthorizationBearer";
+        type Type = super::RequestAuthenticationBearer;
+        type ParentType = crate::RequestAuthenticationData;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for RequestAuthenticationBearer {}
+
+    impl RequestAuthenticationDataImpl for RequestAuthenticationBearer {}
+}

--- a/crates/cartero-objects/src/request_authentication_data.rs
+++ b/crates/cartero-objects/src/request_authentication_data.rs
@@ -1,0 +1,41 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::subclass::prelude::*;
+
+glib::wrapper! {
+    pub struct RequestAuthenticationData(ObjectSubclass<imp::RequestAuthenticationData>);
+}
+
+mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct RequestAuthenticationData;
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for RequestAuthenticationData {
+        const NAME: &'static str = "CarteroRequestAuthorizationData";
+        type Type = super::RequestAuthenticationData;
+    }
+
+    impl ObjectImpl for RequestAuthenticationData {}
+}
+
+pub trait RequestAuthenticationDataImpl: ObjectImpl {}
+
+unsafe impl<T: RequestAuthenticationDataImpl> IsSubclassable<T> for RequestAuthenticationData {}

--- a/crates/cartero-objects/src/request_body.rs
+++ b/crates/cartero-objects/src/request_body.rs
@@ -1,0 +1,131 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::subclass::prelude::*;
+use glib::{prelude::*, Object};
+
+use crate::{RequestBodyMultipart, RequestBodyRaw, RequestBodyUrlencoded};
+
+glib::wrapper! {
+    pub struct RequestBody(ObjectSubclass<imp::RequestBody>);
+}
+
+impl Default for RequestBody {
+    fn default() -> Self {
+        Object::builder().build()
+    }
+}
+
+impl RequestBody {
+    pub fn new() -> Self {
+        Object::builder()
+            .property("auth-type", RequestBodyType::None)
+            .build()
+    }
+
+    pub fn urlencoded(&self) -> Option<RequestBodyUrlencoded> {
+        if self.body_type() == RequestBodyType::UrlEncoded {
+            self.body_data().and_downcast::<RequestBodyUrlencoded>()
+        } else {
+            None
+        }
+    }
+
+    pub fn multipart(&self) -> Option<RequestBodyMultipart> {
+        if self.body_type() == RequestBodyType::Multipart {
+            self.body_data().and_downcast::<RequestBodyMultipart>()
+        } else {
+            None
+        }
+    }
+
+    pub fn raw(&self) -> Option<RequestBodyRaw> {
+        if self.body_type() == RequestBodyType::Raw {
+            self.body_data().and_downcast::<RequestBodyRaw>()
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Copy, Clone, Default, PartialEq, Eq, glib::Enum)]
+#[enum_type(name = "CarteroRequestBodyType")]
+pub enum RequestBodyType {
+    #[default]
+    #[enum_value(name = "NONE", nick = "None")]
+    None,
+    #[enum_value(name = "URL_ENCODED", nick = "URL-Encoded")]
+    UrlEncoded,
+    #[enum_value(name = "MULTIPART", nick = "Multipart")]
+    Multipart,
+    #[enum_value(name = "RAW", nick = "Raw")]
+    Raw,
+}
+
+mod imp {
+    use std::cell::RefCell;
+
+    use glib::Properties;
+
+    use crate::{RequestBodyData, RequestBodyMultipart, RequestBodyRaw, RequestBodyUrlencoded};
+
+    use super::*;
+
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::RequestBody)]
+    pub struct RequestBody {
+        #[property(get, set, name = "body-type", builder(RequestBodyType::None))]
+        body_type: RefCell<RequestBodyType>,
+
+        #[property(get, name = "body-data", nullable)]
+        body_data: RefCell<Option<RequestBodyData>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for RequestBody {
+        const NAME: &'static str = "CarteroRequestBody";
+        type Type = super::RequestBody;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for RequestBody {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            self.obj().connect_body_type_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |body| {
+                    let next = match body.body_type() {
+                        RequestBodyType::None => None,
+                        RequestBodyType::UrlEncoded => {
+                            Some(RequestBodyUrlencoded::default().upcast::<RequestBodyData>())
+                        }
+                        RequestBodyType::Multipart => {
+                            Some(RequestBodyMultipart::default().upcast::<RequestBodyData>())
+                        }
+                        RequestBodyType::Raw => {
+                            Some(RequestBodyRaw::default().upcast::<RequestBodyData>())
+                        }
+                    };
+                    imp.body_data.replace(next);
+                    body.notify_body_data();
+                }
+            ));
+        }
+    }
+}

--- a/crates/cartero-objects/src/request_body_data.rs
+++ b/crates/cartero-objects/src/request_body_data.rs
@@ -1,0 +1,41 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::subclass::prelude::*;
+
+glib::wrapper! {
+    pub struct RequestBodyData(ObjectSubclass<imp::RequestBodyData>);
+}
+
+mod imp {
+    use super::*;
+
+    #[derive(Default)]
+    pub struct RequestBodyData;
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for RequestBodyData {
+        const NAME: &'static str = "CarteroRequestBodyData";
+        type Type = super::RequestBodyData;
+    }
+
+    impl ObjectImpl for RequestBodyData {}
+}
+
+pub trait RequestBodyDataImpl: ObjectImpl {}
+
+unsafe impl<T: RequestBodyDataImpl> IsSubclassable<T> for RequestBodyData {}

--- a/crates/cartero-objects/src/request_body_multipart.rs
+++ b/crates/cartero-objects/src/request_body_multipart.rs
@@ -1,0 +1,58 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::subclass::prelude::*;
+use glib::{prelude::*, Object};
+
+glib::wrapper! {
+    pub struct RequestBodyMultipart(ObjectSubclass<imp::RequestBodyMultipart>) @extends crate::RequestBodyData;
+}
+
+impl Default for RequestBodyMultipart {
+    fn default() -> Self {
+        Object::builder().build()
+    }
+}
+
+mod imp {
+    use glib::Properties;
+
+    use super::*;
+
+    use std::cell::RefCell;
+
+    use crate::{FieldTable, RequestBodyDataImpl};
+
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::RequestBodyMultipart)]
+    pub struct RequestBodyMultipart {
+        #[property(get, set)]
+        params: RefCell<FieldTable>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for RequestBodyMultipart {
+        const NAME: &'static str = "CarteroRequestBodyMultipart";
+        type Type = super::RequestBodyMultipart;
+        type ParentType = crate::RequestBodyData;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for RequestBodyMultipart {}
+
+    impl RequestBodyDataImpl for RequestBodyMultipart {}
+}

--- a/crates/cartero-objects/src/request_body_raw.rs
+++ b/crates/cartero-objects/src/request_body_raw.rs
@@ -1,0 +1,75 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::prelude::*;
+use glib::subclass::prelude::*;
+use glib::Object;
+
+glib::wrapper! {
+    pub struct RequestBodyRaw(ObjectSubclass<imp::RequestBodyRaw>) @extends crate::RequestBodyData;
+}
+
+impl Default for RequestBodyRaw {
+    fn default() -> Self {
+        Object::builder().build()
+    }
+}
+
+#[derive(Copy, Clone, Default, PartialEq, Eq, glib::Enum)]
+#[enum_type(name = "CarteroRequestBodyRawType")]
+pub enum RequestBodyRawType {
+    #[default]
+    #[enum_value(name = "OCTET_STREAM", nick = "Octet Stream")]
+    OctetStream,
+    #[enum_value(name = "JSON", nick = "JSON")]
+    Json,
+    #[enum_value(name = "XML", nick = "XML")]
+    Xml,
+}
+
+mod imp {
+    use std::cell::RefCell;
+
+    use crate::RequestBodyDataImpl;
+
+    use super::*;
+    use glib::Properties;
+
+    use super::RequestBodyRawType;
+
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::RequestBodyRaw)]
+    pub struct RequestBodyRaw {
+        #[property(get, set, name = "body-type", builder(RequestBodyRawType::OctetStream))]
+        body_type: RefCell<RequestBodyRawType>,
+
+        #[property(get, set, nullable)]
+        payload: RefCell<Option<glib::Bytes>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for RequestBodyRaw {
+        const NAME: &'static str = "CarteroRequestBodyRaw";
+        type Type = super::RequestBodyRaw;
+        type ParentType = crate::RequestBodyData;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for RequestBodyRaw {}
+
+    impl RequestBodyDataImpl for RequestBodyRaw {}
+}

--- a/crates/cartero-objects/src/request_body_urlencoded.rs
+++ b/crates/cartero-objects/src/request_body_urlencoded.rs
@@ -1,0 +1,58 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::subclass::prelude::*;
+use glib::{prelude::*, Object};
+
+glib::wrapper! {
+    pub struct RequestBodyUrlencoded(ObjectSubclass<imp::RequestBodyUrlencoded>) @extends crate::RequestBodyData;
+}
+
+impl Default for RequestBodyUrlencoded {
+    fn default() -> Self {
+        Object::builder().build()
+    }
+}
+
+mod imp {
+    use glib::Properties;
+
+    use super::*;
+
+    use std::cell::RefCell;
+
+    use crate::{FieldTable, RequestBodyDataImpl};
+
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::RequestBodyUrlencoded)]
+    pub struct RequestBodyUrlencoded {
+        #[property(get, set)]
+        params: RefCell<FieldTable>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for RequestBodyUrlencoded {
+        const NAME: &'static str = "CarteroRequestBodyUrlencoded";
+        type Type = super::RequestBodyUrlencoded;
+        type ParentType = crate::RequestBodyData;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for RequestBodyUrlencoded {}
+
+    impl RequestBodyDataImpl for RequestBodyUrlencoded {}
+}

--- a/crates/cartero-objects/src/request_method.rs
+++ b/crates/cartero-objects/src/request_method.rs
@@ -1,0 +1,113 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, glib::Enum)]
+#[enum_type(name = "CarteroRequestMethod")]
+pub enum RequestMethod {
+    #[default]
+    #[enum_value(name = "GET")]
+    Get,
+    #[enum_value(name = "POST")]
+    Post,
+    #[enum_value(name = "PUT")]
+    Put,
+    #[enum_value(name = "PATCH")]
+    Patch,
+    #[enum_value(name = "DELETE")]
+    Delete,
+    #[enum_value(name = "OPTIONS")]
+    Options,
+    #[enum_value(name = "HEAD")]
+    Head,
+    #[enum_value(name = "TRACE")]
+    Trace,
+}
+
+impl AsRef<str> for RequestMethod {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::Get => "GET",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Patch => "PATCH",
+            Self::Delete => "DELETE",
+            Self::Head => "HEAD",
+            Self::Options => "OPTIONS",
+            Self::Trace => "TRACE",
+        }
+    }
+}
+
+impl std::fmt::Display for RequestMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_ref())
+    }
+}
+
+impl<'a> TryFrom<&'a str> for RequestMethod {
+    type Error = &'a str;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        match value.to_lowercase().as_str() {
+            "get" => Ok(Self::Get),
+            "post" => Ok(Self::Post),
+            "put" => Ok(Self::Put),
+            "patch" => Ok(Self::Patch),
+            "delete" => Ok(Self::Delete),
+            "options" => Ok(Self::Options),
+            "head" => Ok(Self::Head),
+            "trace" => Ok(Self::Trace),
+            _ => Err(value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_request_method_from_str() {
+        let matches = vec![
+            ("GET", RequestMethod::Get),
+            ("Put", RequestMethod::Put),
+            ("delete", RequestMethod::Delete),
+            ("OpTiOnS", RequestMethod::Options),
+        ];
+        for (verb, expected) in matches {
+            let value = RequestMethod::try_from(verb).unwrap();
+            assert_eq!(value, expected);
+        }
+
+        let failing = RequestMethod::try_from("HELLO");
+        assert!(failing.is_err());
+    }
+
+    #[test]
+    fn test_request_method_to_str() {
+        let matches = vec![
+            (RequestMethod::Get, "GET"),
+            (RequestMethod::Put, "PUT"),
+            (RequestMethod::Trace, "TRACE"),
+            (RequestMethod::Head, "HEAD"),
+        ];
+        for (verb, expected) in matches {
+            let result = verb.as_ref();
+            assert_eq!(result, expected);
+        }
+    }
+}

--- a/crates/cartero-objects/src/response.rs
+++ b/crates/cartero-objects/src/response.rs
@@ -1,0 +1,58 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::prelude::*;
+use glib::subclass::prelude::*;
+
+glib::wrapper! {
+    pub struct Response(ObjectSubclass<imp::Response>);
+}
+
+mod imp {
+    use super::*;
+    use std::cell::RefCell;
+
+    use glib::Properties;
+
+    use crate::{FieldTable, Request};
+
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::Response)]
+    pub struct Response {
+        #[property(get, set)]
+        request: RefCell<Request>,
+        #[property(get, set)]
+        status_code: RefCell<u32>,
+        #[property(get, set)]
+        duration: RefCell<u64>,
+        #[property(get, set)]
+        size: RefCell<u64>,
+        #[property(get, set)]
+        headers: RefCell<FieldTable>,
+        #[property(get, set, nullable)]
+        body: RefCell<Option<glib::Bytes>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for Response {
+        const NAME: &'static str = "CarteroResponse";
+        type Type = super::Response;
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for Response {}
+}

--- a/crates/cartero-objects/src/utils.rs
+++ b/crates/cartero-objects/src/utils.rs
@@ -1,0 +1,75 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/// TODO: convert into a macro?
+#[cfg(test)]
+pub(crate) mod test {
+    use std::sync::{atomic::AtomicBool, Arc, Mutex};
+
+    use glib::object::IsA;
+    use glib::object::ObjectExt;
+
+    pub(crate) fn assert_emits_signal<T, F>(obj: &T, signal: &str, callback: F)
+    where
+        T: IsA<glib::Object>,
+        F: Fn(),
+    {
+        let trigger = Arc::new(Mutex::new(AtomicBool::new(false)));
+        let trigger_cb = trigger.clone();
+        let handler = obj.connect_local(signal, true, move |_| {
+            let ab = trigger_cb.lock().unwrap();
+            ab.store(true, std::sync::atomic::Ordering::Relaxed);
+            None
+        });
+        callback();
+        assert!(
+            trigger
+                .lock()
+                .unwrap()
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "signal {} was not emitted",
+            signal
+        );
+        obj.disconnect(handler);
+    }
+
+    /// TODO: convert into a macro?
+    #[allow(unused)]
+    pub(crate) fn assert_not_emits_signal<T, F>(obj: &T, signal: &str, callback: F)
+    where
+        T: IsA<glib::Object>,
+        F: Fn(),
+    {
+        let trigger = Arc::new(Mutex::new(AtomicBool::new(false)));
+        let trigger_cb = trigger.clone();
+        let handler = obj.connect_local(signal, true, move |_| {
+            let ab = trigger_cb.lock().unwrap();
+            ab.store(true, std::sync::atomic::Ordering::Relaxed);
+            None
+        });
+        callback();
+        assert!(
+            !trigger
+                .lock()
+                .unwrap()
+                .load(std::sync::atomic::Ordering::Relaxed),
+            "emited signal {}",
+            signal
+        );
+        obj.disconnect(handler);
+    }
+}


### PR DESCRIPTION
By using GObject types for our data structures, it will be possible to simplify keeping an updated UI state, by making the widgets automatically hold and update the values of the data structures they are trying to represent, without having to fallback to functions such as `extract` or `assign` to do so manually.

This has been implemented as a separate crate called `cartero_objects`, so yeah, Cartero is now a monorepo.

Note that this PR does not remove the old structures from `cartero::entities`, because this commit just introduces the new objects, but does not change the way the components are bound to the new objects, given that this will also probably affect files. (However, I am interested now in moving the file save routines to a separate crate as well, and maaaaaaaybe then this could allow working on more importers and exporters)