### PR TITLE
Disable sccache due to build times

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -27,12 +27,7 @@ jobs:
   check:
     name: Check
     runs-on: ubuntu-24.04
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
     steps:
-      - name: sccache
-        uses: mozilla-actions/sccache-action@v0.0.7
       - name: dependencies
         run: sudo apt update && sudo apt install -y --no-install-recommends gettext meson libgtk-4-dev libadwaita-1-dev libgtksourceview-5-dev desktop-file-utils xvfb
       - name: clone


### PR DESCRIPTION
## Motivation

Is it my imagination or sccache makes the CI time bump a lot?

It's not.

![A screenshot comparing the build times both with sccache enabled and sccache disabled, it's almost 5 minutes when it's off, it's almost 15 minutes when it's on](https://github.com/user-attachments/assets/ada6c97d-c3c3-459b-afb7-f2fcc1eed6ff)
