### PR TITLE
Define precondition errors for request validation

### DIFF
--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -35,9 +35,21 @@ pub struct BoundRequest {
     pub body: Option<Vec<u8>>,
 }
 
-impl BoundRequest {
-    pub fn full_url(&self) -> Result<Url, url::ParseError> {
-        Url::parse(&self.url)
+fn normalize_url(url: &str) -> Result<String, RequestPreconditionError> {
+    match Url::parse(url) {
+        Ok(url) => {
+            // Check for protocol as well.
+            match url.scheme() {
+                "http" | "https" => Ok(url.to_string()),
+                other => Err(RequestPreconditionError::UnsupportedProtocol(
+                    other.to_owned(),
+                )),
+            }
+        }
+        Err(url::ParseError::RelativeUrlWithoutBase) => {
+            Err(RequestPreconditionError::MissingProtocol)
+        }
+        Err(_) => Err(RequestPreconditionError::UrlBadParse),
     }
 }
 
@@ -48,6 +60,8 @@ impl TryFrom<EndpointData> for BoundRequest {
         let processor = value.template_processor();
 
         let url = processor.render(&value.url)?;
+        let url = normalize_url(&url)?;
+
         let method = value.method.clone();
         let headers = value.headers.render(&processor)?;
 
@@ -219,5 +233,87 @@ mod tests {
 
         // Bind the request.
         let _ = BoundRequest::try_from(endpoint).unwrap();
+    }
+
+    #[test]
+    pub fn test_fails_if_url_lacks_protocol() {
+        let url = "example.com/api/v1/users";
+        let method = RequestMethod::Get;
+
+        let endpoint = EndpointData {
+            url: url.into(),
+            method,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            body: RequestPayload::None,
+        };
+        let result = BoundRequest::try_from(endpoint);
+        assert!(result.is_err_and(|e| e == RequestPreconditionError::MissingProtocol));
+    }
+
+    #[test]
+    pub fn test_fails_if_url_uses_unacceptable_protocol() {
+        let url = "gemini://geminiprotocol.net/";
+        let method = RequestMethod::Get;
+
+        let endpoint = EndpointData {
+            url: url.into(),
+            method,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            body: RequestPayload::None,
+        };
+        let result = BoundRequest::try_from(endpoint);
+        assert!(result.is_err_and(
+            |e| e == RequestPreconditionError::UnsupportedProtocol("gemini".to_string())
+        ));
+    }
+
+    #[test]
+    pub fn test_normalizes_url_with_leading_spaces() {
+        let url = " https://example.com/api/v1/users";
+        let method = RequestMethod::Get;
+
+        let endpoint = EndpointData {
+            url: url.into(),
+            method,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            body: RequestPayload::None,
+        };
+        let result = BoundRequest::try_from(endpoint).unwrap();
+        assert_eq!(result.url, "https://example.com/api/v1/users");
+    }
+
+    #[test]
+    pub fn test_normalizes_url_with_trailing_spaces() {
+        let url = "https://example.com/api/v1/users ";
+        let method = RequestMethod::Get;
+
+        let endpoint = EndpointData {
+            url: url.into(),
+            method,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            body: RequestPayload::None,
+        };
+        let result = BoundRequest::try_from(endpoint).unwrap();
+        assert_eq!(result.url, "https://example.com/api/v1/users");
+    }
+
+    #[test]
+    pub fn test_normalizes_url_with_leading_and_trailing_spaces() {
+        let url = " https://example.com/api/v1/users ";
+        let method = RequestMethod::Get;
+
+        let endpoint = EndpointData {
+            url: url.into(),
+            method,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            body: RequestPayload::None,
+        };
+        let result = BoundRequest::try_from(endpoint).unwrap();
+        assert_eq!(result.url, "https://example.com/api/v1/users");
     }
 }

--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 the Cartero authors
+// Copyright 2024-2025 the Cartero authors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,20 +15,17 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use formdata::FormData;
 use isahc::http::header::{InvalidHeaderName, InvalidHeaderValue};
-use srtemplate::SrTemplate;
-use std::{
-    collections::HashMap,
-    io::{BufWriter, Write},
-};
+use std::collections::HashMap;
 use thiserror::Error;
 use url::Url;
 
 use crate::{
-    entities::{EndpointData, KeyValueTable, RawEncoding, RequestMethod, RequestPayload},
-    error::CarteroError,
+    entities::{EndpointData, RequestMethod},
+    error::RequestPreconditionError,
 };
+
+use super::request_bodies::BoundRequestBody;
 
 #[derive(Default, Debug, Clone)]
 pub struct BoundRequest {
@@ -44,148 +41,30 @@ impl BoundRequest {
     }
 }
 
-#[derive(Default, Debug, Clone)]
-struct BoundBody {
-    content: Vec<u8>,
-    boundary: String,
-}
-
-fn bind_urlencoded_payload(
-    body: &KeyValueTable,
-    processor: &SrTemplate,
-) -> Result<Option<BoundBody>, CarteroError> {
-    if body.is_empty() {
-        return Ok(None);
-    }
-    let pairs: Vec<(String, String)> = body
-        .iter()
-        .filter(|var| var.active)
-        .map(|var| {
-            let key = processor.render(var.name.clone())?;
-            let value = processor.render(var.value.clone())?;
-            Ok((key, value))
-        })
-        .collect::<Result<Vec<(String, String)>, CarteroError>>()?;
-    let body = serde_urlencoded::to_string(pairs).map_err(|_| RequestError::InvalidPayload)?;
-    let content = Vec::from(body.as_str());
-    Ok(Some(BoundBody {
-        content,
-        boundary: String::default(),
-    }))
-}
-
-fn bind_multipart_payload(
-    params: &KeyValueTable,
-    processor: &SrTemplate,
-) -> Result<Option<BoundBody>, CarteroError> {
-    if params.is_empty() {
-        return Ok(None);
-    }
-    let pairs: Vec<(String, String)> = params
-        .iter()
-        .filter(|var| var.active)
-        .map(|var| {
-            let key = processor.render(var.name.clone())?;
-            let value = processor.render(var.value.clone())?;
-            Ok((key, value))
-        })
-        .collect::<Result<Vec<(String, String)>, CarteroError>>()?;
-    let formdata = FormData {
-        fields: pairs,
-        files: vec![],
-    };
-    let boundary = formdata::generate_boundary();
-
-    let mut stream = BufWriter::new(Vec::new());
-    formdata::write_formdata(&mut stream, &boundary, &formdata)
-        .map_err(|_| RequestError::InvalidPayload)?;
-    stream.flush().map_err(RequestError::IOError)?;
-    let copy = stream.get_ref().clone();
-    Ok(Some(BoundBody {
-        content: copy,
-        boundary: String::from_utf8_lossy(&boundary).to_string(),
-    }))
-}
-
-fn bind_raw_payload(
-    body: &[u8],
-    processor: &SrTemplate,
-) -> Result<Option<BoundBody>, CarteroError> {
-    if body.is_empty() {
-        return Ok(None);
-    }
-    let processable_body = String::from_utf8_lossy(body);
-    let processed_body = processor.render(processable_body)?;
-    let body = Vec::from(processed_body.as_str());
-    Ok(Some(BoundBody {
-        content: body,
-        boundary: String::default(),
-    }))
-}
-
-fn bind_payload(
-    body: &RequestPayload,
-    processor: &SrTemplate,
-) -> Result<Option<BoundBody>, CarteroError> {
-    match body {
-        RequestPayload::None => Ok(None),
-        RequestPayload::Urlencoded(payload) => bind_urlencoded_payload(payload, processor),
-        RequestPayload::Multipart { params } => bind_multipart_payload(params, processor),
-        RequestPayload::Raw {
-            content,
-            encoding: _,
-        } => bind_raw_payload(content, processor),
-    }
-}
-
 impl TryFrom<EndpointData> for BoundRequest {
-    type Error = CarteroError;
+    type Error = RequestPreconditionError;
 
     fn try_from(value: EndpointData) -> Result<Self, Self::Error> {
         let processor = value.template_processor();
 
         let url = processor.render(&value.url)?;
         let method = value.method.clone();
+        let headers = value.headers.render(&processor)?;
 
-        let body = bind_payload(&value.body, &processor)?;
-        let content_type = match value.body {
-            RequestPayload::None => None,
-            RequestPayload::Urlencoded(_) => Some("application/x-www-form-urlencoded".to_string()),
-            RequestPayload::Multipart { params: _ } => Some(format!(
-                "multipart/form-data; boundary={}",
-                body.clone().unwrap_or_default().boundary
-            )),
-            RequestPayload::Raw {
-                ref encoding,
-                content: _,
-            } => match encoding {
-                RawEncoding::OctetStream => Some("application/octet-stream".into()),
-                RawEncoding::Xml => Some("application/xml".into()),
-                RawEncoding::Json => Some("application/json".into()),
-            },
+        let body = BoundRequestBody::try_from(&value)?;
+
+        // Use the request body headers to craft the real request headers.
+        let headers = {
+            let mut all_headers = HashMap::from_iter(body.headers);
+            all_headers.extend(headers.to_active_pairs());
+            all_headers
         };
-
-        let mut base_headers = HashMap::new();
-        if let Some(content_type) = content_type {
-            base_headers.insert("Content-Type".to_string(), content_type);
-        }
-        base_headers.extend(value.process_headers());
-
-        let headers: Result<HashMap<String, String>, CarteroError> = base_headers
-            .iter()
-            .map(|(k, v)| {
-                let header_name = processor.render(k)?;
-                let header_value = processor.render(v)?;
-                Ok((header_name, header_value))
-            })
-            .collect();
-        let headers = headers?;
 
         Ok(Self {
             url,
             method,
             headers,
-            body: body.map(|b| b.content),
+            body: body.content,
         })
     }
 }
@@ -222,217 +101,9 @@ pub enum RequestError {
 
 #[cfg(test)]
 mod tests {
-    use crate::entities::KeyValueTable;
+    use crate::entities::*;
 
     use super::*;
-
-    #[test]
-    pub fn test_bind_of_parameters_urlencoded() {
-        // Build a request.
-        let url = "https://{{API_ROOT}}/v1/books".into();
-        let method = RequestMethod::Post;
-        let headers = vec![
-            ("X-Client-Id", "{{CLIENT_ID}}").into(),
-            ("Authorization", "Bearer {{CLIENT_SECRET}}").into(),
-            ("Accept", "application/html").into(),
-        ];
-        let headers = KeyValueTable::new(&headers);
-        let variables = vec![
-            ("API_ROOT", "api.example.com").into(),
-            ("CLIENT_ID", "123412341234").into(),
-            ("CLIENT_SECRET", "789078907890").into(),
-        ];
-        let variables = KeyValueTable::new(&variables);
-        let body = RequestPayload::Urlencoded(KeyValueTable::new(&[
-            ("name", "John").into(),
-            ("surname", "Smith").into(),
-        ]));
-        let endpoint = EndpointData {
-            url,
-            method,
-            headers,
-            variables,
-            body,
-        };
-
-        // Bind the request.
-        let bound = BoundRequest::try_from(endpoint).unwrap();
-
-        assert_eq!(bound.url, "https://api.example.com/v1/books");
-        assert_eq!(bound.headers["Authorization"], "Bearer 789078907890");
-        assert_eq!(
-            bound.headers["Content-Type"],
-            "application/x-www-form-urlencoded"
-        );
-        assert_eq!(bound.body, Some(Vec::from(b"name=John&surname=Smith")));
-    }
-
-    #[test]
-    pub fn test_bind_of_parameters_formdata() {
-        // Build a request.
-        let url = "https://{{API_ROOT}}/v1/books".into();
-        let method = RequestMethod::Post;
-        let headers = vec![
-            ("X-Client-Id", "{{CLIENT_ID}}").into(),
-            ("Authorization", "Bearer {{CLIENT_SECRET}}").into(),
-            ("Accept", "application/html").into(),
-        ];
-        let headers = KeyValueTable::new(&headers);
-        let variables = vec![
-            ("API_ROOT", "api.example.com").into(),
-            ("CLIENT_ID", "123412341234").into(),
-            ("CLIENT_SECRET", "789078907890").into(),
-        ];
-        let variables = KeyValueTable::new(&variables);
-        let body = RequestPayload::Multipart {
-            params: KeyValueTable::new(&[("name", "John").into(), ("surname", "Smith").into()]),
-        };
-        let endpoint = EndpointData {
-            url,
-            method,
-            headers,
-            variables,
-            body,
-        };
-
-        // Bind the request.
-        let bound = BoundRequest::try_from(endpoint).unwrap();
-
-        assert_eq!(bound.url, "https://api.example.com/v1/books");
-        assert_eq!(bound.headers["Authorization"], "Bearer 789078907890");
-
-        let content_type = bound.headers["Content-Type"].clone();
-        assert!(content_type.starts_with("multipart/form-data; boundary="));
-        let body = bound.body.unwrap();
-        let body = String::from_utf8_lossy(&body);
-        assert!(body.contains("name=\"name\""));
-        assert!(body.contains("name=\"surname\""));
-        assert!(body.contains("John"));
-        assert!(body.contains("Smith"));
-    }
-
-    #[test]
-    pub fn test_bind_of_parameters_json() {
-        // Build a request.
-        let url = "https://{{API_ROOT}}/v1/books".into();
-        let method = RequestMethod::Post;
-        let headers = vec![
-            ("X-Client-Id", "{{CLIENT_ID}}").into(),
-            ("Authorization", "Bearer {{CLIENT_SECRET}}").into(),
-            ("Accept", "application/html").into(),
-        ];
-        let headers = KeyValueTable::new(&headers);
-        let variables = vec![
-            ("API_ROOT", "api.example.com").into(),
-            ("CLIENT_ID", "123412341234").into(),
-            ("CLIENT_SECRET", "789078907890").into(),
-        ];
-        let variables = KeyValueTable::new(&variables);
-        let body = RequestPayload::Raw {
-            encoding: RawEncoding::Json,
-            content: Vec::from(b"{\"hello\": \"world\"}"),
-        };
-        let endpoint = EndpointData {
-            url,
-            method,
-            headers,
-            variables,
-            body,
-        };
-
-        // Bind the request.
-        let bound = BoundRequest::try_from(endpoint).unwrap();
-
-        assert_eq!(bound.url, "https://api.example.com/v1/books");
-        assert_eq!(bound.headers["Authorization"], "Bearer 789078907890");
-        assert_eq!(bound.headers["Content-Type"], "application/json");
-
-        let body = bound.body.unwrap();
-        let body = String::from_utf8_lossy(&body);
-        assert_eq!(body, "{\"hello\": \"world\"}");
-    }
-
-    #[test]
-    pub fn test_bind_of_parameters_xml() {
-        // Build a request.
-        let url = "https://{{API_ROOT}}/v1/books".into();
-        let method = RequestMethod::Post;
-        let headers = vec![
-            ("X-Client-Id", "{{CLIENT_ID}}").into(),
-            ("Authorization", "Bearer {{CLIENT_SECRET}}").into(),
-            ("Accept", "application/html").into(),
-        ];
-        let headers = KeyValueTable::new(&headers);
-        let variables = vec![
-            ("API_ROOT", "api.example.com").into(),
-            ("CLIENT_ID", "123412341234").into(),
-            ("CLIENT_SECRET", "789078907890").into(),
-        ];
-        let variables = KeyValueTable::new(&variables);
-        let body = RequestPayload::Raw {
-            encoding: RawEncoding::Xml,
-            content: Vec::from(b"<envelope>1234</envelope>"),
-        };
-        let endpoint = EndpointData {
-            url,
-            method,
-            headers,
-            variables,
-            body,
-        };
-
-        // Bind the request.
-        let bound = BoundRequest::try_from(endpoint).unwrap();
-
-        assert_eq!(bound.url, "https://api.example.com/v1/books");
-        assert_eq!(bound.headers["Authorization"], "Bearer 789078907890");
-        assert_eq!(bound.headers["Content-Type"], "application/xml");
-
-        let body = bound.body.unwrap();
-        let body = String::from_utf8_lossy(&body);
-        assert_eq!(body, "<envelope>1234</envelope>");
-    }
-
-    #[test]
-    pub fn test_bind_of_parameters_octet() {
-        // Build a request.
-        let url = "https://{{API_ROOT}}/v1/books".into();
-        let method = RequestMethod::Post;
-        let headers = vec![
-            ("X-Client-Id", "{{CLIENT_ID}}").into(),
-            ("Authorization", "Bearer {{CLIENT_SECRET}}").into(),
-            ("Accept", "application/html").into(),
-        ];
-        let headers = KeyValueTable::new(&headers);
-        let variables = vec![
-            ("API_ROOT", "api.example.com").into(),
-            ("CLIENT_ID", "123412341234").into(),
-            ("CLIENT_SECRET", "789078907890").into(),
-        ];
-        let variables = KeyValueTable::new(&variables);
-        let body = RequestPayload::Raw {
-            encoding: RawEncoding::OctetStream,
-            content: Vec::from(b"12341234"),
-        };
-        let endpoint = EndpointData {
-            url,
-            method,
-            headers,
-            variables,
-            body,
-        };
-
-        // Bind the request.
-        let bound = BoundRequest::try_from(endpoint).unwrap();
-
-        assert_eq!(bound.url, "https://api.example.com/v1/books");
-        assert_eq!(bound.headers["Authorization"], "Bearer 789078907890");
-        assert_eq!(bound.headers["Content-Type"], "application/octet-stream");
-
-        let body = bound.body.unwrap();
-        let body = String::from_utf8_lossy(&body);
-        assert_eq!(body, "12341234");
-    }
 
     #[test]
     pub fn test_bind_of_parameters_may_still_override_header() {

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 the Cartero authors
+// Copyright 2024-2025 the Cartero authors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,6 +17,7 @@
 
 mod isahc_conv;
 mod local;
+mod request_bodies;
 
 pub use isahc_conv::extract_isahc_response;
 pub use local::*;

--- a/src/client/request_bodies.rs
+++ b/src/client/request_bodies.rs
@@ -1,0 +1,404 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::io::{BufWriter, Write};
+
+use crate::{
+    entities::{EndpointData, RawEncoding, RequestPayload},
+    error::RequestPreconditionError,
+};
+
+/// Represents the request body once unmangled and interpolated, ready to
+/// be attached into a request when it's about to be submitted. Request
+/// bodies include the raw contents that are added as body, as well as
+/// extra headers. These headers are *prepended* to the request, so that
+/// if the request headers overload them (say, there's also a "Content-Type"
+/// header in the request headers), they will replace whatever the bound
+/// request body sets. (This is useful in case you want to send a JSON request
+/// but still need to use a custom media type such as application/ld+json.
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct BoundRequestBody {
+    /// The payload associated with the request body.
+    pub content: Option<Vec<u8>>,
+
+    /// The collection of headers to be prepended to the request.
+    pub headers: Vec<(String, String)>,
+}
+
+impl BoundRequestBody {
+    fn try_from_urlencoded(value: &EndpointData) -> Result<Self, RequestPreconditionError> {
+        let RequestPayload::Urlencoded(ref kv) = value.body else {
+            panic!("Bamboozled by the match");
+        };
+
+        let context = value.template_processor();
+        let interpolated = kv.render(&context)?;
+        let pairs = interpolated.to_active_pairs();
+        let body = serde_urlencoded::to_string(pairs)
+            .map_err(|_| RequestPreconditionError::EncodingError)?;
+        let raw = Vec::from(body.as_str());
+        Ok(BoundRequestBody {
+            content: Some(raw),
+            headers: vec![(
+                "Content-Type".into(),
+                "application/x-www-form-urlencoded".into(),
+            )],
+        })
+    }
+
+    fn try_from_multipart(value: &EndpointData) -> Result<Self, RequestPreconditionError> {
+        let RequestPayload::Multipart { ref params } = value.body else {
+            panic!("Bamboozled by the match");
+        };
+
+        let context = value.template_processor();
+        let interpolated = params.render(&context)?;
+        let pairs = interpolated.to_active_pairs();
+
+        let boundary = formdata::generate_boundary();
+        let formdata = formdata::FormData {
+            fields: pairs,
+            files: vec![],
+        };
+        let mut stream = BufWriter::new(Vec::new());
+        formdata::write_formdata(&mut stream, &boundary, &formdata).map_err(|e| {
+            glib::g_error!("cartero", "form data error: {}", e);
+            RequestPreconditionError::EncodingError
+        })?;
+        stream
+            .flush()
+            .map_err(|_| RequestPreconditionError::EncodingError)?;
+        let body = stream.get_ref().clone();
+        Ok(BoundRequestBody {
+            content: Some(body),
+            headers: vec![(
+                "Content-Type".into(),
+                format!(
+                    "multipart/form-data; boundary={}",
+                    String::from_utf8_lossy(&boundary)
+                ),
+            )],
+        })
+    }
+
+    fn try_from_raw(value: &EndpointData) -> Result<Self, RequestPreconditionError> {
+        let RequestPayload::Raw {
+            ref content,
+            ref encoding,
+        } = value.body
+        else {
+            panic!("Bamboozled by the match");
+        };
+        let processor = value.template_processor();
+        let body = String::from_utf8_lossy(content);
+        let interpolated = processor.render(&body)?;
+
+        let content_type = match encoding {
+            RawEncoding::OctetStream => "application/octet-stream",
+            RawEncoding::Xml => "application/xml",
+            RawEncoding::Json => "application/json",
+        };
+        Ok(BoundRequestBody {
+            content: Some(Vec::from(interpolated.as_str())),
+            headers: vec![("Content-Type".into(), content_type.into())],
+        })
+    }
+}
+
+impl TryFrom<&EndpointData> for BoundRequestBody {
+    type Error = RequestPreconditionError;
+
+    fn try_from(value: &EndpointData) -> Result<Self, Self::Error> {
+        match value.body {
+            RequestPayload::None => Ok(Self {
+                content: None,
+                headers: vec![],
+            }),
+            RequestPayload::Urlencoded(..) => Self::try_from_urlencoded(value),
+            RequestPayload::Multipart { .. } => Self::try_from_multipart(value),
+            RequestPayload::Raw { .. } => Self::try_from_raw(value),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::entities::KeyValueTable;
+
+    use super::*;
+
+    #[test]
+    pub fn test_from_urlencoded() {
+        let variables = vec![("API_KEY", "12341234").into()];
+        let body = vec![
+            ("account_id", "2000").into(),
+            ("api_key", "demo.{{API_KEY}}").into(),
+        ];
+        let endpoint = EndpointData {
+            url: "https://www.example.com/payload".into(),
+            method: crate::entities::RequestMethod::Post,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::new(&variables),
+            body: RequestPayload::Urlencoded(KeyValueTable::new(&body)),
+        };
+
+        let serial = BoundRequestBody::try_from(&endpoint).unwrap();
+        let body = serial.content.unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&body),
+            "account_id=2000&api_key=demo.12341234"
+        );
+        assert_eq!(
+            serial.headers,
+            vec![(
+                "Content-Type".into(),
+                "application/x-www-form-urlencoded".into()
+            ),]
+        );
+    }
+
+    #[test]
+    pub fn test_from_urlencoded_missing_var() {
+        let body = vec![
+            ("account_id", "2000").into(),
+            ("api_key", "demo.{{API_KEY}}").into(),
+        ];
+        let endpoint = EndpointData {
+            url: "https://www.example.com/payload".into(),
+            method: crate::entities::RequestMethod::Post,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            body: RequestPayload::Urlencoded(KeyValueTable::new(&body)),
+        };
+        let result = BoundRequestBody::try_from(&endpoint);
+        assert_eq!(
+            result,
+            Err(RequestPreconditionError::VariableNotFound(
+                "API_KEY".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    pub fn test_from_formdata() {
+        let variables = vec![("API_KEY", "12341234").into()];
+        let body = vec![
+            ("account_id", "2000").into(),
+            ("api_key", "demo.{{API_KEY}}").into(),
+        ];
+        let endpoint = EndpointData {
+            url: "https://www.example.com/payload".into(),
+            method: crate::entities::RequestMethod::Post,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::new(&variables),
+            body: RequestPayload::Multipart {
+                params: KeyValueTable::new(&body),
+            },
+        };
+
+        let serial = BoundRequestBody::try_from(&endpoint).unwrap();
+        let body = serial.content.unwrap();
+
+        // I cannot actually test the boundaries because they are randomly generated...
+        let expected_1 = "Content-Type: text/plain\r\nContent-Disposition: form-data; name=\"account_id\"\r\n\r\n2000";
+        let expected_2 = "Content-Type: text/plain\r\nContent-Disposition: form-data; name=\"api_key\"\r\n\r\ndemo.12341234";
+
+        let encoded_body = String::from_utf8_lossy(&body);
+        assert!(
+            encoded_body.contains(expected_1),
+            "{} part of {}",
+            expected_1,
+            encoded_body
+        );
+        assert!(
+            encoded_body.contains(expected_2),
+            "{} part of {}",
+            expected_2,
+            encoded_body
+        );
+
+        // Same goes for the header.
+        assert_eq!(1, serial.headers.len());
+        let (name, value) = &serial.headers[0];
+        assert_eq!("Content-Type", name);
+        let expected = "multipart/form-data; boundary=";
+        assert!(value.contains(expected), "{} contains {}", value, expected);
+    }
+
+    #[test]
+    pub fn test_from_formdata_missing_variables() {
+        let body = vec![
+            ("account_id", "2000").into(),
+            ("api_key", "demo.{{API_KEY}}").into(),
+        ];
+        let endpoint = EndpointData {
+            url: "https://www.example.com/payload".into(),
+            method: crate::entities::RequestMethod::Post,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            body: RequestPayload::Multipart {
+                params: KeyValueTable::new(&body),
+            },
+        };
+
+        let result = BoundRequestBody::try_from(&endpoint);
+        assert_eq!(
+            result,
+            Err(RequestPreconditionError::VariableNotFound(
+                "API_KEY".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    pub fn test_from_raw_octet() {
+        let body = RequestPayload::Raw {
+            encoding: RawEncoding::OctetStream,
+            content: Vec::from("hello {{TARGET}}"),
+        };
+        let variables = vec![("TARGET", "world").into()];
+        let endpoint = EndpointData {
+            url: "https://www.example.com/payload".into(),
+            method: crate::entities::RequestMethod::Post,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::new(&variables),
+            body,
+        };
+
+        let result = BoundRequestBody::try_from(&endpoint).unwrap();
+        assert_eq!(
+            vec![("Content-Type".into(), "application/octet-stream".into())],
+            result.headers
+        );
+        assert_eq!(Some(Vec::from("hello world")), result.content);
+    }
+
+    #[test]
+    pub fn test_from_raw_octet_missing_variable() {
+        let body = RequestPayload::Raw {
+            encoding: RawEncoding::OctetStream,
+            content: Vec::from("hello {{TARGET}}"),
+        };
+        let endpoint = EndpointData {
+            url: "https://www.example.com/payload".into(),
+            method: crate::entities::RequestMethod::Post,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            body,
+        };
+
+        let result = BoundRequestBody::try_from(&endpoint);
+        assert_eq!(
+            Err(RequestPreconditionError::VariableNotFound("TARGET".into())),
+            result
+        );
+    }
+
+    #[test]
+    pub fn test_from_json() {
+        let body = RequestPayload::Raw {
+            encoding: RawEncoding::Json,
+            content: Vec::from("{\"message\": \"hello {{TARGET}}\"}"),
+        };
+        let variables = vec![("TARGET", "world").into()];
+        let endpoint = EndpointData {
+            url: "https://www.example.com/payload".into(),
+            method: crate::entities::RequestMethod::Post,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::new(&variables),
+            body,
+        };
+
+        let result = BoundRequestBody::try_from(&endpoint).unwrap();
+        assert_eq!(
+            vec![("Content-Type".into(), "application/json".into())],
+            result.headers
+        );
+        assert_eq!(
+            Some(Vec::from("{\"message\": \"hello world\"}")),
+            result.content
+        );
+    }
+
+    #[test]
+    pub fn test_from_json_missing_variable() {
+        let body = RequestPayload::Raw {
+            encoding: RawEncoding::Json,
+            content: Vec::from("{\"message\": \"hello {{TARGET}}\"}"),
+        };
+        let endpoint = EndpointData {
+            url: "https://www.example.com/payload".into(),
+            method: crate::entities::RequestMethod::Post,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            body,
+        };
+
+        let result = BoundRequestBody::try_from(&endpoint);
+        assert_eq!(
+            Err(RequestPreconditionError::VariableNotFound("TARGET".into())),
+            result
+        );
+    }
+
+    #[test]
+    pub fn test_from_xml() {
+        let body = RequestPayload::Raw {
+            encoding: RawEncoding::Xml,
+            content: Vec::from("<hello target=\"{{TARGET}}\" />"),
+        };
+        let variables = vec![("TARGET", "world").into()];
+        let endpoint = EndpointData {
+            url: "https://www.example.com/payload".into(),
+            method: crate::entities::RequestMethod::Post,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::new(&variables),
+            body,
+        };
+
+        let result = BoundRequestBody::try_from(&endpoint).unwrap();
+        assert_eq!(
+            vec![("Content-Type".into(), "application/xml".into())],
+            result.headers
+        );
+        assert_eq!(
+            Some(Vec::from("<hello target=\"world\" />")),
+            result.content
+        );
+    }
+
+    #[test]
+    pub fn test_from_xml_missing_variable() {
+        let body = RequestPayload::Raw {
+            encoding: RawEncoding::Xml,
+            content: Vec::from("<hello target=\"{{TARGET}}\" />"),
+        };
+        let endpoint = EndpointData {
+            url: "https://www.example.com/payload".into(),
+            method: crate::entities::RequestMethod::Post,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            body,
+        };
+
+        let result = BoundRequestBody::try_from(&endpoint);
+        assert_eq!(
+            Err(RequestPreconditionError::VariableNotFound("TARGET".into())),
+            result
+        );
+    }
+}

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 the Cartero authors
+// Copyright 2024-2025 the Cartero authors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -20,7 +20,7 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
-use srtemplate::SrTemplate;
+use srtemplate::{SrTemplate, SrTemplateError};
 
 use crate::objects::KeyValueItem;
 
@@ -118,6 +118,34 @@ impl KeyValueTable {
         } else {
             Some(headers)
         }
+    }
+
+    /// Yields a new KeyValueTable where each value is interpolated according to the rules
+    /// of the given renderer. If any value in the current KeyValueTable uses a variable,
+    /// it will be interpolated.
+    pub fn render(&self, renderer: &SrTemplate) -> Result<KeyValueTable, SrTemplateError> {
+        let entries = self
+            .iter()
+            .map(|var| {
+                let name = renderer.render(var.name.clone())?;
+                let value = renderer.render(var.value.clone())?;
+                Ok(KeyValue {
+                    name,
+                    value,
+                    active: var.active,
+                    secret: var.secret,
+                })
+            })
+            .collect::<Result<Vec<KeyValue>, SrTemplateError>>()?;
+        Ok(KeyValueTable::new(&entries))
+    }
+
+    /// Collects the active pairs of this KeyValueTable, excludes non-actives.
+    pub fn to_active_pairs(&self) -> Vec<(String, String)> {
+        self.iter()
+            .filter(|entry| entry.active)
+            .map(|entry| (entry.name.clone(), entry.value.clone()))
+            .collect::<Vec<(String, String)>>()
     }
 }
 
@@ -302,6 +330,8 @@ impl ResponseData {
 
 #[cfg(test)]
 mod tests {
+    use srtemplate::SrTemplate;
+
     use crate::entities::{KeyValue, RequestMethod};
 
     use super::{KeyValueTable, ResponseData};
@@ -376,6 +406,79 @@ mod tests {
         assert!(RequestMethod::try_from("post").is_ok_and(|x| x == RequestMethod::Post));
         assert!(RequestMethod::try_from("Patch").is_ok_and(|x| x == RequestMethod::Patch));
         assert!(RequestMethod::try_from("Juan").is_err());
+    }
+
+    #[test]
+    fn test_key_value_table_render() {
+        let headers = vec![
+            ("Content-Type", "application/json").into(),
+            ("Authorization", "Bearer {{TOKEN}}").into(),
+        ];
+        let table = KeyValueTable(headers);
+
+        let context = SrTemplate::default();
+        context.add_variable("TOKEN", &"Token_Value");
+
+        let Ok(rendered) = table.render(&context) else {
+            panic!("not ok");
+        };
+        assert_eq!(
+            rendered.header("authorization"),
+            Some(vec!["Bearer Token_Value"])
+        );
+    }
+
+    #[test]
+    fn test_key_value_render_fails() {
+        let headers = vec![
+            ("Content-Type", "application/json").into(),
+            ("Authorization", "Bearer {{TOKEN}}").into(),
+        ];
+        let table = KeyValueTable(headers);
+
+        let context = SrTemplate::default();
+        let rendered = table.render(&context);
+        assert!(rendered.is_err());
+    }
+
+    #[test]
+    fn test_key_value_active_pairs() {
+        let headers = vec![
+            KeyValue {
+                name: "Accept".into(),
+                value: "application/json".into(),
+                active: false,
+                secret: false,
+            },
+            KeyValue {
+                name: "Content-Type".into(),
+                value: "application/json".into(),
+                active: true,
+                secret: false,
+            },
+            KeyValue {
+                name: "Authorization".into(),
+                value: "Bearer roarrr".into(),
+                active: false,
+                secret: false,
+            },
+            KeyValue {
+                name: "User-Agent".into(),
+                value: "Cartero/0.1".into(),
+                active: true,
+                secret: false,
+            },
+        ];
+        let table = KeyValueTable(headers);
+
+        let pairs = table.to_active_pairs();
+        assert_eq!(
+            vec![
+                ("Content-Type".to_string(), "application/json".to_string()),
+                ("User-Agent".to_string(), "Cartero/0.1".to_string()),
+            ],
+            pairs
+        );
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,4 +37,28 @@ pub enum CarteroError {
 
     #[error("Outdated schema, please update the software")]
     OutdatedSchema,
+
+    #[error("{0}")]
+    PreconditionError(#[from] RequestPreconditionError),
+}
+
+#[derive(Debug, Eq, PartialEq, Error)]
+pub enum RequestPreconditionError {
+    #[error("Payload could not be encoded")]
+    EncodingError,
+
+    #[error("Variable {0} not found")]
+    VariableNotFound(String),
+
+    #[error("String interpolation error, review variables")]
+    BadInterpolation,
+}
+
+impl From<SrTemplateError> for RequestPreconditionError {
+    fn from(value: SrTemplateError) -> Self {
+        match value {
+            SrTemplateError::VariableNotFound(var) => Self::VariableNotFound(var),
+            _ => Self::BadInterpolation,
+        }
+    }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -17,9 +17,6 @@ pub enum CarteroError {
     #[error("DNS error")]
     Dns,
 
-    #[error("Invalid protocol")]
-    InvalidProtocol,
-
     #[error("HTTP request error")]
     Request(#[from] RequestError),
 
@@ -32,9 +29,6 @@ pub enum CarteroError {
     #[error("Error manipulating TOML")]
     SerializationError(#[from] toml::ser::Error),
 
-    #[error("Error during variable interpolation: {0}")]
-    VariableInterpolationError(#[from] SrTemplateError),
-
     #[error("Outdated schema, please update the software")]
     OutdatedSchema,
 
@@ -44,6 +38,15 @@ pub enum CarteroError {
 
 #[derive(Debug, Eq, PartialEq, Error)]
 pub enum RequestPreconditionError {
+    #[error("Cannot parse the URL, check for typos")]
+    UrlBadParse,
+
+    #[error("URL is missing a protocol")]
+    MissingProtocol,
+
+    #[error("Protocol {0}:// is not supported")]
+    UnsupportedProtocol(String),
+
     #[error("Payload could not be encoded")]
     EncodingError,
 

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -1,4 +1,4 @@
-// Copyright 2024 the Cartero authors
+// Copyright 2024-2025 the Cartero authors
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -39,7 +39,7 @@ mod imp {
     use crate::app::CarteroApplication;
     use crate::client::{BoundRequest, RequestError};
     use crate::entities::{EndpointData, KeyValue, RequestExportType};
-    use crate::error::CarteroError;
+    use crate::error::{CarteroError, RequestPreconditionError};
     use crate::objects::KeyValueItem;
     use crate::widgets::{
         ExportTab, ExportType, ItemPane, KeyValuePane, MethodDropdown, PayloadTab, ResponsePanel,
@@ -404,39 +404,35 @@ mod imp {
         /// Executes an HTTP request based on the current contents of the pane.
         pub(super) async fn perform_request(&self) -> Result<(), CarteroError> {
             let request = self.extract_endpoint()?;
-            let request = BoundRequest::try_from(request)?;
+            let request = BoundRequest::try_from(request);
 
-            // Protocol validation.
-            let request_url = match request.full_url() {
-                Ok(r) => r,
-                Err(url::ParseError::RelativeUrlWithoutBase) => {
-                    // The URL is not considered an absolute URL, missing protocol.
-                    let url_field = self.request_url.text().to_string();
-                    let url_field = format!("http://{}", url_field);
-                    self.request_url.set_text(&url_field);
+            // A special case before giving up: if the protocol is not specified, add it.
+            if let Err(RequestPreconditionError::MissingProtocol) = request {
+                // The URL is not considered an absolute URL, missing protocol.
+                let url_field = self.request_url.text().to_string();
+                let url_field = format!("http://{}", url_field);
+                self.request_url.set_text(&url_field);
 
-                    // Now try again.
-                    return std::boxed::Box::pin(self.perform_request()).await;
-                }
-                Err(_) => return Err(RequestError::InvalidUrl.into()),
-            };
-
-            // Validate protocol is supported.
-            let request_scheme = request_url.scheme();
-            if request_scheme != "http" && request_scheme != "https" {
-                return Err(CarteroError::InvalidProtocol);
+                // Now try again.
+                return std::boxed::Box::pin(self.perform_request()).await;
             }
 
-            // Execute the request.
-            let request_obj = isahc::Request::try_from(request)?;
-            let start = Instant::now();
-            let mut response_obj = request_obj
-                .send_async()
-                .await
-                .map_err(RequestError::NetworkError)?;
-            let response = crate::client::extract_isahc_response(&mut response_obj, &start).await?;
-            self.response.assign_from_response(&response);
-            Ok(())
+            match request {
+                Ok(request) => {
+                    // Execute the request.
+                    let request_obj = isahc::Request::try_from(request)?;
+                    let start = Instant::now();
+                    let mut response_obj = request_obj
+                        .send_async()
+                        .await
+                        .map_err(RequestError::NetworkError)?;
+                    let response =
+                        crate::client::extract_isahc_response(&mut response_obj, &start).await?;
+                    self.response.assign_from_response(&response);
+                    Ok(())
+                }
+                Err(e) => Err(CarteroError::from(e)),
+            }
         }
     }
 }


### PR DESCRIPTION
# Motivation

As part of [the deprecation of `CarteroError`](https://github.com/danirod/cartero/issues/139), this PR will introduce changes to slice enum values related to preconditions into its own error type. As a side effect, it introduces some refactors to the HTTP client in order to move the request payload processing to a separate type, and uses code better structured.

# Precondition errors

A **precondition error** happens when there is an error in the user interface that prevents a request from happening. It's not a request error because the request does not exist yet. It cannot be created due to some condition in the user input data. Examples of precondition errors:

* The user is trying to use an invalid scheme in the URL (for instance, trying to request ws:// or gopher:// instead of http:// or https://).
* The user has set a variable that is undefined or there is a syntax error with the interpolation (for instance, missing `}}` at the end of a field.

# Future work

This PR is part of https://github.com/danirod/cartero/issues/139.

I am very interested in setting up full screen error messages for this one, so https://github.com/danirod/cartero/pull/129 will be rebased on top of this once this PR merges.

---

This message is not written by an AI. It's important to exercise our brains.