### PR TITLE
Prepare serde structures for query params

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -11,6 +11,10 @@ use crate::entities::{
 };
 use crate::error::CarteroError;
 
+trait ToKeyValue {
+    fn to_key_value(&self, key: &str) -> KeyValue;
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 enum FieldValue {
@@ -22,7 +26,7 @@ enum FieldValue {
     },
 }
 
-impl FieldValue {
+impl ToKeyValue for FieldValue {
     fn to_key_value(&self, key: &str) -> KeyValue {
         match self {
             FieldValue::Simple(str) => KeyValue {
@@ -67,33 +71,44 @@ impl From<KeyValue> for FieldValue {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
-enum FieldContainer {
-    Unique(FieldValue),
-    Multiple(Vec<FieldValue>),
+enum FileContainer<T>
+where
+    T: From<KeyValue> + ToKeyValue,
+{
+    Unique(T),
+    Multiple(Vec<T>),
 }
 
-impl From<Vec<KeyValue>> for FieldContainer {
+impl<T> From<Vec<KeyValue>> for FileContainer<T>
+where
+    T: From<KeyValue> + ToKeyValue,
+{
     fn from(value: Vec<KeyValue>) -> Self {
         if value.len() == 1 {
             Self::Unique(value[0].clone().into())
         } else {
-            let multiple: Vec<FieldValue> = value.into_iter().map(FieldValue::from).collect();
+            let multiple: Vec<T> = value.into_iter().map(T::from).collect();
             Self::Multiple(multiple)
         }
     }
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
-pub struct FieldFileTable(HashMap<String, FieldContainer>);
+struct FileTable<T>(HashMap<String, FileContainer<T>>)
+where
+    T: From<KeyValue> + ToKeyValue;
 
-impl From<FieldFileTable> for KeyValueTable {
-    fn from(value: FieldFileTable) -> Self {
+impl<T> From<FileTable<T>> for KeyValueTable
+where
+    T: From<KeyValue> + ToKeyValue,
+{
+    fn from(value: FileTable<T>) -> Self {
         let mut vector: Vec<KeyValue> = value
             .0
             .into_iter()
             .flat_map(|(header, values)| match values {
-                FieldContainer::Unique(x) => vec![x.to_key_value(&header)],
-                FieldContainer::Multiple(mult) => {
+                FileContainer::Unique(x) => vec![x.to_key_value(&header)],
+                FileContainer::Multiple(mult) => {
                     mult.into_iter().map(|v| v.to_key_value(&header)).collect()
                 }
             })
@@ -103,7 +118,10 @@ impl From<FieldFileTable> for KeyValueTable {
     }
 }
 
-impl From<KeyValueTable> for FieldFileTable {
+impl<T> From<KeyValueTable> for FileTable<T>
+where
+    T: From<KeyValue> + ToKeyValue,
+{
     fn from(value: KeyValueTable) -> Self {
         let group = value.group_by();
         let inner = group
@@ -147,13 +165,17 @@ impl From<FilePayloadRawFormat> for RawEncoding {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type")]
-pub enum FilePayload {
+enum FilePayload {
     #[serde(rename = "none")]
     None,
     #[serde(rename = "urlencoded")]
-    UrlEncoded { variables: Option<FieldFileTable> },
+    UrlEncoded {
+        variables: Option<FileTable<FieldValue>>,
+    },
     #[serde(rename = "multipart")]
-    Multipart { variables: Option<FieldFileTable> },
+    Multipart {
+        variables: Option<FileTable<FieldValue>>,
+    },
     #[serde(rename = "raw")]
     Raw {
         format: Option<FilePayloadRawFormat>,
@@ -163,7 +185,7 @@ pub enum FilePayload {
 
 #[derive(Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum FileBody {
+enum FileBody {
     Raw(String),
     Structured(FilePayload),
 }
@@ -228,8 +250,8 @@ struct RequestFile {
     url: String,
     method: String,
     body: Option<FileBody>,
-    headers: Option<FieldFileTable>,
-    variables: Option<FieldFileTable>,
+    headers: Option<FileTable<FieldValue>>,
+    variables: Option<FileTable<FieldValue>>,
 }
 
 impl TryFrom<RequestFile> for EndpointData {
@@ -324,21 +346,21 @@ mod tests {
         EndpointData, KeyValue, KeyValueTable, RawEncoding, RequestMethod, RequestPayload,
     };
 
-    use super::{FieldContainer, FieldFileTable};
+    use super::{FileContainer, FileTable};
 
     #[test]
     pub fn test_key_valued_file_table_to_key_value_table_sorts_simple() {
         let map = HashMap::from([
             (
                 "User-Agent".into(),
-                FieldContainer::Unique(super::FieldValue::Simple("Cartero/0.1".into())),
+                FileContainer::Unique(super::FieldValue::Simple("Cartero/0.1".into())),
             ),
             (
                 "Host".into(),
-                FieldContainer::Unique(super::FieldValue::Simple("www.google.com".into())),
+                FileContainer::Unique(super::FieldValue::Simple("www.google.com".into())),
             ),
         ]);
-        let file = FieldFileTable(map);
+        let file = FileTable(map);
 
         let table = KeyValueTable::from(file);
 
@@ -357,7 +379,7 @@ mod tests {
         let map = HashMap::from([
             (
                 "User-Agent".into(),
-                FieldContainer::Unique(super::FieldValue::Complex {
+                FileContainer::Unique(super::FieldValue::Complex {
                     value: "Cartero/0.1".into(),
                     active: false,
                     secret: true,
@@ -365,10 +387,10 @@ mod tests {
             ),
             (
                 "Host".into(),
-                FieldContainer::Unique(super::FieldValue::Simple("www.google.com".into())),
+                FileContainer::Unique(super::FieldValue::Simple("www.google.com".into())),
             ),
         ]);
-        let file = FieldFileTable(map);
+        let file = FileTable(map);
 
         let table = KeyValueTable::from(file);
 
@@ -392,11 +414,11 @@ mod tests {
         let map = HashMap::from([
             (
                 "User-Agent".into(),
-                FieldContainer::Unique(super::FieldValue::Simple("Cartero/0.1".into())),
+                FileContainer::Unique(super::FieldValue::Simple("Cartero/0.1".into())),
             ),
             (
                 "Accept".into(),
-                FieldContainer::Multiple(vec![
+                FileContainer::Multiple(vec![
                     super::FieldValue::Simple("*/*".into()),
                     super::FieldValue::Simple("application/json".into()),
                     super::FieldValue::Simple("application/ld+json".into()),
@@ -404,10 +426,10 @@ mod tests {
             ),
             (
                 "Host".into(),
-                FieldContainer::Unique(super::FieldValue::Simple("www.google.com".into())),
+                FileContainer::Unique(super::FieldValue::Simple("www.google.com".into())),
             ),
         ]);
-        let file = FieldFileTable(map);
+        let file = FileTable(map);
 
         let table = KeyValueTable::from(file);
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -11,28 +11,58 @@ use crate::entities::{
 };
 use crate::error::CarteroError;
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-struct FieldDetail {
-    value: String,
-    active: bool,
-    secret: bool,
-}
-
-impl Default for FieldDetail {
-    fn default() -> Self {
-        Self {
-            value: String::default(),
-            active: true,
-            secret: false,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
 enum FieldValue {
     Simple(String),
-    Complex(FieldDetail),
+    Complex {
+        value: String,
+        active: bool,
+        secret: bool,
+    },
+}
+
+impl FieldValue {
+    fn to_key_value(&self, key: &str) -> KeyValue {
+        match self {
+            FieldValue::Simple(str) => KeyValue {
+                name: key.to_owned(),
+                value: str.clone(),
+                active: true,
+                secret: false,
+            },
+            FieldValue::Complex {
+                value,
+                active,
+                secret,
+            } => KeyValue {
+                name: key.to_owned(),
+                value: value.clone(),
+                active: *active,
+                secret: *secret,
+            },
+        }
+    }
+}
+
+impl Default for FieldValue {
+    fn default() -> Self {
+        Self::Simple(String::default())
+    }
+}
+
+impl From<KeyValue> for FieldValue {
+    fn from(value: KeyValue) -> Self {
+        if value.active && !value.secret {
+            Self::Simple(value.value)
+        } else {
+            Self::Complex {
+                active: value.active,
+                secret: value.secret,
+                value: value.value,
+            }
+        }
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -42,61 +72,15 @@ enum FieldContainer {
     Multiple(Vec<FieldValue>),
 }
 
-impl Default for FieldValue {
-    fn default() -> Self {
-        Self::Simple(String::default())
-    }
-}
-
-impl From<FieldValue> for KeyValue {
-    fn from(value: FieldValue) -> KeyValue {
-        match value {
-            FieldValue::Simple(str) => KeyValue {
-                name: String::default(),
-                value: str.clone(),
-                active: true,
-                secret: false,
-            },
-            FieldValue::Complex(kd) => KeyValue {
-                name: String::default(),
-                value: kd.value.clone(),
-                active: kd.active,
-                secret: kd.secret,
-            },
-        }
-    }
-}
-
-impl From<KeyValue> for FieldValue {
-    fn from(value: KeyValue) -> Self {
-        let def = FieldDetail::default();
-        if value.active == def.active && value.secret == def.secret {
-            Self::Simple(value.value)
-        } else {
-            Self::Complex(FieldDetail {
-                active: value.active,
-                secret: value.secret,
-                value: value.value,
-            })
-        }
-    }
-}
-
 impl From<Vec<KeyValue>> for FieldContainer {
     fn from(value: Vec<KeyValue>) -> Self {
         if value.len() == 1 {
-            FieldContainer::Unique(value[0].clone().into())
+            Self::Unique(value[0].clone().into())
         } else {
             let multiple: Vec<FieldValue> = value.into_iter().map(FieldValue::from).collect();
-            FieldContainer::Multiple(multiple)
+            Self::Multiple(multiple)
         }
     }
-}
-
-fn extract_kv_entry(value: FieldValue, key: &str) -> KeyValue {
-    let mut value = KeyValue::from(value);
-    value.name = key.into();
-    value
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
@@ -108,11 +92,10 @@ impl From<FieldFileTable> for KeyValueTable {
             .0
             .into_iter()
             .flat_map(|(header, values)| match values {
-                FieldContainer::Unique(x) => vec![extract_kv_entry(x, &header)],
-                FieldContainer::Multiple(mult) => mult
-                    .into_iter()
-                    .map(|v| extract_kv_entry(v, &header))
-                    .collect(),
+                FieldContainer::Unique(x) => vec![x.to_key_value(&header)],
+                FieldContainer::Multiple(mult) => {
+                    mult.into_iter().map(|v| v.to_key_value(&header)).collect()
+                }
             })
             .collect();
         vector.sort();
@@ -337,11 +320,8 @@ pub async fn write_file(file: &gio::File, contents: &str) -> Result<(), CarteroE
 mod tests {
     use std::collections::HashMap;
 
-    use crate::{
-        entities::{
-            EndpointData, KeyValue, KeyValueTable, RawEncoding, RequestMethod, RequestPayload,
-        },
-        file::FieldDetail,
+    use crate::entities::{
+        EndpointData, KeyValue, KeyValueTable, RawEncoding, RequestMethod, RequestPayload,
     };
 
     use super::{FieldContainer, FieldFileTable};
@@ -377,11 +357,11 @@ mod tests {
         let map = HashMap::from([
             (
                 "User-Agent".into(),
-                FieldContainer::Unique(super::FieldValue::Complex(FieldDetail {
+                FieldContainer::Unique(super::FieldValue::Complex {
                     value: "Cartero/0.1".into(),
                     active: false,
                     secret: true,
-                })),
+                }),
             ),
             (
                 "Host".into(),

--- a/src/file.rs
+++ b/src/file.rs
@@ -12,13 +12,13 @@ use crate::entities::{
 use crate::error::CarteroError;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct KeyValueDetail {
+struct FieldDetail {
     value: String,
     active: bool,
     secret: bool,
 }
 
-impl Default for KeyValueDetail {
+impl Default for FieldDetail {
     fn default() -> Self {
         Self {
             value: String::default(),
@@ -30,34 +30,34 @@ impl Default for KeyValueDetail {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
-enum KeyValuedValue {
+enum FieldValue {
     Simple(String),
-    Complex(KeyValueDetail),
+    Complex(FieldDetail),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
-enum KeyValuedValueContainer {
-    Unique(KeyValuedValue),
-    Multiple(Vec<KeyValuedValue>),
+enum FieldContainer {
+    Unique(FieldValue),
+    Multiple(Vec<FieldValue>),
 }
 
-impl Default for KeyValuedValue {
+impl Default for FieldValue {
     fn default() -> Self {
         Self::Simple(String::default())
     }
 }
 
-impl From<KeyValuedValue> for KeyValue {
-    fn from(value: KeyValuedValue) -> KeyValue {
+impl From<FieldValue> for KeyValue {
+    fn from(value: FieldValue) -> KeyValue {
         match value {
-            KeyValuedValue::Simple(str) => KeyValue {
+            FieldValue::Simple(str) => KeyValue {
                 name: String::default(),
                 value: str.clone(),
                 active: true,
                 secret: false,
             },
-            KeyValuedValue::Complex(kd) => KeyValue {
+            FieldValue::Complex(kd) => KeyValue {
                 name: String::default(),
                 value: kd.value.clone(),
                 active: kd.active,
@@ -67,13 +67,13 @@ impl From<KeyValuedValue> for KeyValue {
     }
 }
 
-impl From<KeyValue> for KeyValuedValue {
+impl From<KeyValue> for FieldValue {
     fn from(value: KeyValue) -> Self {
-        let def = KeyValueDetail::default();
+        let def = FieldDetail::default();
         if value.active == def.active && value.secret == def.secret {
             Self::Simple(value.value)
         } else {
-            Self::Complex(KeyValueDetail {
+            Self::Complex(FieldDetail {
                 active: value.active,
                 secret: value.secret,
                 value: value.value,
@@ -82,35 +82,34 @@ impl From<KeyValue> for KeyValuedValue {
     }
 }
 
-impl From<Vec<KeyValue>> for KeyValuedValueContainer {
+impl From<Vec<KeyValue>> for FieldContainer {
     fn from(value: Vec<KeyValue>) -> Self {
         if value.len() == 1 {
-            KeyValuedValueContainer::Unique(value[0].clone().into())
+            FieldContainer::Unique(value[0].clone().into())
         } else {
-            let multiple: Vec<KeyValuedValue> =
-                value.into_iter().map(KeyValuedValue::from).collect();
-            KeyValuedValueContainer::Multiple(multiple)
+            let multiple: Vec<FieldValue> = value.into_iter().map(FieldValue::from).collect();
+            FieldContainer::Multiple(multiple)
         }
     }
 }
 
-fn extract_kv_entry(value: KeyValuedValue, key: &str) -> KeyValue {
+fn extract_kv_entry(value: FieldValue, key: &str) -> KeyValue {
     let mut value = KeyValue::from(value);
     value.name = key.into();
     value
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, Default)]
-pub struct KeyValuedFileTable(HashMap<String, KeyValuedValueContainer>);
+pub struct FieldFileTable(HashMap<String, FieldContainer>);
 
-impl From<KeyValuedFileTable> for KeyValueTable {
-    fn from(value: KeyValuedFileTable) -> Self {
+impl From<FieldFileTable> for KeyValueTable {
+    fn from(value: FieldFileTable) -> Self {
         let mut vector: Vec<KeyValue> = value
             .0
             .into_iter()
             .flat_map(|(header, values)| match values {
-                KeyValuedValueContainer::Unique(x) => vec![extract_kv_entry(x, &header)],
-                KeyValuedValueContainer::Multiple(mult) => mult
+                FieldContainer::Unique(x) => vec![extract_kv_entry(x, &header)],
+                FieldContainer::Multiple(mult) => mult
                     .into_iter()
                     .map(|v| extract_kv_entry(v, &header))
                     .collect(),
@@ -121,7 +120,7 @@ impl From<KeyValuedFileTable> for KeyValueTable {
     }
 }
 
-impl From<KeyValueTable> for KeyValuedFileTable {
+impl From<KeyValueTable> for FieldFileTable {
     fn from(value: KeyValueTable) -> Self {
         let group = value.group_by();
         let inner = group
@@ -169,13 +168,9 @@ pub enum FilePayload {
     #[serde(rename = "none")]
     None,
     #[serde(rename = "urlencoded")]
-    UrlEncoded {
-        variables: Option<KeyValuedFileTable>,
-    },
+    UrlEncoded { variables: Option<FieldFileTable> },
     #[serde(rename = "multipart")]
-    Multipart {
-        variables: Option<KeyValuedFileTable>,
-    },
+    Multipart { variables: Option<FieldFileTable> },
     #[serde(rename = "raw")]
     Raw {
         format: Option<FilePayloadRawFormat>,
@@ -185,8 +180,8 @@ pub enum FilePayload {
 
 #[derive(Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum Body {
-    ClassicRaw(String),
+pub enum FileBody {
+    Raw(String),
     Structured(FilePayload),
 }
 
@@ -226,20 +221,20 @@ impl From<FilePayload> for RequestPayload {
     }
 }
 
-impl From<RequestPayload> for Body {
+impl From<RequestPayload> for FileBody {
     fn from(value: RequestPayload) -> Self {
         Self::Structured(value.into())
     }
 }
 
-impl From<Body> for RequestPayload {
-    fn from(value: Body) -> Self {
+impl From<FileBody> for RequestPayload {
+    fn from(value: FileBody) -> Self {
         match value {
-            Body::ClassicRaw(payload) => Self::Raw {
+            FileBody::Raw(payload) => Self::Raw {
                 encoding: RawEncoding::OctetStream,
                 content: Vec::from(payload.clone().as_str()),
             },
-            Body::Structured(payload) => payload.into(),
+            FileBody::Structured(payload) => payload.into(),
         }
     }
 }
@@ -249,9 +244,9 @@ struct RequestFile {
     version: usize,
     url: String,
     method: String,
-    body: Option<Body>,
-    headers: Option<KeyValuedFileTable>,
-    variables: Option<KeyValuedFileTable>,
+    body: Option<FileBody>,
+    headers: Option<FieldFileTable>,
+    variables: Option<FieldFileTable>,
 }
 
 impl TryFrom<RequestFile> for EndpointData {
@@ -346,28 +341,24 @@ mod tests {
         entities::{
             EndpointData, KeyValue, KeyValueTable, RawEncoding, RequestMethod, RequestPayload,
         },
-        file::KeyValueDetail,
+        file::FieldDetail,
     };
 
-    use super::{KeyValuedFileTable, KeyValuedValueContainer};
+    use super::{FieldContainer, FieldFileTable};
 
     #[test]
     pub fn test_key_valued_file_table_to_key_value_table_sorts_simple() {
         let map = HashMap::from([
             (
                 "User-Agent".into(),
-                KeyValuedValueContainer::Unique(super::KeyValuedValue::Simple(
-                    "Cartero/0.1".into(),
-                )),
+                FieldContainer::Unique(super::FieldValue::Simple("Cartero/0.1".into())),
             ),
             (
                 "Host".into(),
-                KeyValuedValueContainer::Unique(super::KeyValuedValue::Simple(
-                    "www.google.com".into(),
-                )),
+                FieldContainer::Unique(super::FieldValue::Simple("www.google.com".into())),
             ),
         ]);
-        let file = KeyValuedFileTable(map);
+        let file = FieldFileTable(map);
 
         let table = KeyValueTable::from(file);
 
@@ -386,7 +377,7 @@ mod tests {
         let map = HashMap::from([
             (
                 "User-Agent".into(),
-                KeyValuedValueContainer::Unique(super::KeyValuedValue::Complex(KeyValueDetail {
+                FieldContainer::Unique(super::FieldValue::Complex(FieldDetail {
                     value: "Cartero/0.1".into(),
                     active: false,
                     secret: true,
@@ -394,12 +385,10 @@ mod tests {
             ),
             (
                 "Host".into(),
-                KeyValuedValueContainer::Unique(super::KeyValuedValue::Simple(
-                    "www.google.com".into(),
-                )),
+                FieldContainer::Unique(super::FieldValue::Simple("www.google.com".into())),
             ),
         ]);
-        let file = KeyValuedFileTable(map);
+        let file = FieldFileTable(map);
 
         let table = KeyValueTable::from(file);
 
@@ -423,26 +412,22 @@ mod tests {
         let map = HashMap::from([
             (
                 "User-Agent".into(),
-                KeyValuedValueContainer::Unique(super::KeyValuedValue::Simple(
-                    "Cartero/0.1".into(),
-                )),
+                FieldContainer::Unique(super::FieldValue::Simple("Cartero/0.1".into())),
             ),
             (
                 "Accept".into(),
-                KeyValuedValueContainer::Multiple(vec![
-                    super::KeyValuedValue::Simple("*/*".into()),
-                    super::KeyValuedValue::Simple("application/json".into()),
-                    super::KeyValuedValue::Simple("application/ld+json".into()),
+                FieldContainer::Multiple(vec![
+                    super::FieldValue::Simple("*/*".into()),
+                    super::FieldValue::Simple("application/json".into()),
+                    super::FieldValue::Simple("application/ld+json".into()),
                 ]),
             ),
             (
                 "Host".into(),
-                KeyValuedValueContainer::Unique(super::KeyValuedValue::Simple(
-                    "www.google.com".into(),
-                )),
+                FieldContainer::Unique(super::FieldValue::Simple("www.google.com".into())),
             ),
         ]);
-        let file = KeyValuedFileTable(map);
+        let file = FieldFileTable(map);
 
         let table = KeyValueTable::from(file);
 


### PR DESCRIPTION
# Motivation

As part of a fix for issue #50, I need to prepare the serialized structures used to persist endpoints so that they accept a new data structure for "inactive query parameters". This PR collects a bunch of refactors that modify `src/file.rs` to make this happen.

# Refactors made

* First, I've renamed the `KeyValue*` prefix to `Field`, to differenciate entries related to fields like HTTP headers or variables to entries related to inactive query params. The main difference is that query params do not need to persist the `active` bool, because it's always set to false (otherwise, it would be part of the URL).

* Some data structures have been squashed if they can be inlined to a parent data structure. Also, a trait has been created to organize the mapping functions to convert between KeyValue and file structures if they need more parameters.

* But the most important change is that containers and files now use generic types, to make easier in the future to just a new kind of complex value and avoid repeating a lot of code.

# Final notes

The data structure implementation of inactive query params is still not closed. I am still evaluating how to treat query params and inactive query params:

1. Active query params always in the "URL" field, only store inactive query params.
2. Active query params in the URL, but every query param is always in a query param table.

Solution 2 is more simple but requires more care with the synchronization so that both elements are always in sync. Also, what if the persisted file is corrupted and the query params in the URL field are different than what the table says.