### PR TITLE
Allow to cancel requests

### DIFF
--- a/data/ui/endpoint_pane.blp
+++ b/data/ui/endpoint_pane.blp
@@ -63,6 +63,16 @@ template $CarteroEndpointPane: Adw.BreakpointBin {
           activate => $on_url_activated() swapped;
         }
 
+        Button cancel {
+          styles [
+            "destructive-action",
+          ]
+
+          action-name: "endpoint.cancel";
+          icon-name: "process-stop-symbolic";
+          tooltip-text: _("Cancel request");
+        }
+
         Button send {
           styles [
             "suggested-action",

--- a/po/ca.po
+++ b/po/ca.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 23:06+0100\n"
+"POT-Creation-Date: 2025-03-12 22:34+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -217,35 +217,40 @@ msgstr ""
 msgid "Copy"
 msgstr "Copiar"
 
-#: data/ui/endpoint_pane.blp:58
+#: data/ui/endpoint_pane.blp:61
 msgid "Request URL"
 msgstr "URL de petició"
 
-#: data/ui/endpoint_pane.blp:69
+#: data/ui/endpoint_pane.blp:73
+#, fuzzy
+msgid "Cancel request"
+msgstr "Guardar petició"
+
+#: data/ui/endpoint_pane.blp:82
 msgid "Send"
 msgstr "Enviar"
 
-#: data/ui/endpoint_pane.blp:70
+#: data/ui/endpoint_pane.blp:83
 msgid "Execute this HTTP request"
 msgstr "Executar aquesta petició HTTP"
 
-#: data/ui/endpoint_pane.blp:102
+#: data/ui/endpoint_pane.blp:115
 msgid "Parameters"
 msgstr "Paràmetres"
 
-#: data/ui/endpoint_pane.blp:123 data/ui/response_panel.blp:97
+#: data/ui/endpoint_pane.blp:138 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Capçaleres"
 
-#: data/ui/endpoint_pane.blp:144
+#: data/ui/endpoint_pane.blp:161
 msgid "Variables"
 msgstr "Variables"
 
-#: data/ui/endpoint_pane.blp:165 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:184 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Cos"
 
-#: data/ui/endpoint_pane.blp:173
+#: data/ui/endpoint_pane.blp:194
 msgid "Export request"
 msgstr "Exportar petició"
 
@@ -253,27 +258,27 @@ msgstr "Exportar petició"
 msgid "Export to"
 msgstr "Exportar com"
 
-#: data/ui/export_tab.blp:69 data/ui/payload_tab.blp:81
+#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
 msgid "(none)"
 msgstr "(nada)"
 
-#: data/ui/key_value_row.blp:40
+#: data/ui/key_value_row.blp:42
 msgid "Name"
 msgstr "Nom"
 
-#: data/ui/key_value_row.blp:50
+#: data/ui/key_value_row.blp:53
 msgid "Value"
 msgstr "Valor"
 
-#: data/ui/key_value_row.blp:61
+#: data/ui/key_value_row.blp:64
 msgid "Actions"
 msgstr "Accions"
 
-#: data/ui/key_value_row.blp:74
+#: data/ui/key_value_row.blp:78
 msgid "Toggle secret"
 msgstr "Alternar secret"
 
-#: data/ui/key_value_row.blp:81
+#: data/ui/key_value_row.blp:85
 msgid "Delete"
 msgstr "Esborrar"
 
@@ -388,15 +393,15 @@ msgstr "Mètode de petició"
 msgid "Body type"
 msgstr "Tipus de cos"
 
-#: data/ui/payload_tab.blp:82
+#: data/ui/payload_tab.blp:89
 msgid "URL Encoded"
 msgstr "Codificat com URL"
 
-#: data/ui/payload_tab.blp:83
+#: data/ui/payload_tab.blp:90
 msgid "Multipart Form Data"
 msgstr "Formulari Multipart"
 
-#: data/ui/payload_tab.blp:86
+#: data/ui/payload_tab.blp:93
 msgid "Raw"
 msgstr "En brut"
 

--- a/po/cartero.pot
+++ b/po/cartero.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 23:06+0100\n"
+"POT-Creation-Date: 2025-03-12 22:34+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -209,35 +209,39 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:58
+#: data/ui/endpoint_pane.blp:61
 msgid "Request URL"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:69
+#: data/ui/endpoint_pane.blp:73
+msgid "Cancel request"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:82
 msgid "Send"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:70
+#: data/ui/endpoint_pane.blp:83
 msgid "Execute this HTTP request"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:102
+#: data/ui/endpoint_pane.blp:115
 msgid "Parameters"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:123 data/ui/response_panel.blp:97
+#: data/ui/endpoint_pane.blp:138 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:144
+#: data/ui/endpoint_pane.blp:161
 msgid "Variables"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:165 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:184 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:173
+#: data/ui/endpoint_pane.blp:194
 msgid "Export request"
 msgstr ""
 
@@ -245,27 +249,27 @@ msgstr ""
 msgid "Export to"
 msgstr ""
 
-#: data/ui/export_tab.blp:69 data/ui/payload_tab.blp:81
+#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
 msgid "(none)"
 msgstr ""
 
-#: data/ui/key_value_row.blp:40
+#: data/ui/key_value_row.blp:42
 msgid "Name"
 msgstr ""
 
-#: data/ui/key_value_row.blp:50
+#: data/ui/key_value_row.blp:53
 msgid "Value"
 msgstr ""
 
-#: data/ui/key_value_row.blp:61
+#: data/ui/key_value_row.blp:64
 msgid "Actions"
 msgstr ""
 
-#: data/ui/key_value_row.blp:74
+#: data/ui/key_value_row.blp:78
 msgid "Toggle secret"
 msgstr ""
 
-#: data/ui/key_value_row.blp:81
+#: data/ui/key_value_row.blp:85
 msgid "Delete"
 msgstr ""
 
@@ -380,15 +384,15 @@ msgstr ""
 msgid "Body type"
 msgstr ""
 
-#: data/ui/payload_tab.blp:82
+#: data/ui/payload_tab.blp:89
 msgid "URL Encoded"
 msgstr ""
 
-#: data/ui/payload_tab.blp:83
+#: data/ui/payload_tab.blp:90
 msgid "Multipart Form Data"
 msgstr ""
 
-#: data/ui/payload_tab.blp:86
+#: data/ui/payload_tab.blp:93
 msgid "Raw"
 msgstr ""
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 23:06+0100\n"
+"POT-Creation-Date: 2025-03-12 22:34+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: vesp <vesp@post.cz>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartero/cartero/cs/"
@@ -218,35 +218,40 @@ msgstr "Odeslat požadavek"
 msgid "Copy"
 msgstr "Kopírovat"
 
-#: data/ui/endpoint_pane.blp:58
+#: data/ui/endpoint_pane.blp:61
 msgid "Request URL"
 msgstr "URL požadavku"
 
-#: data/ui/endpoint_pane.blp:69
+#: data/ui/endpoint_pane.blp:73
+#, fuzzy
+msgid "Cancel request"
+msgstr "Uložit požadavek"
+
+#: data/ui/endpoint_pane.blp:82
 msgid "Send"
 msgstr "Odeslat"
 
-#: data/ui/endpoint_pane.blp:70
+#: data/ui/endpoint_pane.blp:83
 msgid "Execute this HTTP request"
 msgstr "Provést tento HTTP požadavek"
 
-#: data/ui/endpoint_pane.blp:102
+#: data/ui/endpoint_pane.blp:115
 msgid "Parameters"
 msgstr "Parametry"
 
-#: data/ui/endpoint_pane.blp:123 data/ui/response_panel.blp:97
+#: data/ui/endpoint_pane.blp:138 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Hlavičky"
 
-#: data/ui/endpoint_pane.blp:144
+#: data/ui/endpoint_pane.blp:161
 msgid "Variables"
 msgstr "Proměnné"
 
-#: data/ui/endpoint_pane.blp:165 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:184 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Tělo"
 
-#: data/ui/endpoint_pane.blp:173
+#: data/ui/endpoint_pane.blp:194
 msgid "Export request"
 msgstr "Exportovat požadavek"
 
@@ -254,27 +259,27 @@ msgstr "Exportovat požadavek"
 msgid "Export to"
 msgstr "Exportovat do"
 
-#: data/ui/export_tab.blp:69 data/ui/payload_tab.blp:81
+#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
 msgid "(none)"
 msgstr "(nic)"
 
-#: data/ui/key_value_row.blp:40
+#: data/ui/key_value_row.blp:42
 msgid "Name"
 msgstr "Jméno"
 
-#: data/ui/key_value_row.blp:50
+#: data/ui/key_value_row.blp:53
 msgid "Value"
 msgstr "Hodnota"
 
-#: data/ui/key_value_row.blp:61
+#: data/ui/key_value_row.blp:64
 msgid "Actions"
 msgstr "Akce"
 
-#: data/ui/key_value_row.blp:74
+#: data/ui/key_value_row.blp:78
 msgid "Toggle secret"
 msgstr "Skrýt"
 
-#: data/ui/key_value_row.blp:81
+#: data/ui/key_value_row.blp:85
 msgid "Delete"
 msgstr "Smazat"
 
@@ -389,15 +394,15 @@ msgstr "Metoda požadavku"
 msgid "Body type"
 msgstr "Typ těla"
 
-#: data/ui/payload_tab.blp:82
+#: data/ui/payload_tab.blp:89
 msgid "URL Encoded"
 msgstr ""
 
-#: data/ui/payload_tab.blp:83
+#: data/ui/payload_tab.blp:90
 msgid "Multipart Form Data"
 msgstr ""
 
-#: data/ui/payload_tab.blp:86
+#: data/ui/payload_tab.blp:93
 msgid "Raw"
 msgstr ""
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 23:06+0100\n"
+"POT-Creation-Date: 2025-03-12 22:34+0100\n"
 "PO-Revision-Date: 2024-11-04 17:46+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/cartero/"
@@ -208,35 +208,39 @@ msgstr ""
 msgid "Copy"
 msgstr "Kopii"
 
-#: data/ui/endpoint_pane.blp:58
+#: data/ui/endpoint_pane.blp:61
 msgid "Request URL"
 msgstr "URL"
 
-#: data/ui/endpoint_pane.blp:69
+#: data/ui/endpoint_pane.blp:73
+msgid "Cancel request"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:82
 msgid "Send"
 msgstr "Petu"
 
-#: data/ui/endpoint_pane.blp:70
+#: data/ui/endpoint_pane.blp:83
 msgid "Execute this HTTP request"
 msgstr "Sendu ĉi tiun http-peton"
 
-#: data/ui/endpoint_pane.blp:102
+#: data/ui/endpoint_pane.blp:115
 msgid "Parameters"
 msgstr "Parametroj"
 
-#: data/ui/endpoint_pane.blp:123 data/ui/response_panel.blp:97
+#: data/ui/endpoint_pane.blp:138 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Kapoj"
 
-#: data/ui/endpoint_pane.blp:144
+#: data/ui/endpoint_pane.blp:161
 msgid "Variables"
 msgstr "Variabloj"
 
-#: data/ui/endpoint_pane.blp:165 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:184 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Korpo"
 
-#: data/ui/endpoint_pane.blp:173
+#: data/ui/endpoint_pane.blp:194
 msgid "Export request"
 msgstr ""
 
@@ -244,27 +248,27 @@ msgstr ""
 msgid "Export to"
 msgstr ""
 
-#: data/ui/export_tab.blp:69 data/ui/payload_tab.blp:81
+#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
 msgid "(none)"
 msgstr "(nenio)"
 
-#: data/ui/key_value_row.blp:40
+#: data/ui/key_value_row.blp:42
 msgid "Name"
 msgstr "Nomo"
 
-#: data/ui/key_value_row.blp:50
+#: data/ui/key_value_row.blp:53
 msgid "Value"
 msgstr "Enhavo"
 
-#: data/ui/key_value_row.blp:61
+#: data/ui/key_value_row.blp:64
 msgid "Actions"
 msgstr "Agoj"
 
-#: data/ui/key_value_row.blp:74
+#: data/ui/key_value_row.blp:78
 msgid "Toggle secret"
 msgstr "Baskuli sekreton"
 
-#: data/ui/key_value_row.blp:81
+#: data/ui/key_value_row.blp:85
 msgid "Delete"
 msgstr "Forigi kapo"
 
@@ -379,15 +383,15 @@ msgstr "HTTP-metodo"
 msgid "Body type"
 msgstr ""
 
-#: data/ui/payload_tab.blp:82
+#: data/ui/payload_tab.blp:89
 msgid "URL Encoded"
 msgstr ""
 
-#: data/ui/payload_tab.blp:83
+#: data/ui/payload_tab.blp:90
 msgid "Multipart Form Data"
 msgstr ""
 
-#: data/ui/payload_tab.blp:86
+#: data/ui/payload_tab.blp:93
 msgid "Raw"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 23:06+0100\n"
+"POT-Creation-Date: 2025-03-12 22:34+0100\n"
 "PO-Revision-Date: 2025-03-06 22:02+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -218,35 +218,39 @@ msgstr "Enviar petición"
 msgid "Copy"
 msgstr "Copiar"
 
-#: data/ui/endpoint_pane.blp:58
+#: data/ui/endpoint_pane.blp:61
 msgid "Request URL"
 msgstr "URL de petición"
 
-#: data/ui/endpoint_pane.blp:69
+#: data/ui/endpoint_pane.blp:73
+msgid "Cancel request"
+msgstr "Cancelar petición"
+
+#: data/ui/endpoint_pane.blp:82
 msgid "Send"
 msgstr "Enviar"
 
-#: data/ui/endpoint_pane.blp:70
+#: data/ui/endpoint_pane.blp:83
 msgid "Execute this HTTP request"
 msgstr "Ejecutar esta petición HTTP"
 
-#: data/ui/endpoint_pane.blp:102
+#: data/ui/endpoint_pane.blp:115
 msgid "Parameters"
 msgstr "Parámetros"
 
-#: data/ui/endpoint_pane.blp:123 data/ui/response_panel.blp:97
+#: data/ui/endpoint_pane.blp:138 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Cabeceras"
 
-#: data/ui/endpoint_pane.blp:144
+#: data/ui/endpoint_pane.blp:161
 msgid "Variables"
 msgstr "Variables"
 
-#: data/ui/endpoint_pane.blp:165 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:184 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Cuerpo"
 
-#: data/ui/endpoint_pane.blp:173
+#: data/ui/endpoint_pane.blp:194
 msgid "Export request"
 msgstr "Exportar petición"
 
@@ -254,27 +258,27 @@ msgstr "Exportar petición"
 msgid "Export to"
 msgstr "Exportar como"
 
-#: data/ui/export_tab.blp:69 data/ui/payload_tab.blp:81
+#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
 msgid "(none)"
 msgstr "(nada)"
 
-#: data/ui/key_value_row.blp:40
+#: data/ui/key_value_row.blp:42
 msgid "Name"
 msgstr "Nombre"
 
-#: data/ui/key_value_row.blp:50
+#: data/ui/key_value_row.blp:53
 msgid "Value"
 msgstr "Valor"
 
-#: data/ui/key_value_row.blp:61
+#: data/ui/key_value_row.blp:64
 msgid "Actions"
 msgstr "Acciones"
 
-#: data/ui/key_value_row.blp:74
+#: data/ui/key_value_row.blp:78
 msgid "Toggle secret"
 msgstr "Alternar secreto"
 
-#: data/ui/key_value_row.blp:81
+#: data/ui/key_value_row.blp:85
 msgid "Delete"
 msgstr "Borrar"
 
@@ -389,15 +393,15 @@ msgstr "Método de petición"
 msgid "Body type"
 msgstr "Tipo de cuerpo"
 
-#: data/ui/payload_tab.blp:82
+#: data/ui/payload_tab.blp:89
 msgid "URL Encoded"
 msgstr "Codificado como URL"
 
-#: data/ui/payload_tab.blp:83
+#: data/ui/payload_tab.blp:90
 msgid "Multipart Form Data"
 msgstr "Formulario Multipart"
 
-#: data/ui/payload_tab.blp:86
+#: data/ui/payload_tab.blp:93
 msgid "Raw"
 msgstr "En bruto"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 23:06+0100\n"
+"POT-Creation-Date: 2025-03-12 22:34+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: Altero <aurelien.reinert4@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -211,35 +211,40 @@ msgstr "Envoyer la requête"
 msgid "Copy"
 msgstr "Copier"
 
-#: data/ui/endpoint_pane.blp:58
+#: data/ui/endpoint_pane.blp:61
 msgid "Request URL"
 msgstr "URL de requête"
 
-#: data/ui/endpoint_pane.blp:69
+#: data/ui/endpoint_pane.blp:73
+#, fuzzy
+msgid "Cancel request"
+msgstr "Enregistrer la requête"
+
+#: data/ui/endpoint_pane.blp:82
 msgid "Send"
 msgstr "Envoyer"
 
-#: data/ui/endpoint_pane.blp:70
+#: data/ui/endpoint_pane.blp:83
 msgid "Execute this HTTP request"
 msgstr "Exécuter cette requête HTTP"
 
-#: data/ui/endpoint_pane.blp:102
+#: data/ui/endpoint_pane.blp:115
 msgid "Parameters"
 msgstr "Paramètres"
 
-#: data/ui/endpoint_pane.blp:123 data/ui/response_panel.blp:97
+#: data/ui/endpoint_pane.blp:138 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "En-têtes"
 
-#: data/ui/endpoint_pane.blp:144
+#: data/ui/endpoint_pane.blp:161
 msgid "Variables"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:165 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:184 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Corps"
 
-#: data/ui/endpoint_pane.blp:173
+#: data/ui/endpoint_pane.blp:194
 msgid "Export request"
 msgstr "Exporter la requête"
 
@@ -247,27 +252,27 @@ msgstr "Exporter la requête"
 msgid "Export to"
 msgstr "Exporter vers"
 
-#: data/ui/export_tab.blp:69 data/ui/payload_tab.blp:81
+#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
 msgid "(none)"
 msgstr "(aucun)"
 
-#: data/ui/key_value_row.blp:40
+#: data/ui/key_value_row.blp:42
 msgid "Name"
 msgstr "Nom"
 
-#: data/ui/key_value_row.blp:50
+#: data/ui/key_value_row.blp:53
 msgid "Value"
 msgstr "Valeur"
 
-#: data/ui/key_value_row.blp:61
+#: data/ui/key_value_row.blp:64
 msgid "Actions"
 msgstr "Actions"
 
-#: data/ui/key_value_row.blp:74
+#: data/ui/key_value_row.blp:78
 msgid "Toggle secret"
 msgstr ""
 
-#: data/ui/key_value_row.blp:81
+#: data/ui/key_value_row.blp:85
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -383,15 +388,15 @@ msgstr "Méthode de requête"
 msgid "Body type"
 msgstr "Type de corps"
 
-#: data/ui/payload_tab.blp:82
+#: data/ui/payload_tab.blp:89
 msgid "URL Encoded"
 msgstr "Encodé comme URL"
 
-#: data/ui/payload_tab.blp:83
+#: data/ui/payload_tab.blp:90
 msgid "Multipart Form Data"
 msgstr "Données de formulaire multiparties"
 
-#: data/ui/payload_tab.blp:86
+#: data/ui/payload_tab.blp:93
 msgid "Raw"
 msgstr "Brut"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 23:06+0100\n"
+"POT-Creation-Date: 2025-03-12 22:34+0100\n"
 "PO-Revision-Date: 2025-02-01 23:50-0300\n"
 "Last-Translator: john peter <johnppetersa@gmail.com>\n"
 "Language-Team: \n"
@@ -219,35 +219,40 @@ msgstr "Enviar solicitação"
 msgid "Copy"
 msgstr "Cópia"
 
-#: data/ui/endpoint_pane.blp:58
+#: data/ui/endpoint_pane.blp:61
 msgid "Request URL"
 msgstr "Solicitar url"
 
-#: data/ui/endpoint_pane.blp:69
+#: data/ui/endpoint_pane.blp:73
+#, fuzzy
+msgid "Cancel request"
+msgstr "Salvar solicitação"
+
+#: data/ui/endpoint_pane.blp:82
 msgid "Send"
 msgstr "Enviar"
 
-#: data/ui/endpoint_pane.blp:70
+#: data/ui/endpoint_pane.blp:83
 msgid "Execute this HTTP request"
 msgstr "Execute esta solicitação HTTP"
 
-#: data/ui/endpoint_pane.blp:102
+#: data/ui/endpoint_pane.blp:115
 msgid "Parameters"
 msgstr "Parâmetros"
 
-#: data/ui/endpoint_pane.blp:123 data/ui/response_panel.blp:97
+#: data/ui/endpoint_pane.blp:138 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Cabeçalhos"
 
-#: data/ui/endpoint_pane.blp:144
+#: data/ui/endpoint_pane.blp:161
 msgid "Variables"
 msgstr "Variáveis"
 
-#: data/ui/endpoint_pane.blp:165 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:184 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Corpo"
 
-#: data/ui/endpoint_pane.blp:173
+#: data/ui/endpoint_pane.blp:194
 msgid "Export request"
 msgstr "Solicitação de exportação"
 
@@ -255,27 +260,27 @@ msgstr "Solicitação de exportação"
 msgid "Export to"
 msgstr "Exportar para"
 
-#: data/ui/export_tab.blp:69 data/ui/payload_tab.blp:81
+#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
 msgid "(none)"
 msgstr "(nenhum)"
 
-#: data/ui/key_value_row.blp:40
+#: data/ui/key_value_row.blp:42
 msgid "Name"
 msgstr "Nome"
 
-#: data/ui/key_value_row.blp:50
+#: data/ui/key_value_row.blp:53
 msgid "Value"
 msgstr "Valor"
 
-#: data/ui/key_value_row.blp:61
+#: data/ui/key_value_row.blp:64
 msgid "Actions"
 msgstr "Ações"
 
-#: data/ui/key_value_row.blp:74
+#: data/ui/key_value_row.blp:78
 msgid "Toggle secret"
 msgstr "Alternar o segredo"
 
-#: data/ui/key_value_row.blp:81
+#: data/ui/key_value_row.blp:85
 msgid "Delete"
 msgstr "Excluir"
 
@@ -390,15 +395,15 @@ msgstr "Método de solicitação"
 msgid "Body type"
 msgstr "Tipo de corpo"
 
-#: data/ui/payload_tab.blp:82
+#: data/ui/payload_tab.blp:89
 msgid "URL Encoded"
 msgstr "URL codificado"
 
-#: data/ui/payload_tab.blp:83
+#: data/ui/payload_tab.blp:90
 msgid "Multipart Form Data"
 msgstr "Dados de formulário multipart"
 
-#: data/ui/payload_tab.blp:86
+#: data/ui/payload_tab.blp:93
 msgid "Raw"
 msgstr "Cru"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 23:06+0100\n"
+"POT-Creation-Date: 2025-03-12 22:34+0100\n"
 "PO-Revision-Date: 2024-07-30 15:00+0200\n"
 "Last-Translator:  <>\n"
 "Language-Team: Romanian\n"
@@ -207,35 +207,40 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:58
+#: data/ui/endpoint_pane.blp:61
 msgid "Request URL"
 msgstr "URL-ul cererii"
 
-#: data/ui/endpoint_pane.blp:69
+#: data/ui/endpoint_pane.blp:73
+#, fuzzy
+msgid "Cancel request"
+msgstr "Salvați cererea"
+
+#: data/ui/endpoint_pane.blp:82
 msgid "Send"
 msgstr "Trimiteți"
 
-#: data/ui/endpoint_pane.blp:70
+#: data/ui/endpoint_pane.blp:83
 msgid "Execute this HTTP request"
 msgstr "Executați această cerere HTTP"
 
-#: data/ui/endpoint_pane.blp:102
+#: data/ui/endpoint_pane.blp:115
 msgid "Parameters"
 msgstr "Parametrii"
 
-#: data/ui/endpoint_pane.blp:123 data/ui/response_panel.blp:97
+#: data/ui/endpoint_pane.blp:138 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Antetele"
 
-#: data/ui/endpoint_pane.blp:144
+#: data/ui/endpoint_pane.blp:161
 msgid "Variables"
 msgstr "Variabilele"
 
-#: data/ui/endpoint_pane.blp:165 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:184 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Corpul"
 
-#: data/ui/endpoint_pane.blp:173
+#: data/ui/endpoint_pane.blp:194
 msgid "Export request"
 msgstr ""
 
@@ -243,27 +248,27 @@ msgstr ""
 msgid "Export to"
 msgstr ""
 
-#: data/ui/export_tab.blp:69 data/ui/payload_tab.blp:81
+#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
 msgid "(none)"
 msgstr "(niciunul)"
 
-#: data/ui/key_value_row.blp:40
+#: data/ui/key_value_row.blp:42
 msgid "Name"
 msgstr "Numele"
 
-#: data/ui/key_value_row.blp:50
+#: data/ui/key_value_row.blp:53
 msgid "Value"
 msgstr "Valoarea"
 
-#: data/ui/key_value_row.blp:61
+#: data/ui/key_value_row.blp:64
 msgid "Actions"
 msgstr "Acțiunile"
 
-#: data/ui/key_value_row.blp:74
+#: data/ui/key_value_row.blp:78
 msgid "Toggle secret"
 msgstr "Comutați secretul"
 
-#: data/ui/key_value_row.blp:81
+#: data/ui/key_value_row.blp:85
 msgid "Delete"
 msgstr "Ștergeți"
 
@@ -378,15 +383,15 @@ msgstr "Metoda cererii"
 msgid "Body type"
 msgstr "Tipul corpului"
 
-#: data/ui/payload_tab.blp:82
+#: data/ui/payload_tab.blp:89
 msgid "URL Encoded"
 msgstr "Codat URL"
 
-#: data/ui/payload_tab.blp:83
+#: data/ui/payload_tab.blp:90
 msgid "Multipart Form Data"
 msgstr "Date de formă multipart"
 
-#: data/ui/payload_tab.blp:86
+#: data/ui/payload_tab.blp:93
 msgid "Raw"
 msgstr "Brut"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 23:06+0100\n"
+"POT-Creation-Date: 2025-03-12 22:34+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -219,35 +219,40 @@ msgstr "Отправить запрос"
 msgid "Copy"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:58
+#: data/ui/endpoint_pane.blp:61
 msgid "Request URL"
 msgstr "URL-адрес запроса"
 
-#: data/ui/endpoint_pane.blp:69
+#: data/ui/endpoint_pane.blp:73
+#, fuzzy
+msgid "Cancel request"
+msgstr "Сохранить запрос"
+
+#: data/ui/endpoint_pane.blp:82
 msgid "Send"
 msgstr "Отправить"
 
-#: data/ui/endpoint_pane.blp:70
+#: data/ui/endpoint_pane.blp:83
 msgid "Execute this HTTP request"
 msgstr "Выполнить этот HTTP-запрос"
 
-#: data/ui/endpoint_pane.blp:102
+#: data/ui/endpoint_pane.blp:115
 msgid "Parameters"
 msgstr "Параметры"
 
-#: data/ui/endpoint_pane.blp:123 data/ui/response_panel.blp:97
+#: data/ui/endpoint_pane.blp:138 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "Заголовки"
 
-#: data/ui/endpoint_pane.blp:144
+#: data/ui/endpoint_pane.blp:161
 msgid "Variables"
 msgstr "Переменные"
 
-#: data/ui/endpoint_pane.blp:165 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:184 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Тело"
 
-#: data/ui/endpoint_pane.blp:173
+#: data/ui/endpoint_pane.blp:194
 msgid "Export request"
 msgstr ""
 
@@ -255,27 +260,27 @@ msgstr ""
 msgid "Export to"
 msgstr ""
 
-#: data/ui/export_tab.blp:69 data/ui/payload_tab.blp:81
+#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
 msgid "(none)"
 msgstr "(нет)"
 
-#: data/ui/key_value_row.blp:40
+#: data/ui/key_value_row.blp:42
 msgid "Name"
 msgstr "Имя"
 
-#: data/ui/key_value_row.blp:50
+#: data/ui/key_value_row.blp:53
 msgid "Value"
 msgstr "Значение"
 
-#: data/ui/key_value_row.blp:61
+#: data/ui/key_value_row.blp:64
 msgid "Actions"
 msgstr "Действия"
 
-#: data/ui/key_value_row.blp:74
+#: data/ui/key_value_row.blp:78
 msgid "Toggle secret"
 msgstr "Скрыть значение"
 
-#: data/ui/key_value_row.blp:81
+#: data/ui/key_value_row.blp:85
 msgid "Delete"
 msgstr "Удалить"
 
@@ -390,15 +395,15 @@ msgstr "Метод запроса"
 msgid "Body type"
 msgstr "Тип тела"
 
-#: data/ui/payload_tab.blp:82
+#: data/ui/payload_tab.blp:89
 msgid "URL Encoded"
 msgstr "Кодированный URL"
 
-#: data/ui/payload_tab.blp:83
+#: data/ui/payload_tab.blp:90
 msgid "Multipart Form Data"
 msgstr "Многочастичные данные"
 
-#: data/ui/payload_tab.blp:86
+#: data/ui/payload_tab.blp:93
 msgid "Raw"
 msgstr "Простой"
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-11 23:06+0100\n"
+"POT-Creation-Date: 2025-03-12 22:34+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartero/cartero/ta/"
@@ -217,35 +217,40 @@ msgstr "கோரிக்கையை அனுப்பவும்"
 msgid "Copy"
 msgstr "நகலெடு"
 
-#: data/ui/endpoint_pane.blp:58
+#: data/ui/endpoint_pane.blp:61
 msgid "Request URL"
 msgstr "முகவரி ஐக் கோருங்கள்"
 
-#: data/ui/endpoint_pane.blp:69
+#: data/ui/endpoint_pane.blp:73
+#, fuzzy
+msgid "Cancel request"
+msgstr "கோரிக்கையைச் சேமிக்கவும்"
+
+#: data/ui/endpoint_pane.blp:82
 msgid "Send"
 msgstr "அனுப்பு"
 
-#: data/ui/endpoint_pane.blp:70
+#: data/ui/endpoint_pane.blp:83
 msgid "Execute this HTTP request"
 msgstr "இந்த HTTP கோரிக்கையை இயக்கவும்"
 
-#: data/ui/endpoint_pane.blp:102
+#: data/ui/endpoint_pane.blp:115
 msgid "Parameters"
 msgstr "அளவுருக்கள்"
 
-#: data/ui/endpoint_pane.blp:123 data/ui/response_panel.blp:97
+#: data/ui/endpoint_pane.blp:138 data/ui/response_panel.blp:97
 msgid "Headers"
 msgstr "தலைப்பிகளுக்கு"
 
-#: data/ui/endpoint_pane.blp:144
+#: data/ui/endpoint_pane.blp:161
 msgid "Variables"
 msgstr "மாறிகள்"
 
-#: data/ui/endpoint_pane.blp:165 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:184 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "உடல்"
 
-#: data/ui/endpoint_pane.blp:173
+#: data/ui/endpoint_pane.blp:194
 msgid "Export request"
 msgstr "ஏற்றுமதி கோரிக்கை"
 
@@ -253,27 +258,27 @@ msgstr "ஏற்றுமதி கோரிக்கை"
 msgid "Export to"
 msgstr "ஏற்றுமதி"
 
-#: data/ui/export_tab.blp:69 data/ui/payload_tab.blp:81
+#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
 msgid "(none)"
 msgstr "(எதுவுமில்லை)"
 
-#: data/ui/key_value_row.blp:40
+#: data/ui/key_value_row.blp:42
 msgid "Name"
 msgstr "பெயர்"
 
-#: data/ui/key_value_row.blp:50
+#: data/ui/key_value_row.blp:53
 msgid "Value"
 msgstr "மதிப்பு"
 
-#: data/ui/key_value_row.blp:61
+#: data/ui/key_value_row.blp:64
 msgid "Actions"
 msgstr "செயல்கள்"
 
-#: data/ui/key_value_row.blp:74
+#: data/ui/key_value_row.blp:78
 msgid "Toggle secret"
 msgstr "ரகசியத்தை மாற்றவும்"
 
-#: data/ui/key_value_row.blp:81
+#: data/ui/key_value_row.blp:85
 msgid "Delete"
 msgstr "நீக்கு"
 
@@ -388,15 +393,15 @@ msgstr "கோரிக்கை முறை"
 msgid "Body type"
 msgstr "உடல் வகை"
 
-#: data/ui/payload_tab.blp:82
+#: data/ui/payload_tab.blp:89
 msgid "URL Encoded"
 msgstr "முகவரி குறியாக்கம் செய்யப்பட்டது"
 
-#: data/ui/payload_tab.blp:83
+#: data/ui/payload_tab.blp:90
 msgid "Multipart Form Data"
 msgstr "மல்டிபார்ட் படிவ தரவு"
 
-#: data/ui/payload_tab.blp:86
+#: data/ui/payload_tab.blp:93
 msgid "Raw"
 msgstr "மூல"
 

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -31,7 +31,7 @@ mod imp {
 
     use adw::subclass::breakpoint_bin::BreakpointBinImpl;
     use glib::subclass::InitializingObject;
-    use glib::Properties;
+    use glib::{JoinHandle, Properties};
     use gtk::gio::{self, SimpleAction, SimpleActionGroup};
     use gtk::subclass::prelude::*;
     use gtk::{prelude::*, ClosureExpression, CompositeTemplate};
@@ -53,6 +53,9 @@ mod imp {
     pub struct EndpointPane {
         #[template_child(id = "send")]
         pub send_button: TemplateChild<gtk::Button>,
+
+        #[template_child(id = "cancel")]
+        cancel_button: TemplateChild<gtk::Button>,
 
         #[template_child]
         pub parameter_pane: TemplateChild<KeyValuePane>,
@@ -93,6 +96,8 @@ mod imp {
         // Busy requesting
         #[property(get, set)]
         busy: RefCell<bool>,
+
+        request_thread: Arc<RefCell<Option<JoinHandle<()>>>>,
 
         variable_changing: Arc<Mutex<bool>>,
     }
@@ -206,6 +211,15 @@ mod imp {
                 }
             ));
 
+            let action_cancel = SimpleAction::new("cancel", None);
+            action_cancel.connect_activate(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |_, _| {
+                    imp.action_cancel_request();
+                }
+            ));
+
             /* The action should only be enabled if there is an URL set and if not busy. */
             let text = self.request_url.property_expression("text");
             let busy = obj.property_expression("busy");
@@ -219,8 +233,17 @@ mod imp {
             )
             .bind(&action_request, "enabled", Some(&*obj));
 
+            /* The cancel should only be possible if currently busy. */
+            busy.bind(&action_cancel, "enabled", gtk::Widget::NONE);
+
+            /* Also, bind the visibility of the cancel button to whether the action is enabled. */
+            action_cancel
+                .bind_property("enabled", &*self.cancel_button, "visible")
+                .build();
+
             let action_group = SimpleActionGroup::new();
             action_group.add_action(&action_request);
+            action_group.add_action(&action_cancel);
             obj.insert_action_group("endpoint", Some(&action_group));
         }
 
@@ -490,8 +513,25 @@ mod imp {
             Ok(response)
         }
 
+        fn action_cancel_request(&self) {
+            let obj = self.obj();
+
+            {
+                let maybe_request_thread = self.request_thread.borrow();
+                if let Some(ref thread_ref) = *maybe_request_thread {
+                    thread_ref.abort();
+
+                    /* reset the user interface state. */
+                    self.response.set_spinning(false);
+                    obj.set_read_only(false);
+                    obj.set_busy(false);
+                }
+            }
+            self.request_thread.replace(None);
+        }
+
         fn action_perform_request(&self) {
-            glib::spawn_future_local(glib::clone!(
+            let thread_ref = glib::spawn_future_local(glib::clone!(
                 #[weak(rename_to = imp)]
                 self,
                 async move {
@@ -508,8 +548,12 @@ mod imp {
                     imp.response.set_spinning(false);
                     obj.set_read_only(false);
                     obj.set_busy(false);
+
+                    imp.request_thread.replace(None);
                 }
             ));
+
+            self.request_thread.replace(Some(thread_ref));
         }
 
         /// Executes an HTTP request based on the current contents of the pane.

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -239,6 +239,7 @@ mod imp {
             /* Also, bind the visibility of the cancel button to whether the action is enabled. */
             action_cancel
                 .bind_property("enabled", &*self.cancel_button, "visible")
+                .sync_create()
                 .build();
 
             let action_group = SimpleActionGroup::new();


### PR DESCRIPTION
# Motivation

Sometimes a request will take more time than what it should, and even if there is already a timeout in the settings, having to wait for a rogue endpoint to timeout is a waste of time. This PR proposes a new button that appears only while a request is in progress, that allows the user to cancel the request, ignoring the result and making the whole panel editable again.

# Visible changes

When a request is in progress, there is a new button with the icon of a stop sign and the tooltip of "Cancel request" near the "Send" button that is now disabled.

![image](https://github.com/user-attachments/assets/bc462ad7-ffa4-4a66-a8c7-b1e9fe8b6e0d)
