### PR TITLE
Stop losing inactive query params on save

### DIFF
--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -147,6 +147,7 @@ mod tests {
             headers,
             variables,
             body,
+            parameters: KeyValueTable::default(),
         };
 
         // Bind the request.
@@ -177,6 +178,7 @@ mod tests {
             headers,
             variables,
             body,
+            parameters: KeyValueTable::default(),
         };
 
         let bound = BoundRequest::try_from(endpoint).unwrap();
@@ -199,6 +201,7 @@ mod tests {
             headers,
             variables,
             body,
+            parameters: KeyValueTable::default(),
         };
 
         let bound = BoundRequest::try_from(endpoint).unwrap();
@@ -229,6 +232,7 @@ mod tests {
             headers,
             variables,
             body,
+            parameters: KeyValueTable::default(),
         };
 
         // Bind the request.
@@ -246,6 +250,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
             body: RequestPayload::None,
+            parameters: KeyValueTable::default(),
         };
         let result = BoundRequest::try_from(endpoint);
         assert!(result.is_err_and(|e| e == RequestPreconditionError::MissingProtocol));
@@ -262,6 +267,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
             body: RequestPayload::None,
+            parameters: KeyValueTable::default(),
         };
         let result = BoundRequest::try_from(endpoint);
         assert!(result.is_err_and(
@@ -280,6 +286,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
             body: RequestPayload::None,
+            parameters: KeyValueTable::default(),
         };
         let result = BoundRequest::try_from(endpoint).unwrap();
         assert_eq!(result.url, "https://example.com/api/v1/users");
@@ -296,6 +303,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
             body: RequestPayload::None,
+            parameters: KeyValueTable::default(),
         };
         let result = BoundRequest::try_from(endpoint).unwrap();
         assert_eq!(result.url, "https://example.com/api/v1/users");
@@ -312,6 +320,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
             body: RequestPayload::None,
+            parameters: KeyValueTable::default(),
         };
         let result = BoundRequest::try_from(endpoint).unwrap();
         assert_eq!(result.url, "https://example.com/api/v1/users");

--- a/src/client/request_bodies.rs
+++ b/src/client/request_bodies.rs
@@ -154,6 +154,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::new(&variables),
             body: RequestPayload::Urlencoded(KeyValueTable::new(&body)),
+            parameters: KeyValueTable::default(),
         };
 
         let serial = BoundRequestBody::try_from(&endpoint).unwrap();
@@ -183,6 +184,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
             body: RequestPayload::Urlencoded(KeyValueTable::new(&body)),
+            parameters: KeyValueTable::default(),
         };
         let result = BoundRequestBody::try_from(&endpoint);
         assert_eq!(
@@ -208,6 +210,7 @@ mod tests {
             body: RequestPayload::Multipart {
                 params: KeyValueTable::new(&body),
             },
+            parameters: KeyValueTable::default(),
         };
 
         let serial = BoundRequestBody::try_from(&endpoint).unwrap();
@@ -253,6 +256,7 @@ mod tests {
             body: RequestPayload::Multipart {
                 params: KeyValueTable::new(&body),
             },
+            parameters: KeyValueTable::default(),
         };
 
         let result = BoundRequestBody::try_from(&endpoint);
@@ -277,6 +281,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::new(&variables),
             body,
+            parameters: KeyValueTable::default(),
         };
 
         let result = BoundRequestBody::try_from(&endpoint).unwrap();
@@ -298,6 +303,7 @@ mod tests {
             method: crate::entities::RequestMethod::Post,
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
+            parameters: KeyValueTable::default(),
             body,
         };
 
@@ -320,6 +326,7 @@ mod tests {
             method: crate::entities::RequestMethod::Post,
             headers: KeyValueTable::default(),
             variables: KeyValueTable::new(&variables),
+            parameters: KeyValueTable::default(),
             body,
         };
 
@@ -345,6 +352,7 @@ mod tests {
             method: crate::entities::RequestMethod::Post,
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
+            parameters: KeyValueTable::default(),
             body,
         };
 
@@ -367,6 +375,7 @@ mod tests {
             method: crate::entities::RequestMethod::Post,
             headers: KeyValueTable::default(),
             variables: KeyValueTable::new(&variables),
+            parameters: KeyValueTable::default(),
             body,
         };
 
