### PR TITLE
Add more keybindings

### DIFF
--- a/data/ui/code_export_pane.blp
+++ b/data/ui/code_export_pane.blp
@@ -29,10 +29,6 @@ template $CarteroCodeExportPane: $CarteroBaseExportPane {
         hexpand: true;
 
         $CarteroCodeView view {
-          styles [
-            "use-cartero-font",
-          ]
-
           left-margin: 10;
           right-margin: 10;
           top-margin: 10;

--- a/data/ui/endpoint_pane.blp
+++ b/data/ui/endpoint_pane.blp
@@ -34,6 +34,15 @@ template $CarteroEndpointPane: Adw.BreakpointBin {
     }
   }
 
+  ShortcutController {
+    scope: managed;
+
+    Shortcut {
+      trigger: '<Primary>l';
+      action: 'action(endpoint.focus-url)';
+    }
+  }
+
   Box {
     orientation: vertical;
 

--- a/data/ui/raw_payload_pane.blp
+++ b/data/ui/raw_payload_pane.blp
@@ -25,10 +25,6 @@ template $CarteroRawPayloadPane: $CarteroBasePayloadPane {
       vexpand: true;
 
       $CarteroCodeView view {
-        styles [
-          "use-cartero-font",
-        ]
-
         editable: bind template.read-only inverted;
         top-margin: 10;
         bottom-margin: 10;

--- a/data/ui/response_panel.blp
+++ b/data/ui/response_panel.blp
@@ -59,10 +59,6 @@ template $CarteroResponsePanel: Adw.Bin {
                 vexpand: true;
 
                 $CarteroCodeView response_body {
-                  styles [
-                    "use-cartero-font",
-                  ]
-
                   top-margin: 10;
                   bottom-margin: 10;
                   left-margin: 10;

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,11 +18,8 @@
 use adw::prelude::*;
 use glib::subclass::types::ObjectSubclassIsExt;
 use glib::Object;
-use gtk::gdk::Display;
 use gtk::gio::{self, ActionEntryBuilder, Settings};
-use gtk::pango::FontDescription;
 use gtk::prelude::ActionMapExtManual;
-use gtk::{CssProvider, STYLE_PROVIDER_PRIORITY_APPLICATION};
 
 use crate::config::{APP_ID, BASE_ID, RESOURCE_PATH};
 use crate::win::CarteroWindow;
@@ -54,9 +51,6 @@ mod imp {
     #[derive(Default)]
     pub struct CarteroApplication {
         pub(super) settings: OnceCell<Settings>,
-
-        /* Used to change the text editors font descriptors. */
-        pub(super) provider: OnceCell<CssProvider>,
     }
 
     #[glib::object_subclass]
@@ -110,7 +104,6 @@ mod imp {
             obj.set_accels_for_action("win.show-help-overlay", &[accelerator!("question")]);
             obj.setup_app_actions();
             obj.setup_color_scheme();
-            obj.setup_font();
         }
 
         fn open(&self, files: &[gio::File], hint: &str) {
@@ -175,10 +168,6 @@ impl CarteroApplication {
         self.imp().settings.get_or_init(|| Settings::new(BASE_ID))
     }
 
-    pub fn css_provider(&self) -> &CssProvider {
-        self.imp().provider.get_or_init(CssProvider::new)
-    }
-
     fn setup_color_scheme(&self) {
         let settings = self.settings();
         settings
@@ -192,86 +181,6 @@ impl CarteroApplication {
                 Some(scheme.into())
             })
             .build();
-    }
-
-    fn setup_font(&self) {
-        let css_provider = self.css_provider();
-        let display = Display::default().expect("No display available");
-        gtk::style_context_add_provider_for_display(
-            &display,
-            css_provider,
-            STYLE_PROVIDER_PRIORITY_APPLICATION,
-        );
-
-        let settings = self.settings();
-        settings.connect_changed(
-            None,
-            glib::clone!(
-                #[weak(rename_to = app)]
-                self,
-                move |_, _| {
-                    app.update_font();
-                }
-            ),
-        );
-        self.style_manager().connect_dark_notify(glib::clone!(
-            #[weak(rename_to = app)]
-            self,
-            move |_| {
-                app.update_font();
-            }
-        ));
-    }
-
-    fn update_font(&self) {
-        let current_font_descriptor = self.settings().get::<String>("custom-font");
-        let system_font = self.settings().get::<bool>("use-system-font");
-
-        let provider = self.css_provider();
-
-        let css: String = if system_font {
-            "".into()
-        } else {
-            let descriptor = FontDescription::from_string(&current_font_descriptor);
-            let font_family: String = descriptor.family().unwrap_or_default().into();
-            let font_size = descriptor.size() / gtk::pango::SCALE;
-            let font_style = {
-                match descriptor.style() {
-                    gtk::pango::Style::Italic => "italic",
-                    gtk::pango::Style::Oblique => "oblique",
-                    _ => "normal",
-                }
-            };
-            let font_weight = {
-                match descriptor.weight() {
-                    gtk::pango::Weight::Bold => 700,
-                    gtk::pango::Weight::Book => 380,
-                    gtk::pango::Weight::Heavy => 900,
-                    gtk::pango::Weight::Light => 300,
-                    gtk::pango::Weight::Medium => 500,
-                    gtk::pango::Weight::Normal => 400,
-                    gtk::pango::Weight::Semibold => 600,
-                    gtk::pango::Weight::Semilight => 350,
-                    gtk::pango::Weight::Thin => 100,
-                    gtk::pango::Weight::Ultrabold => 800,
-                    gtk::pango::Weight::Ultraheavy => 1000,
-                    gtk::pango::Weight::Ultralight => 200,
-                    gtk::pango::Weight::__Unknown(i) => i,
-                    _ => 400,
-                }
-            };
-
-            format!(
-                r#"
-                textview.use-cartero-font {{
-                    font-family: "{font_family}";
-                    font-size: {font_size}pt;
-                    font-style: {font_style};
-                    font-weight: {font_weight};
-                }}"#
-            )
-        };
-        provider.load_from_string(&css);
     }
 
     fn setup_app_actions(&self) {

--- a/src/widgets/code_view.rs
+++ b/src/widgets/code_view.rs
@@ -21,11 +21,13 @@ use gtk::{glib, pango::FontDescription, prelude::SettingsExtManual};
 use crate::app::CarteroApplication;
 
 mod imp {
+    use std::cell::RefCell;
     use std::sync::OnceLock;
 
-    use glib::object::Cast;
+    use glib::object::{Cast, ObjectExt};
     use glib::subclass::Signal;
     use glib::value::ToValue;
+    use glib::Properties;
     use gtk::gdk;
     use gtk::gio::SettingsBindFlags;
     #[allow(deprecated)]
@@ -39,11 +41,14 @@ mod imp {
     use sourceview5::StyleSchemeManager;
 
     use crate::app::CarteroApplication;
+    use crate::widgets::code_view::{get_monospace_font_descriptor, render_css_rules};
 
-    use super::render_basic_font_settings;
-
-    #[derive(Default)]
-    pub struct CodeView {}
+    #[derive(Default, Properties)]
+    #[properties(wrapper_type = super::CodeView)]
+    pub struct CodeView {
+        #[property(get, set, name = "zoom-level")]
+        zoom_level: RefCell<i32>,
+    }
 
     #[glib::object_subclass]
     impl ObjectSubclass for CodeView {
@@ -57,12 +62,44 @@ mod imp {
                 gdk::ModifierType::CONTROL_MASK,
                 "codeview.search",
             );
+            klass.add_binding_action(
+                gdk::Key::plus,
+                gdk::ModifierType::CONTROL_MASK,
+                "widget.zoom-in",
+            );
+            klass.add_binding_action(
+                gdk::Key::minus,
+                gdk::ModifierType::CONTROL_MASK,
+                "widget.zoom-out",
+            );
+            klass.add_binding_action(
+                gdk::Key::_0,
+                gdk::ModifierType::CONTROL_MASK,
+                "widget.zoom-reset",
+            );
+
             klass.install_action("codeview.search", None, |widget, _, _| {
                 widget.start_search();
+            });
+            klass.install_action("widget.zoom-in", None, |widget, _, _| {
+                let old_zoom = widget.zoom_level();
+                if old_zoom < 18 {
+                    widget.set_zoom_level(old_zoom + 1);
+                }
+            });
+            klass.install_action("widget.zoom-out", None, |widget, _, _| {
+                let old_zoom = widget.zoom_level();
+                if old_zoom > -6 {
+                    widget.set_zoom_level(old_zoom - 1);
+                }
+            });
+            klass.install_action("widget.zoom-reset", None, |widget, _, _| {
+                widget.set_zoom_level(0);
             });
         }
     }
 
+    #[glib::derived_properties]
     impl ObjectImpl for CodeView {
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
@@ -142,8 +179,10 @@ mod imp {
 
         /// Renders the whole CSS string that will be attached to the widget instance.
         fn generate_css(&self) -> String {
-            let common_font_settings = render_basic_font_settings();
-            format!(r#"textview {{ {} }}"#, common_font_settings)
+            let obj = self.obj();
+            let zoom_level = obj.zoom_level();
+            let font = get_monospace_font_descriptor();
+            render_css_rules(&font, zoom_level)
         }
 
         /// Configures the initial CSS style for this widget, and also setups the callbacks
@@ -179,6 +218,15 @@ mod imp {
                     }
                 ),
             );
+
+            obj.connect_zoom_level_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |_| {
+                    let css = imp.generate_css();
+                    provider.load_from_string(&css);
+                }
+            ));
         }
 
         fn update_source_view_style(&self) {
@@ -237,22 +285,42 @@ impl Default for CodeView {
     }
 }
 
-/// Generates a string with the common CSS rules that apply for setting the font family
-/// based on the font present in the application settings. Will include font family,
-/// size and weight if present.
-fn render_basic_font_settings() -> String {
+/// Returns the pango font descriptor used to render monospaced text views.
+/// If the user has customized the font in the settings, that's the descriptor
+/// that will be returned, otherwise just returns the default system one.
+fn get_monospace_font_descriptor() -> FontDescription {
     let app = CarteroApplication::get();
     let settings = app.settings();
     let system_font = settings.get::<bool>("use-system-font");
-    if system_font {
-        return "".to_string(); // nothing to add
-    }
 
-    // let's get to business
-    let current_font_descriptor = settings.get::<String>("custom-font");
-    let descriptor = FontDescription::from_string(&current_font_descriptor);
+    if system_font {
+        /* Does this work outside of GNOME...? */
+        let settings = gtk::gio::Settings::new("org.gnome.desktop.interface");
+        let monospace = settings.get::<String>("monospace-font-name");
+        FontDescription::from_string(&monospace)
+    } else {
+        let current_font_descriptor = settings.get::<String>("custom-font");
+        FontDescription::from_string(&current_font_descriptor)
+    }
+}
+
+/// Given the zoom level, returns the scaling percentage.
+fn map_zoom_level(zoom: i32) -> f32 {
+    let perc = 1.0 + (zoom as f32 / 8.0);
+    if perc < 0.25 {
+        0.25
+    } else {
+        perc
+    }
+}
+
+/// Returns the CSS document that should be provided to the StyleContext of a CodeView
+/// in order to tweak how the view should appear, based on the font settings and the
+/// zoom level in use.
+fn render_css_rules(descriptor: &FontDescription, zoom: i32) -> String {
     let font_family: String = descriptor.family().unwrap_or_default().into();
-    let font_size = descriptor.size() / gtk::pango::SCALE;
+    let font_size = descriptor.size() as f32 * map_zoom_level(zoom);
+    let real_font_size = font_size as i32 / gtk::pango::SCALE;
     let font_style = {
         match descriptor.style() {
             gtk::pango::Style::Italic => "italic",
@@ -280,10 +348,33 @@ fn render_basic_font_settings() -> String {
     };
     format!(
         r#"
+          textview {{
               font-family: "{font_family}";
-              font-size: {font_size}pt;
+              font-size: {real_font_size}pt;
               font-style: {font_style};
               font-weight: {font_weight};
-              "#
+          }}
+        "#
     )
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_map_zoom_level() {
+        let cases = vec![
+            (-6, 0.25), // Cannot go negative or zero
+            (-4, 0.5),
+            (-2, 0.75),
+            (0, 1.0),
+            (1, 1.125),
+            (2, 1.25),
+            (4, 1.5),
+            (8, 2.0),
+            (10, 2.25),
+        ];
+        for (input, output) in cases {
+            assert_eq!(output, super::map_zoom_level(input));
+        }
+    }
 }

--- a/src/widgets/code_view.rs
+++ b/src/widgets/code_view.rs
@@ -16,7 +16,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use glib::{object::ObjectExt, Object};
-use gtk::glib;
+use gtk::{glib, pango::FontDescription, prelude::SettingsExtManual};
+
+use crate::app::CarteroApplication;
 
 mod imp {
     use std::sync::OnceLock;
@@ -26,7 +28,10 @@ mod imp {
     use glib::value::ToValue;
     use gtk::gdk;
     use gtk::gio::SettingsBindFlags;
-    use gtk::prelude::{SettingsExtManual, TextViewExt};
+    #[allow(deprecated)]
+    use gtk::prelude::StyleContextExt;
+    use gtk::prelude::WidgetExt;
+    use gtk::prelude::{SettingsExt, SettingsExtManual, TextViewExt};
     use gtk::subclass::prelude::*;
     use gtk::{glib, WrapMode};
     use sourceview5::prelude::BufferExt;
@@ -34,6 +39,8 @@ mod imp {
     use sourceview5::StyleSchemeManager;
 
     use crate::app::CarteroApplication;
+
+    use super::render_basic_font_settings;
 
     #[derive(Default)]
     pub struct CodeView {}
@@ -65,6 +72,7 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
             self.init_settings();
+            self.init_source_view_css();
             self.init_source_view_style();
         }
     }
@@ -132,6 +140,47 @@ mod imp {
                 .build();
         }
 
+        /// Renders the whole CSS string that will be attached to the widget instance.
+        fn generate_css(&self) -> String {
+            let common_font_settings = render_basic_font_settings();
+            format!(r#"textview {{ {} }}"#, common_font_settings)
+        }
+
+        /// Configures the initial CSS style for this widget, and also setups the callbacks
+        /// to reconsider the CSS style whenever the configuration changes.
+        fn init_source_view_css(&self) {
+            let obj = self.obj();
+
+            /* First, register the CSS provider attached to this view. */
+            let provider = gtk::CssProvider::new();
+            #[allow(deprecated)] // eat shit
+            obj.style_context()
+                .add_provider(&provider, gtk::STYLE_PROVIDER_PRIORITY_APPLICATION);
+
+            /* Set the initial CSS style. */
+            let css = self.generate_css();
+            provider.load_from_string(&css);
+
+            /* Whenever the settings change, we also need to update the font. */
+            let app = CarteroApplication::get();
+            let settings = app.settings();
+            settings.connect_changed(
+                None,
+                glib::clone!(
+                    #[weak(rename_to = imp)]
+                    self,
+                    #[weak]
+                    provider,
+                    move |_, key: &str| {
+                        if key == "use-system-font" || key == "custom-font" {
+                            let css = imp.generate_css();
+                            provider.load_from_string(&css);
+                        }
+                    }
+                ),
+            );
+        }
+
         fn update_source_view_style(&self) {
             let obj = self.obj();
             let dark_mode = adw::StyleManager::default().is_dark();
@@ -186,4 +235,55 @@ impl Default for CodeView {
     fn default() -> Self {
         Object::builder().build()
     }
+}
+
+/// Generates a string with the common CSS rules that apply for setting the font family
+/// based on the font present in the application settings. Will include font family,
+/// size and weight if present.
+fn render_basic_font_settings() -> String {
+    let app = CarteroApplication::get();
+    let settings = app.settings();
+    let system_font = settings.get::<bool>("use-system-font");
+    if system_font {
+        return "".to_string(); // nothing to add
+    }
+
+    // let's get to business
+    let current_font_descriptor = settings.get::<String>("custom-font");
+    let descriptor = FontDescription::from_string(&current_font_descriptor);
+    let font_family: String = descriptor.family().unwrap_or_default().into();
+    let font_size = descriptor.size() / gtk::pango::SCALE;
+    let font_style = {
+        match descriptor.style() {
+            gtk::pango::Style::Italic => "italic",
+            gtk::pango::Style::Oblique => "oblique",
+            _ => "normal",
+        }
+    };
+    let font_weight = {
+        match descriptor.weight() {
+            gtk::pango::Weight::Bold => 700,
+            gtk::pango::Weight::Book => 380,
+            gtk::pango::Weight::Heavy => 900,
+            gtk::pango::Weight::Light => 300,
+            gtk::pango::Weight::Medium => 500,
+            gtk::pango::Weight::Normal => 400,
+            gtk::pango::Weight::Semibold => 600,
+            gtk::pango::Weight::Semilight => 350,
+            gtk::pango::Weight::Thin => 100,
+            gtk::pango::Weight::Ultrabold => 800,
+            gtk::pango::Weight::Ultraheavy => 1000,
+            gtk::pango::Weight::Ultralight => 200,
+            gtk::pango::Weight::__Unknown(i) => i,
+            _ => 400,
+        }
+    };
+    format!(
+        r#"
+              font-family: "{font_family}";
+              font-size: {font_size}pt;
+              font-style: {font_style};
+              font-weight: {font_weight};
+              "#
+    )
 }

--- a/src/widgets/code_view.rs
+++ b/src/widgets/code_view.rs
@@ -28,13 +28,14 @@ mod imp {
     use glib::subclass::Signal;
     use glib::value::ToValue;
     use glib::Properties;
-    use gtk::gdk;
+    use gtk::gdk::ModifierType;
     use gtk::gio::SettingsBindFlags;
     #[allow(deprecated)]
     use gtk::prelude::StyleContextExt;
-    use gtk::prelude::WidgetExt;
+    use gtk::prelude::{EventControllerExt, WidgetExt};
     use gtk::prelude::{SettingsExt, SettingsExtManual, TextViewExt};
     use gtk::subclass::prelude::*;
+    use gtk::{gdk, EventControllerScroll, EventControllerScrollFlags, PropagationPhase};
     use gtk::{glib, WrapMode};
     use sourceview5::prelude::BufferExt;
     use sourceview5::subclass::view::ViewImpl;
@@ -111,6 +112,7 @@ mod imp {
             self.init_settings();
             self.init_source_view_css();
             self.init_source_view_style();
+            self.init_scroll_controller();
         }
     }
 
@@ -121,6 +123,32 @@ mod imp {
     impl ViewImpl for CodeView {}
 
     impl CodeView {
+        fn init_scroll_controller(&self) {
+            let obj = self.obj();
+            let controller = EventControllerScroll::new(EventControllerScrollFlags::VERTICAL);
+            controller.set_propagation_phase(PropagationPhase::Capture);
+            controller.connect_scroll(glib::clone!(
+                #[weak]
+                obj,
+                #[upgrade_or_panic]
+                move |controller: &EventControllerScroll, _dx: f64, dy: f64| {
+                    /* Only interested in CTRL + scroll events. */
+                    let state = controller.current_event_state();
+                    if state == ModifierType::CONTROL_MASK {
+                        if dy > 0.0 {
+                            obj.activate_action("widget.zoom-out", None).unwrap();
+                        } else {
+                            obj.activate_action("widget.zoom-in", None).unwrap();
+                        }
+                        glib::Propagation::Stop
+                    } else {
+                        glib::Propagation::Proceed
+                    }
+                }
+            ));
+            obj.add_controller(controller);
+        }
+
         fn init_settings(&self) {
             let app = CarteroApplication::get();
             let settings = app.settings();

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -197,6 +197,15 @@ mod imp {
         fn init_actions(&self) {
             let obj = self.obj();
 
+            let action_focus_url = SimpleAction::new("focus-url", None);
+            action_focus_url.connect_activate(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |_, _| {
+                    imp.request_url.grab_focus();
+                }
+            ));
+
             let action_request = SimpleAction::new("request", None);
             action_request.connect_activate(glib::clone!(
                 #[weak(rename_to = imp)]
@@ -220,6 +229,7 @@ mod imp {
             .bind(&action_request, "enabled", Some(&*obj));
 
             let action_group = SimpleActionGroup::new();
+            action_group.add_action(&action_focus_url);
             action_group.add_action(&action_request);
             obj.insert_action_group("endpoint", Some(&action_group));
         }


### PR DESCRIPTION
# Motivation

This PR addresses issues #156 and #158 by implementing a couple of feedback suggestions related to key bindings for the endpoint pane designed to make the application more usable with keyboard.

# Changes

- [x] **Pressing Ctrl-L in an endpoint pane should focus the request URL**
This is implemented using a ShortcutController and a simple action that calls grab_focus() because it is easy to do.

The following changes work in couple because they are added at the same time. They require to implement previously the changes to how the codeview gets the custom CSS style.

- [x] **Pressing Ctrl-Plus in a codeview should zoom it in**
- [x] **Pressing Ctrl-Minus in a codeview should zoom it out**
- [x] **Pressing Ctrl-0 in a codeview should reset the zoom**

Don't forget about CSS, which will be added to this PR too.

- [x] **Refactor codeview CSS rules and move them at component level**