### PR TITLE
Make UI fonts larger on macOS

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -18,3 +18,27 @@
   background: var(--headerbar-bg-color);
   border-bottom-left-radius: 10px;
 }
+
+window.macos, dialog.macos {
+  letter-spacing: 0.5px;
+  -gtk-dpi: 86;
+}
+
+dialog.macos {
+  font-size: 14px;
+}
+
+window.macos listview, window.macos popover {
+  letter-spacing: 0;
+  -gtk-dpi: 80;
+}
+
+window.macos .title-2, dialog.macos .title-2 {
+  letter-spacing: 1.5px;
+  font-weight: 700;
+}
+
+window.macos statuspage .title {
+  letter-spacing: 1.5px;
+  font-weight: 700;
+}

--- a/src/widgets/dialogs.rs
+++ b/src/widgets/dialogs.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 use adw::{
-    prelude::{AlertDialogExt, AlertDialogExtManual},
+    prelude::{AlertDialogExt, AlertDialogExtManual, WidgetExt},
     AlertDialog,
 };
 use gettextrs::gettext;
@@ -57,6 +57,9 @@ pub async fn file_load_error_dialog(
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
+    if cfg!(target_os = "macos") {
+        alert.add_css_class("macos");
+    }
     alert.choose_future(root).await;
 }
 
@@ -88,6 +91,9 @@ pub async fn file_load_warning_dialog(
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
+    if cfg!(target_os = "macos") {
+        alert.add_css_class("macos");
+    }
     alert.choose_future(root).await;
 }
 
@@ -111,6 +117,9 @@ pub async fn file_save_error(
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
+    if cfg!(target_os = "macos") {
+        alert.add_css_class("macos");
+    }
     alert.choose_future(root).await;
 }
 
@@ -124,6 +133,9 @@ pub async fn glib_file_dialog_error(root: &impl IsA<gtk::Widget>, error: &glib::
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
+    if cfg!(target_os = "macos") {
+        alert.add_css_class("macos");
+    }
     alert.choose_future(root).await;
 }
 
@@ -143,6 +155,9 @@ pub async fn confirm_close_window(root: &impl IsA<gtk::Widget>) -> bool {
     ]);
     question.set_response_appearance("continue", adw::ResponseAppearance::Destructive);
     question.set_default_response(Some("cancel"));
+    if cfg!(target_os = "macos") {
+        question.add_css_class("macos");
+    }
     let response = question.choose_future(root).await;
     response == "continue"
 }
@@ -178,6 +193,9 @@ pub async fn confirm_save(
     ]);
     question.set_response_appearance("save", adw::ResponseAppearance::Suggested);
     question.set_response_appearance("discard", adw::ResponseAppearance::Destructive);
+    if cfg!(target_os = "macos") {
+        question.add_css_class("macos");
+    }
     let response = question.choose_future(root).await;
     match response.as_str() {
         "discard" => SaveAlertDialogResponse::Discard,

--- a/src/win.rs
+++ b/src/win.rs
@@ -26,6 +26,7 @@ use indexmap::IndexMap;
 mod imp {
     use std::collections::HashSet;
 
+    use adw::prelude::WidgetExt;
     use adw::AboutWindow;
     use adw::{subclass::prelude::*, TabPage};
     use gettextrs::gettext;
@@ -553,6 +554,10 @@ mod imp {
                 let obj = self.obj();
                 obj.add_css_class("devel");
             }
+            if cfg!(target_os = "macos") {
+                let obj = self.obj();
+                obj.add_css_class("macos");
+            }
 
             self.init_settings();
 
@@ -690,6 +695,9 @@ mod imp {
                             .copyright(gettext("© 2024 the Cartero authors"))
                             .license_type(gtk::License::Gpl30)
                             .build();
+                        if cfg!(target_os = "macos") {
+                            about.add_css_class("macos");
+                        }
                         about.present();
                     }
                 ))

--- a/src/windows/settings.rs
+++ b/src/windows/settings.rs
@@ -20,6 +20,7 @@ use glib::{object::IsA, Object};
 use gtk::gio;
 
 mod imp {
+    use adw::prelude::WidgetExt;
     use adw::subclass::prelude::*;
     use glib::{object::ObjectExt, subclass::InitializingObject};
     use gtk::{
@@ -77,6 +78,11 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
             self.init_settings();
+
+            if cfg!(target_os = "macos") {
+                let obj = self.obj();
+                obj.add_css_class("macos");
+            }
         }
     }
 


### PR DESCRIPTION
# Motivation

Font size is too small when running on macOS and I'm tired of pretending that this is normal (as much as my eyes are tired of using the application all day on macOS). This seems to be the case with GTK applications when running on macOS.

I haven't been able to find any references to this bug in the GNOME GitLab instance. However, searching for anything in GitLab sucks, so who knows if it's already reported. If someone from GTK or GNOME reads this, please consider using your powers to doing something (about the default font size, not about GitLab).

# UI changes

Here is a screenshot showing the before and after of my change.

![A comparison between how it used to look and how it looks](https://github.com/user-attachments/assets/739a8017-ccdc-476c-b732-0eb08ff5a8d2)

This is done by adding some hacks into style.css and custom CSS classes that are injected in code. I'm sure that this is going to break at some point if I add a widget and don't test it. However, it seems that for every widget currently being presented, it works.