@@ -392,6 +401,7 @@ mod tests {
             method: crate::entities::RequestMethod::Post,
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
+            parameters: KeyValueTable::default(),
             body,
         };
 

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -258,6 +258,7 @@ pub enum RequestExportType {
 pub struct EndpointData {
     pub url: String,
     pub method: RequestMethod,
+    pub parameters: KeyValueTable,
     pub headers: KeyValueTable,
     pub variables: KeyValueTable,
     pub body: RequestPayload,

--- a/src/file.rs
+++ b/src/file.rs
@@ -796,6 +796,7 @@ Accept = 'text/html'
             headers,
             variables: KeyValueTable::default(),
             body,
+            parameters: KeyValueTable::default(),
         };
 
         let content = super::store_toml(&r).unwrap();
@@ -826,6 +827,7 @@ Accept = 'text/html'
             headers,
             variables: KeyValueTable::default(),
             body,
+            parameters: KeyValueTable::default(),
         };
 
         let content = super::store_toml(&r).unwrap();
@@ -874,6 +876,7 @@ body = 'hello'
             headers,
             variables: KeyValueTable::default(),
             body,
+            parameters: KeyValueTable::default(),
         };
 
         let content = super::store_toml(&r).unwrap();
@@ -931,6 +934,7 @@ body = 'hello'
             headers,
             variables,
             body,
+            parameters: KeyValueTable::default(),
         };
 
         let content = super::store_toml(&r).unwrap();

