### PR TITLE
Fix minor issues with the settings page

### DIFF
--- a/data/ui/settings_dialog.blp
+++ b/data/ui/settings_dialog.blp
@@ -25,7 +25,7 @@ template $CarteroSettingsDialog: Adw.PreferencesDialog {
 
   Adw.PreferencesPage {
     title: _("Application");
-    icon-name: "applications-system";
+    icon-name: "applications-system-symbolic";
 
     Adw.PreferencesGroup {
       title: _("Appearance");
@@ -73,17 +73,19 @@ template $CarteroSettingsDialog: Adw.PreferencesDialog {
 
   Adw.PreferencesPage {
     title: _("HTTP Client");
-    icon-name: "network-transmit-receive";
+    icon-name: "network-transmit-receive-symbolic";
 
     Adw.PreferencesGroup {
       title: _("HTTP Client");
 
       Adw.SwitchRow option_validate_tls {
         title: _("Enforce TLS validation");
+        subtitle: _("Cancel a request if the TLS handshake fails");
       }
 
       Adw.ExpanderRow option_follow_redirects {
         title: _("Follow redirects");
+        subtitle: _("Make follow-up requests if the server returns an HTTP 3xx response");
         show-enable-switch: true;
         enable-expansion: true;
 
@@ -101,7 +103,8 @@ template $CarteroSettingsDialog: Adw.PreferencesDialog {
 
       Adw.SpinRow option_timeout {
         title: _("Request timeout");
-        digits: 3;
+        subtitle: _("Seconds to wait before cancelling the request");
+        digits: 1;
 
         adjustment: Gtk.Adjustment {
           lower: 0;


### PR DESCRIPTION
* Icons for the settings tabs were not symbolic. After this commit, they will use the symbolic variant.
* As reported in https://github.com/danirod/cartero/issues/159, it would be good if the "request timeout" setting indicates that it is measured in seconds.
* Use a request timeout with 1 decimal position. There is no need to make the control as complicated as 3 decimal positions. Even a decimal number seems to much.