--- a/src/file.rs
+++ b/src/file.rs
@@ -71,6 +71,51 @@ impl From<KeyValue> for FieldValue {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(untagged)]
+enum QueryValue {
+    Simple(String),
+    Complex { value: String, secret: bool },
+}
+
+impl ToKeyValue for QueryValue {
+    fn to_key_value(&self, key: &str) -> KeyValue {
+        match self {
+            QueryValue::Simple(str) => KeyValue {
+                name: key.to_owned(),
+                value: str.clone(),
+                active: false,
+                secret: false,
+            },
+            QueryValue::Complex { value, secret } => KeyValue {
+                name: key.to_owned(),
+                value: value.clone(),
+                active: false,
+                secret: *secret,
+            },
+        }
+    }
+}
+
+impl Default for QueryValue {
+    fn default() -> Self {
+        Self::Simple(String::default())
+    }
+}
+
+impl From<KeyValue> for QueryValue {
+    fn from(value: KeyValue) -> Self {
+        if !value.secret {
+            Self::Simple(value.value)
+        } else {
+            Self::Complex {
+                secret: value.secret,
+                value: value.value,
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
 enum FileContainer<T>
 where
     T: From<KeyValue> + ToKeyValue,
@@ -252,6 +297,8 @@ struct RequestFile {
     body: Option<FileBody>,
     headers: Option<FileTable<FieldValue>>,
     variables: Option<FileTable<FieldValue>>,
+    #[serde(rename = "inactive-params")]
+    inactive_params: Option<FileTable<QueryValue>>,
 }
 
 impl TryFrom<RequestFile> for EndpointData {
@@ -267,6 +314,7 @@ impl TryFrom<RequestFile> for EndpointData {
         let body = value.body.map(RequestPayload::from).unwrap_or_default();
         let headers = value.headers.unwrap_or_default().into();
         let variables = value.variables.unwrap_or_default().into();
+        let inactive_params = value.inactive_params.unwrap_or_default().into();
 
         let request = EndpointData {
             url: value.url.clone(),
@@ -274,6 +322,7 @@ impl TryFrom<RequestFile> for EndpointData {
             body,
             variables,
             headers,
+            parameters: inactive_params,
         };
         Ok(request)
     }
@@ -288,6 +337,17 @@ impl From<EndpointData> for RequestFile {
         };
         let headers = value.headers.into();
         let variables = value.variables.into();
+
+        let parameters = {
+            let mut entries = Vec::new();
+            for param in value.parameters.iter() {
+                if !param.active {
+                    entries.push(param.clone());
+                }
+            }
+            KeyValueTable::new(&entries)
+        };
+
         RequestFile {
             version: 1,
             url: value.url.clone(),
@@ -295,6 +355,7 @@ impl From<EndpointData> for RequestFile {
             body,
             headers: Some(headers),
             variables: Some(variables),
+            inactive_params: Some(parameters.into()),
         }
     }
 }

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -38,7 +38,7 @@ mod imp {
 
     use crate::app::CarteroApplication;
     use crate::client::{BoundRequest, RequestError};
-    use crate::entities::{EndpointData, KeyValue, KeyValueTable, RequestExportType};
+    use crate::entities::{EndpointData, KeyValue, RequestExportType};
     use crate::error::{CarteroError, RequestPreconditionError};
     use crate::objects::KeyValueItem;
     use crate::widgets::{

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -38,7 +38,7 @@ mod imp {
 
     use crate::app::CarteroApplication;
     use crate::client::{BoundRequest, RequestError};
-    use crate::entities::{EndpointData, KeyValue, RequestExportType};
+    use crate::entities::{EndpointData, KeyValue, KeyValueTable, RequestExportType};
     use crate::error::{CarteroError, RequestPreconditionError};
     use crate::objects::KeyValueItem;
     use crate::widgets::{
@@ -369,12 +369,24 @@ mod imp {
             self.variable_pane.set_entries(&variables);
             self.payload_pane.set_payload(&endpoint.body);
             self.export_pane_load_endpoint_data(endpoint);
+
+            // Merge parameters
+            let active_params: Vec<KeyValueItem> = self.parameter_pane.get_entries();
+            let parameters = {
+                let mut params = active_params.clone();
+                for param in endpoint.parameters.clone().iter() {
+                    params.push(KeyValueItem::from(param.clone()));
+                }
+                params
+            };
+            self.parameter_pane.set_entries(&parameters);
         }
 
         /// Takes the current state of the pane and extracts it into an Endpoint value.
         pub(super) fn extract_endpoint(&self) -> Result<EndpointData, CarteroError> {
             let header_list = self.header_pane.get_entries();
             let variable_list = self.variable_pane.get_entries();
+            let parameter_list = self.parameter_pane.get_entries();
 
             let url = String::from(self.request_url.buffer().text());
             let method = self.request_method.request_method();
@@ -397,11 +409,20 @@ mod imp {
                     secret: pair.secret(),
                 })
                 .collect();
-
+            let parameters = parameter_list
+                .iter()
+                .map(|pair| KeyValue {
+                    name: pair.header_name(),
+                    value: pair.header_value(),
+                    active: pair.active(),
+                    secret: pair.secret(),
+                })
+                .collect();
             let body = self.payload_pane.payload();
             Ok(EndpointData {
                 url,
                 method,
+                parameters,
                 headers,
                 variables,
                 body,

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -190,9 +190,8 @@ mod imp {
         fn update_query_params(&self) -> Result<(), url::ParseError> {
             let parsed_url = self.request_url.text().to_string();
             let url = Url::parse(&parsed_url)?;
-            let pairs = url.query_pairs();
-
-            let entries: Vec<KeyValueItem> = pairs
+            let new_query_pairs = url.query_pairs();
+            let mut new_query_entries: Vec<KeyValueItem> = new_query_pairs
                 .map(|(key, value)| {
                     let key = String::from(key);
                     let value = String::from(value);
@@ -203,7 +202,15 @@ mod imp {
                     value
                 })
                 .collect();
-            self.parameter_pane.set_entries(&entries);
+
+            let old_entries = self.parameter_pane.get_entries();
+            let old_entries: Vec<KeyValueItem> = old_entries
+                .into_iter()
+                .filter(|entry| !entry.active())
+                .collect();
+            new_query_entries.extend(old_entries);
+
+            self.parameter_pane.set_entries(&new_query_entries);
             Ok(())
         }
 


### PR DESCRIPTION
# Motivation

As reported in #50, if you disable a query parameter and save, close or reload anyhow the request, the disabled query parameters are lost, because they don't actually exist, it's just a UI artifact.

This PR will change that by making sure that when a request is saved, the query parameters that are marked as disabled in the table are saved into the file, and restored if a file with inactive query params are loaded.

At the same time, it also fixes an interesting bug where if you disable a few parameters in the UI and then update the URL, those query params are also lost.