### PR TITLE
Add authorization pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -137,6 +143,7 @@ dependencies = [
 name = "cartero"
 version = "0.2.0"
 dependencies = [
+ "base64 0.22.1",
  "formatx",
  "formdata",
  "futures-lite 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ csd = []
 
 [dependencies]
 adw = { version = "0.7.1", package = "libadwaita", features = ["v1_5"] }
+base64 = "0.22.1"
 formatx = "0.2.3"
 formdata = "0.13.0"
 futures-lite = "2.6.0"

--- a/data/cartero.gresource.xml
+++ b/data/cartero.gresource.xml
@@ -3,6 +3,7 @@
   <gresource prefix="/es/danirod/Cartero/">
     <file alias="style.css" compressed="true">style.css</file>
     <file alias="gtk/help-overlay.ui" compressed="true" preprocess="xml-stripblanks">gtk/help_overlay.ui</file>
+    <file alias="authorization_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/authorization_pane.ui</file>
     <file alias="endpoint_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/endpoint_pane.ui</file>
     <file alias="error_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/error_pane.ui</file>
     <file alias="formdata_payload_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/formdata_payload_pane.ui</file>

--- a/data/meson.build
+++ b/data/meson.build
@@ -17,6 +17,7 @@
 
 blueprint_files = [
   'gtk/help_overlay.blp',
+  'ui/authorization_pane.blp',
   'ui/code_export_pane.blp',
   'ui/endpoint_pane.blp',
   'ui/error_pane.blp',

--- a/data/ui/authorization_pane.blp
+++ b/data/ui/authorization_pane.blp
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2024-2025 the Cartero authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Gtk 4.0;
+using Adw 1;
+
+template $CarteroAuthorizationPane: Gtk.Box {
+  orientation: vertical;
+
+  Adw.Clamp {
+    margin-top: 10;
+    vexpand: false;
+
+    Adw.PreferencesGroup {
+      Adw.ComboRow combo {
+        title: _("Authorization method");
+        model: entries;
+        notify::selected => $on_selection_changed() swapped;
+        sensitive: true;
+      }
+    }
+  }
+
+  Gtk.Stack stack {
+    margin-top: 15;
+
+    Gtk.StackPage {
+      name: "none";
+
+      child: Adw.Bin {};
+    }
+
+    Gtk.StackPage {
+      name: "basic";
+
+      child: Adw.Clamp {
+        margin-top: 10;
+        vexpand: false;
+
+        Adw.PreferencesGroup {
+          Adw.EntryRow basic_username {
+            title: _("Username");
+            sensitive: true;
+          }
+
+          Adw.PasswordEntryRow basic_password {
+            title: _("Password");
+            sensitive: true;
+          }
+        }
+      };
+    }
+
+    Gtk.StackPage {
+      name: "bearer";
+
+      child: Adw.Clamp {
+        margin-top: 10;
+        vexpand: false;
+
+        Adw.PreferencesGroup {
+          Adw.PasswordEntryRow bearer_token {
+            title: _("Token");
+            sensitive: true;
+          }
+        }
+      };
+    }
+  }
+}
+
+Gtk.StringList entries {
+  strings [
+    _("(none)"),
+    _("Basic auth"),
+    _("Bearer token"),
+  ]
+}

--- a/data/ui/endpoint_pane.blp
+++ b/data/ui/endpoint_pane.blp
@@ -190,6 +190,29 @@ template $CarteroEndpointPane: Adw.BreakpointBin {
 
             NotebookPage {
               tab: Label {
+                label: _("Authorization");
+              };
+
+              child: ScrolledWindow {
+                hexpand: true;
+                vexpand: true;
+
+                Adw.Clamp {
+                  styles [
+                    "background",
+                  ]
+
+                  maximum-size: 720;
+
+                  $CarteroAuthorizationPane authorization_pane {
+                    read-only: bind template.read-only;
+                  }
+                }
+              };
+            }
+
+            NotebookPage {
+              tab: Label {
                 label: _("Body");
               };
 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -28,6 +28,7 @@ src/app.rs
 src/client/isahc_conv.rs
 src/client/local.rs
 src/client/mod.rs
+src/client/request_auth.rs
 src/client/request_bodies.rs
 src/entities/endpoint_data.rs
 src/entities/key_value.rs

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -5,6 +5,7 @@ data/cartero.desktop.in.in
 data/es.danirod.Cartero.gschema.xml
 
 data/gtk/help_overlay.blp
+data/ui/authorization_pane.blp
 data/ui/code_export_pane.blp
 data/ui/endpoint_pane.blp
 data/ui/error_pane.blp
@@ -42,6 +43,7 @@ src/file.rs
 src/main.rs
 src/objects/key_value_item.rs
 src/objects/mod.rs
+src/widgets/authorization_pane.rs
 src/widgets/code_view.rs
 src/widgets/dialogs.rs
 src/widgets/endpoint_pane.rs

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -32,6 +32,7 @@ src/entities/endpoint_data.rs
 src/entities/key_value.rs
 src/entities/key_value_table.rs
 src/entities/mod.rs
+src/entities/request_authorization.rs
 src/entities/request_export.rs
 src/entities/request_method.rs
 src/entities/request_payload.rs

--- a/po/ca.po
+++ b/po/ca.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 14:34+0100\n"
+"POT-Creation-Date: 2025-03-16 18:14+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -568,7 +568,7 @@ msgstr ""
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
-#: src/file.rs:349
+#: src/file.rs:394
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."

--- a/po/ca.po
+++ b/po/ca.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 18:14+0100\n"
+"POT-Creation-Date: 2025-03-16 18:24+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -213,6 +213,35 @@ msgctxt "shortcuts window"
 msgid "Send request"
 msgstr ""
 
+#: data/ui/authorization_pane.blp:30
+msgid "Authorization method"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:56
+msgid "Username"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:61
+msgid "Password"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:77
+msgid "Token"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:88 data/ui/export_tab.blp:70
+#: data/ui/payload_tab.blp:88
+msgid "(none)"
+msgstr "(nada)"
+
+#: data/ui/authorization_pane.blp:89
+msgid "Basic auth"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:90
+msgid "Bearer token"
+msgstr ""
+
 #: data/ui/code_export_pane.blp:60
 msgid "Copy"
 msgstr "Copiar"
@@ -246,21 +275,21 @@ msgstr "Capçaleres"
 msgid "Variables"
 msgstr "Variables"
 
-#: data/ui/endpoint_pane.blp:193 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:193
+msgid "Authorization"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:216 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Cos"
 
-#: data/ui/endpoint_pane.blp:203
+#: data/ui/endpoint_pane.blp:226
 msgid "Export request"
 msgstr "Exportar petició"
 
 #: data/ui/export_tab.blp:35
 msgid "Export to"
 msgstr "Exportar com"
-
-#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
-msgid "(none)"
-msgstr "(nada)"
 
 #: data/ui/key_value_row.blp:42
 msgid "Name"

--- a/po/cartero.pot
+++ b/po/cartero.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 14:34+0100\n"
+"POT-Creation-Date: 2025-03-16 18:14+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -556,7 +556,7 @@ msgstr ""
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
-#: src/file.rs:349
+#: src/file.rs:394
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."

--- a/po/cartero.pot
+++ b/po/cartero.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 18:14+0100\n"
+"POT-Creation-Date: 2025-03-16 18:24+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -205,6 +205,35 @@ msgctxt "shortcuts window"
 msgid "Send request"
 msgstr ""
 
+#: data/ui/authorization_pane.blp:30
+msgid "Authorization method"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:56
+msgid "Username"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:61
+msgid "Password"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:77
+msgid "Token"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:88 data/ui/export_tab.blp:70
+#: data/ui/payload_tab.blp:88
+msgid "(none)"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:89
+msgid "Basic auth"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:90
+msgid "Bearer token"
+msgstr ""
+
 #: data/ui/code_export_pane.blp:60
 msgid "Copy"
 msgstr ""
@@ -237,20 +266,20 @@ msgstr ""
 msgid "Variables"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:193 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:193
+msgid "Authorization"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:216 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:203
+#: data/ui/endpoint_pane.blp:226
 msgid "Export request"
 msgstr ""
 
 #: data/ui/export_tab.blp:35
 msgid "Export to"
-msgstr ""
-
-#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
-msgid "(none)"
 msgstr ""
 
 #: data/ui/key_value_row.blp:42

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 14:34+0100\n"
+"POT-Creation-Date: 2025-03-16 18:14+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: vesp <vesp@post.cz>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartero/cartero/cs/"
@@ -571,7 +571,7 @@ msgstr ""
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
-#: src/file.rs:349
+#: src/file.rs:394
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 18:14+0100\n"
+"POT-Creation-Date: 2025-03-16 18:24+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: vesp <vesp@post.cz>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartero/cartero/cs/"
@@ -214,6 +214,35 @@ msgctxt "shortcuts window"
 msgid "Send request"
 msgstr "Odeslat požadavek"
 
+#: data/ui/authorization_pane.blp:30
+msgid "Authorization method"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:56
+msgid "Username"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:61
+msgid "Password"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:77
+msgid "Token"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:88 data/ui/export_tab.blp:70
+#: data/ui/payload_tab.blp:88
+msgid "(none)"
+msgstr "(nic)"
+
+#: data/ui/authorization_pane.blp:89
+msgid "Basic auth"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:90
+msgid "Bearer token"
+msgstr ""
+
 #: data/ui/code_export_pane.blp:60
 msgid "Copy"
 msgstr "Kopírovat"
@@ -247,21 +276,21 @@ msgstr "Hlavičky"
 msgid "Variables"
 msgstr "Proměnné"
 
-#: data/ui/endpoint_pane.blp:193 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:193
+msgid "Authorization"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:216 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Tělo"
 
-#: data/ui/endpoint_pane.blp:203
+#: data/ui/endpoint_pane.blp:226
 msgid "Export request"
 msgstr "Exportovat požadavek"
 
 #: data/ui/export_tab.blp:35
 msgid "Export to"
 msgstr "Exportovat do"
-
-#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
-msgid "(none)"
-msgstr "(nic)"
 
 #: data/ui/key_value_row.blp:42
 msgid "Name"

--- a/po/eo.po
+++ b/po/eo.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 18:14+0100\n"
+"POT-Creation-Date: 2025-03-16 18:24+0100\n"
 "PO-Revision-Date: 2024-11-04 17:46+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/cartero/"
@@ -204,6 +204,35 @@ msgctxt "shortcuts window"
 msgid "Send request"
 msgstr ""
 
+#: data/ui/authorization_pane.blp:30
+msgid "Authorization method"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:56
+msgid "Username"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:61
+msgid "Password"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:77
+msgid "Token"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:88 data/ui/export_tab.blp:70
+#: data/ui/payload_tab.blp:88
+msgid "(none)"
+msgstr "(nenio)"
+
+#: data/ui/authorization_pane.blp:89
+msgid "Basic auth"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:90
+msgid "Bearer token"
+msgstr ""
+
 #: data/ui/code_export_pane.blp:60
 msgid "Copy"
 msgstr "Kopii"
@@ -236,21 +265,21 @@ msgstr "Kapoj"
 msgid "Variables"
 msgstr "Variabloj"
 
-#: data/ui/endpoint_pane.blp:193 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:193
+msgid "Authorization"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:216 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Korpo"
 
-#: data/ui/endpoint_pane.blp:203
+#: data/ui/endpoint_pane.blp:226
 msgid "Export request"
 msgstr ""
 
 #: data/ui/export_tab.blp:35
 msgid "Export to"
 msgstr ""
-
-#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
-msgid "(none)"
-msgstr "(nenio)"
 
 #: data/ui/key_value_row.blp:42
 msgid "Name"

--- a/po/eo.po
+++ b/po/eo.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 14:34+0100\n"
+"POT-Creation-Date: 2025-03-16 18:14+0100\n"
 "PO-Revision-Date: 2024-11-04 17:46+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/cartero/"
@@ -555,7 +555,7 @@ msgstr ""
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
-#: src/file.rs:349
+#: src/file.rs:394
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 18:14+0100\n"
+"POT-Creation-Date: 2025-03-16 18:24+0100\n"
 "PO-Revision-Date: 2025-03-06 22:02+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -214,6 +214,35 @@ msgctxt "shortcuts window"
 msgid "Send request"
 msgstr "Enviar petición"
 
+#: data/ui/authorization_pane.blp:30
+msgid "Authorization method"
+msgstr "Método de autorización"
+
+#: data/ui/authorization_pane.blp:56
+msgid "Username"
+msgstr "Usuario"
+
+#: data/ui/authorization_pane.blp:61
+msgid "Password"
+msgstr "Contraseña"
+
+#: data/ui/authorization_pane.blp:77
+msgid "Token"
+msgstr "Token"
+
+#: data/ui/authorization_pane.blp:88 data/ui/export_tab.blp:70
+#: data/ui/payload_tab.blp:88
+msgid "(none)"
+msgstr "(nada)"
+
+#: data/ui/authorization_pane.blp:89
+msgid "Basic auth"
+msgstr "Autorización básica"
+
+#: data/ui/authorization_pane.blp:90
+msgid "Bearer token"
+msgstr "Token bearer"
+
 #: data/ui/code_export_pane.blp:60
 msgid "Copy"
 msgstr "Copiar"
@@ -246,21 +275,21 @@ msgstr "Cabeceras"
 msgid "Variables"
 msgstr "Variables"
 
-#: data/ui/endpoint_pane.blp:193 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:193
+msgid "Authorization"
+msgstr "Autorización"
+
+#: data/ui/endpoint_pane.blp:216 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Cuerpo"
 
-#: data/ui/endpoint_pane.blp:203
+#: data/ui/endpoint_pane.blp:226
 msgid "Export request"
 msgstr "Exportar petición"
 
 #: data/ui/export_tab.blp:35
 msgid "Export to"
 msgstr "Exportar como"
-
-#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
-msgid "(none)"
-msgstr "(nada)"
 
 #: data/ui/key_value_row.blp:42
 msgid "Name"

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 14:34+0100\n"
+"POT-Creation-Date: 2025-03-16 18:14+0100\n"
 "PO-Revision-Date: 2025-03-06 22:02+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -571,7 +571,7 @@ msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 "El archivo está corrupto o no contiene datos válidos para esta aplicación"
 
-#: src/file.rs:349
+#: src/file.rs:394
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 18:14+0100\n"
+"POT-Creation-Date: 2025-03-16 18:24+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: Altero <aurelien.reinert4@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -207,6 +207,35 @@ msgctxt "shortcuts window"
 msgid "Send request"
 msgstr "Envoyer la requête"
 
+#: data/ui/authorization_pane.blp:30
+msgid "Authorization method"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:56
+msgid "Username"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:61
+msgid "Password"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:77
+msgid "Token"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:88 data/ui/export_tab.blp:70
+#: data/ui/payload_tab.blp:88
+msgid "(none)"
+msgstr "(aucun)"
+
+#: data/ui/authorization_pane.blp:89
+msgid "Basic auth"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:90
+msgid "Bearer token"
+msgstr ""
+
 #: data/ui/code_export_pane.blp:60
 msgid "Copy"
 msgstr "Copier"
@@ -240,21 +269,21 @@ msgstr "En-têtes"
 msgid "Variables"
 msgstr ""
 
-#: data/ui/endpoint_pane.blp:193 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:193
+msgid "Authorization"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:216 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Corps"
 
-#: data/ui/endpoint_pane.blp:203
+#: data/ui/endpoint_pane.blp:226
 msgid "Export request"
 msgstr "Exporter la requête"
 
 #: data/ui/export_tab.blp:35
 msgid "Export to"
 msgstr "Exporter vers"
-
-#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
-msgid "(none)"
-msgstr "(aucun)"
 
 #: data/ui/key_value_row.blp:42
 msgid "Name"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 14:34+0100\n"
+"POT-Creation-Date: 2025-03-16 18:14+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: Altero <aurelien.reinert4@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -564,7 +564,7 @@ msgstr ""
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
-#: src/file.rs:349
+#: src/file.rs:394
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 14:34+0100\n"
+"POT-Creation-Date: 2025-03-16 18:14+0100\n"
 "PO-Revision-Date: 2025-02-01 23:50-0300\n"
 "Last-Translator: john peter <johnppetersa@gmail.com>\n"
 "Language-Team: \n"
@@ -572,7 +572,7 @@ msgstr ""
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
-#: src/file.rs:349
+#: src/file.rs:394
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 18:14+0100\n"
+"POT-Creation-Date: 2025-03-16 18:24+0100\n"
 "PO-Revision-Date: 2025-02-01 23:50-0300\n"
 "Last-Translator: john peter <johnppetersa@gmail.com>\n"
 "Language-Team: \n"
@@ -215,6 +215,35 @@ msgctxt "shortcuts window"
 msgid "Send request"
 msgstr "Enviar solicitação"
 
+#: data/ui/authorization_pane.blp:30
+msgid "Authorization method"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:56
+msgid "Username"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:61
+msgid "Password"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:77
+msgid "Token"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:88 data/ui/export_tab.blp:70
+#: data/ui/payload_tab.blp:88
+msgid "(none)"
+msgstr "(nenhum)"
+
+#: data/ui/authorization_pane.blp:89
+msgid "Basic auth"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:90
+msgid "Bearer token"
+msgstr ""
+
 #: data/ui/code_export_pane.blp:60
 msgid "Copy"
 msgstr "Cópia"
@@ -248,21 +277,21 @@ msgstr "Cabeçalhos"
 msgid "Variables"
 msgstr "Variáveis"
 
-#: data/ui/endpoint_pane.blp:193 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:193
+msgid "Authorization"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:216 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Corpo"
 
-#: data/ui/endpoint_pane.blp:203
+#: data/ui/endpoint_pane.blp:226
 msgid "Export request"
 msgstr "Solicitação de exportação"
 
 #: data/ui/export_tab.blp:35
 msgid "Export to"
 msgstr "Exportar para"
-
-#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
-msgid "(none)"
-msgstr "(nenhum)"
 
 #: data/ui/key_value_row.blp:42
 msgid "Name"

--- a/po/ro.po
+++ b/po/ro.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 18:14+0100\n"
+"POT-Creation-Date: 2025-03-16 18:24+0100\n"
 "PO-Revision-Date: 2024-07-30 15:00+0200\n"
 "Last-Translator:  <>\n"
 "Language-Team: Romanian\n"
@@ -203,6 +203,35 @@ msgctxt "shortcuts window"
 msgid "Send request"
 msgstr ""
 
+#: data/ui/authorization_pane.blp:30
+msgid "Authorization method"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:56
+msgid "Username"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:61
+msgid "Password"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:77
+msgid "Token"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:88 data/ui/export_tab.blp:70
+#: data/ui/payload_tab.blp:88
+msgid "(none)"
+msgstr "(niciunul)"
+
+#: data/ui/authorization_pane.blp:89
+msgid "Basic auth"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:90
+msgid "Bearer token"
+msgstr ""
+
 #: data/ui/code_export_pane.blp:60
 msgid "Copy"
 msgstr ""
@@ -236,21 +265,21 @@ msgstr "Antetele"
 msgid "Variables"
 msgstr "Variabilele"
 
-#: data/ui/endpoint_pane.blp:193 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:193
+msgid "Authorization"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:216 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Corpul"
 
-#: data/ui/endpoint_pane.blp:203
+#: data/ui/endpoint_pane.blp:226
 msgid "Export request"
 msgstr ""
 
 #: data/ui/export_tab.blp:35
 msgid "Export to"
 msgstr ""
-
-#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
-msgid "(none)"
-msgstr "(niciunul)"
 
 #: data/ui/key_value_row.blp:42
 msgid "Name"

--- a/po/ro.po
+++ b/po/ro.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 14:34+0100\n"
+"POT-Creation-Date: 2025-03-16 18:14+0100\n"
 "PO-Revision-Date: 2024-07-30 15:00+0200\n"
 "Last-Translator:  <>\n"
 "Language-Team: Romanian\n"
@@ -558,7 +558,7 @@ msgstr ""
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
-#: src/file.rs:349
+#: src/file.rs:394
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 18:14+0100\n"
+"POT-Creation-Date: 2025-03-16 18:24+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -215,6 +215,35 @@ msgctxt "shortcuts window"
 msgid "Send request"
 msgstr "Отправить запрос"
 
+#: data/ui/authorization_pane.blp:30
+msgid "Authorization method"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:56
+msgid "Username"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:61
+msgid "Password"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:77
+msgid "Token"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:88 data/ui/export_tab.blp:70
+#: data/ui/payload_tab.blp:88
+msgid "(none)"
+msgstr "(нет)"
+
+#: data/ui/authorization_pane.blp:89
+msgid "Basic auth"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:90
+msgid "Bearer token"
+msgstr ""
+
 #: data/ui/code_export_pane.blp:60
 msgid "Copy"
 msgstr ""
@@ -248,21 +277,21 @@ msgstr "Заголовки"
 msgid "Variables"
 msgstr "Переменные"
 
-#: data/ui/endpoint_pane.blp:193 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:193
+msgid "Authorization"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:216 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "Тело"
 
-#: data/ui/endpoint_pane.blp:203
+#: data/ui/endpoint_pane.blp:226
 msgid "Export request"
 msgstr ""
 
 #: data/ui/export_tab.blp:35
 msgid "Export to"
 msgstr ""
-
-#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
-msgid "(none)"
-msgstr "(нет)"
 
 #: data/ui/key_value_row.blp:42
 msgid "Name"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 14:34+0100\n"
+"POT-Creation-Date: 2025-03-16 18:14+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -570,7 +570,7 @@ msgstr ""
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
-#: src/file.rs:349
+#: src/file.rs:394
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 18:14+0100\n"
+"POT-Creation-Date: 2025-03-16 18:24+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartero/cartero/ta/"
@@ -213,6 +213,35 @@ msgctxt "shortcuts window"
 msgid "Send request"
 msgstr "கோரிக்கையை அனுப்பவும்"
 
+#: data/ui/authorization_pane.blp:30
+msgid "Authorization method"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:56
+msgid "Username"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:61
+msgid "Password"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:77
+msgid "Token"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:88 data/ui/export_tab.blp:70
+#: data/ui/payload_tab.blp:88
+msgid "(none)"
+msgstr "(எதுவுமில்லை)"
+
+#: data/ui/authorization_pane.blp:89
+msgid "Basic auth"
+msgstr ""
+
+#: data/ui/authorization_pane.blp:90
+msgid "Bearer token"
+msgstr ""
+
 #: data/ui/code_export_pane.blp:60
 msgid "Copy"
 msgstr "நகலெடு"
@@ -246,21 +275,21 @@ msgstr "தலைப்பிகளுக்கு"
 msgid "Variables"
 msgstr "மாறிகள்"
 
-#: data/ui/endpoint_pane.blp:193 data/ui/response_panel.blp:53
+#: data/ui/endpoint_pane.blp:193
+msgid "Authorization"
+msgstr ""
+
+#: data/ui/endpoint_pane.blp:216 data/ui/response_panel.blp:53
 msgid "Body"
 msgstr "உடல்"
 
-#: data/ui/endpoint_pane.blp:203
+#: data/ui/endpoint_pane.blp:226
 msgid "Export request"
 msgstr "ஏற்றுமதி கோரிக்கை"
 
 #: data/ui/export_tab.blp:35
 msgid "Export to"
 msgstr "ஏற்றுமதி"
-
-#: data/ui/export_tab.blp:70 data/ui/payload_tab.blp:88
-msgid "(none)"
-msgstr "(எதுவுமில்லை)"
 
 #: data/ui/key_value_row.blp:42
 msgid "Name"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 14:34+0100\n"
+"POT-Creation-Date: 2025-03-16 18:14+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartero/cartero/ta/"
@@ -567,7 +567,7 @@ msgstr ""
 msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
-#: src/file.rs:349
+#: src/file.rs:394
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."

--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -188,6 +188,7 @@ mod tests {
             variables,
             body,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         // Bind the request.
@@ -219,6 +220,7 @@ mod tests {
             variables,
             body,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         let bound = BoundRequest::try_from(endpoint).unwrap();
@@ -242,6 +244,7 @@ mod tests {
             variables,
             body,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         let bound = BoundRequest::try_from(endpoint).unwrap();
@@ -273,6 +276,7 @@ mod tests {
             variables,
             body,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         // Bind the request.
@@ -291,6 +295,7 @@ mod tests {
             variables: KeyValueTable::default(),
             body: RequestPayload::None,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
         let result = BoundRequest::try_from(endpoint);
         assert!(result.is_err_and(|e| e == RequestPreconditionError::MissingProtocol));
@@ -308,6 +313,7 @@ mod tests {
             variables: KeyValueTable::default(),
             body: RequestPayload::None,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
         let result = BoundRequest::try_from(endpoint);
         assert!(result.is_err_and(
@@ -327,6 +333,7 @@ mod tests {
             variables: KeyValueTable::default(),
             body: RequestPayload::None,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
         let result = BoundRequest::try_from(endpoint).unwrap();
         assert_eq!(result.url, "https://example.com/api/v1/users");
@@ -344,6 +351,7 @@ mod tests {
             variables: KeyValueTable::default(),
             body: RequestPayload::None,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
         let result = BoundRequest::try_from(endpoint).unwrap();
         assert_eq!(result.url, "https://example.com/api/v1/users");
@@ -361,6 +369,7 @@ mod tests {
             variables: KeyValueTable::default(),
             body: RequestPayload::None,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
         let result = BoundRequest::try_from(endpoint).unwrap();
         assert_eq!(result.url, "https://example.com/api/v1/users");

--- a/src/client/local.rs
+++ b/src/client/local.rs
@@ -23,7 +23,7 @@ use crate::{
     error::RequestPreconditionError,
 };
 
-use super::request_bodies::BoundRequestBody;
+use super::{request_auth::BoundAuthorization, request_bodies::BoundRequestBody};
 
 #[derive(Default, Debug, Clone)]
 pub struct BoundRequest {
@@ -67,10 +67,12 @@ impl TryFrom<EndpointData> for BoundRequest {
         let headers = value.headers.render(&processor)?;
 
         let body = BoundRequestBody::try_from(&value)?;
+        let auth = BoundAuthorization::try_from(&value)?;
 
         // Use the request body headers to craft the real request headers.
         let headers = {
             let mut all_headers = HashMap::from_iter(body.headers);
+            all_headers.extend(auth.headers);
             all_headers.extend(headers.to_active_pairs());
             all_headers
         };

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -17,6 +17,7 @@
 
 mod isahc_conv;
 mod local;
+mod request_auth;
 mod request_bodies;
 
 pub use isahc_conv::build_request;

--- a/src/client/request_auth.rs
+++ b/src/client/request_auth.rs
@@ -1,0 +1,58 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use base64::prelude::*;
+
+use crate::{
+    entities::{EndpointData, RequestAuthorization},
+    error::RequestPreconditionError,
+};
+
+pub(super) struct BoundAuthorization {
+    pub headers: Vec<(String, String)>,
+}
+
+impl TryFrom<&EndpointData> for BoundAuthorization {
+    type Error = RequestPreconditionError;
+
+    fn try_from(value: &EndpointData) -> Result<Self, Self::Error> {
+        let processor = value.template_processor();
+
+        let authorization = match &value.authorization {
+            RequestAuthorization::None => None,
+            RequestAuthorization::Basic { username, password } => {
+                let username = processor.render(&username)?;
+                let password = processor.render(&password)?;
+                let hash = BASE64_STANDARD.encode(format!("{username}:{password}"));
+                let encoded = format!("Basic {hash}");
+                Some(encoded.to_string())
+            }
+            RequestAuthorization::Bearer(token) => {
+                let token = processor.render(&token)?;
+                let encoded = format!("Bearer {token}");
+                Some(encoded.to_string())
+            }
+        };
+
+        let headers = match authorization {
+            None => vec![],
+            Some(value) => vec![("Authorization".to_string(), value)],
+        };
+
+        Ok(Self { headers })
+    }
+}

--- a/src/client/request_bodies.rs
+++ b/src/client/request_bodies.rs
@@ -137,7 +137,7 @@ impl TryFrom<&EndpointData> for BoundRequestBody {
 
 #[cfg(test)]
 mod tests {
-    use crate::entities::KeyValueTable;
+    use crate::entities::{KeyValueTable, RequestAuthorization};
 
     use super::*;
 
@@ -155,6 +155,7 @@ mod tests {
             variables: KeyValueTable::new(&variables),
             body: RequestPayload::Urlencoded(KeyValueTable::new(&body)),
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         let serial = BoundRequestBody::try_from(&endpoint).unwrap();
@@ -185,6 +186,7 @@ mod tests {
             variables: KeyValueTable::default(),
             body: RequestPayload::Urlencoded(KeyValueTable::new(&body)),
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
         let result = BoundRequestBody::try_from(&endpoint);
         assert_eq!(
@@ -211,6 +213,7 @@ mod tests {
                 params: KeyValueTable::new(&body),
             },
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         let serial = BoundRequestBody::try_from(&endpoint).unwrap();
@@ -257,6 +260,7 @@ mod tests {
                 params: KeyValueTable::new(&body),
             },
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         let result = BoundRequestBody::try_from(&endpoint);
@@ -282,6 +286,7 @@ mod tests {
             variables: KeyValueTable::new(&variables),
             body,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         let result = BoundRequestBody::try_from(&endpoint).unwrap();
@@ -304,6 +309,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
             body,
         };
 
@@ -327,6 +333,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::new(&variables),
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
             body,
         };
 
@@ -353,6 +360,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
             body,
         };
 
@@ -376,6 +384,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::new(&variables),
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
             body,
         };
 
@@ -402,6 +411,7 @@ mod tests {
             headers: KeyValueTable::default(),
             variables: KeyValueTable::default(),
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
             body,
         };
 

--- a/src/entities/endpoint_data.rs
+++ b/src/entities/endpoint_data.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 use srtemplate::SrTemplate;
 
-use super::{KeyValueTable, RequestMethod, RequestPayload};
+use super::{KeyValueTable, RequestAuthorization, RequestMethod, RequestPayload};
 
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct EndpointData {
@@ -29,6 +29,7 @@ pub struct EndpointData {
     pub headers: KeyValueTable,
     pub variables: KeyValueTable,
     pub body: RequestPayload,
+    pub authorization: RequestAuthorization,
 }
 
 impl EndpointData {

--- a/src/entities/request_authorization.rs
+++ b/src/entities/request_authorization.rs
@@ -15,20 +15,13 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-mod endpoint_data;
-mod key_value;
-mod key_value_table;
-mod request_authorization;
-mod request_export;
-mod request_method;
-mod request_payload;
-mod response_data;
-
-pub use endpoint_data::EndpointData;
-pub use key_value::KeyValue;
-pub use key_value_table::KeyValueTable;
-pub use request_authorization::RequestAuthorization;
-pub use request_export::RequestExportType;
-pub use request_method::RequestMethod;
-pub use request_payload::{RawEncoding, RequestPayload};
-pub use response_data::ResponseData;
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
+pub enum RequestAuthorization {
+    #[default]
+    None,
+    Basic {
+        username: String,
+        password: String,
+    },
+    Bearer(String),
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::app::CarteroApplication;
 use crate::entities::{
-    EndpointData, KeyValue, KeyValueTable, RawEncoding, RequestMethod, RequestPayload,
+    EndpointData, KeyValue, KeyValueTable, RawEncoding, RequestAuthorization, RequestMethod,
+    RequestPayload,
 };
 use crate::error::{FileLoadError, FileSaveError};
 
@@ -290,6 +291,42 @@ impl From<FileBody> for RequestPayload {
     }
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(tag = "type")]
+enum FileAuthorization {
+    #[serde(rename = "none")]
+    #[default]
+    None,
+
+    #[serde(rename = "basic")]
+    Basic { username: String, password: String },
+
+    #[serde(rename = "bearer")]
+    Bearer { token: String },
+}
+
+impl From<RequestAuthorization> for FileAuthorization {
+    fn from(value: RequestAuthorization) -> Self {
+        match value {
+            RequestAuthorization::None => Self::None,
+            RequestAuthorization::Basic { username, password } => {
+                Self::Basic { username, password }
+            }
+            RequestAuthorization::Bearer(token) => Self::Bearer { token },
+        }
+    }
+}
+
+impl From<FileAuthorization> for RequestAuthorization {
+    fn from(value: FileAuthorization) -> Self {
+        match value {
+            FileAuthorization::None => Self::None,
+            FileAuthorization::Basic { username, password } => Self::Basic { username, password },
+            FileAuthorization::Bearer { token } => Self::Bearer(token),
+        }
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 struct RequestFile {
     version: usize,
@@ -298,6 +335,7 @@ struct RequestFile {
     body: Option<FileBody>,
     headers: Option<FileTable<FieldValue>>,
     variables: Option<FileTable<FieldValue>>,
+    authorization: Option<FileAuthorization>,
     #[serde(rename = "inactive-params")]
     inactive_params: Option<FileTable<QueryValue>>,
 }
@@ -311,6 +349,12 @@ impl From<EndpointData> for RequestFile {
         };
         let headers = value.headers.into();
         let variables = value.variables.into();
+
+        let authorization = value.authorization.into();
+        let authorization = match authorization {
+            FileAuthorization::None => None,
+            other => Some(other),
+        };
 
         let inactive_params: Vec<_> = value
             .parameters
@@ -328,6 +372,7 @@ impl From<EndpointData> for RequestFile {
             headers: Some(headers),
             variables: Some(variables),
             inactive_params: Some(inactive_params.into()),
+            authorization,
         }
     }
 }
@@ -462,6 +507,7 @@ impl From<RequestFile> for EndpointLoadResult {
         let headers = value.headers.unwrap_or_default().into();
         let variables = value.variables.unwrap_or_default().into();
         let inactive_params = value.inactive_params.unwrap_or_default().into();
+        let authorization = value.authorization.unwrap_or_default().into();
 
         /* Therefore we can craft the response. */
         let request = EndpointData {
@@ -471,6 +517,7 @@ impl From<RequestFile> for EndpointLoadResult {
             variables,
             headers,
             parameters: inactive_params,
+            authorization,
         };
 
         /* The result depends on whether there are tags. */
@@ -551,7 +598,8 @@ mod tests {
 
     use crate::{
         entities::{
-            EndpointData, KeyValue, KeyValueTable, RawEncoding, RequestMethod, RequestPayload,
+            EndpointData, KeyValue, KeyValueTable, RawEncoding, RequestAuthorization,
+            RequestMethod, RequestPayload,
         },
         error::FileLoadError,
         file::{EndpointLoadResult, FileWarningTag},
@@ -970,6 +1018,7 @@ Accept = 'text/html'
             variables: KeyValueTable::default(),
             body,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         let content = super::write_endpoint_string(&r).unwrap();
@@ -1001,6 +1050,7 @@ Accept = 'text/html'
             variables: KeyValueTable::default(),
             body,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         let content = super::write_endpoint_string(&r).unwrap();
@@ -1052,6 +1102,7 @@ body = 'hello'
             variables: KeyValueTable::default(),
             body,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         let content = super::write_endpoint_string(&r).unwrap();
@@ -1110,6 +1161,7 @@ body = 'hello'
             variables,
             body,
             parameters: KeyValueTable::default(),
+            authorization: RequestAuthorization::default(),
         };
 
         let content = super::write_endpoint_string(&r).unwrap();
@@ -1137,5 +1189,119 @@ body = 'hello'
             ]),
             parsed.variables
         );
+    }
+
+    #[test]
+    fn test_serializes_empty_authorization() {
+        let data = EndpointData {
+            url: "https://www.example.com".into(),
+            method: RequestMethod::Get,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            parameters: KeyValueTable::default(),
+            body: RequestPayload::default(),
+            authorization: RequestAuthorization::default(),
+        };
+
+        let content = super::write_endpoint_string(&data).unwrap();
+        assert!(content.contains("url = \"https://www.example.com\""));
+        assert!(!content.contains("authorization"));
+    }
+
+    #[test]
+    fn test_serializes_basic_authorization() {
+        let data = EndpointData {
+            url: "https://www.example.com".into(),
+            method: RequestMethod::Get,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            parameters: KeyValueTable::default(),
+            body: RequestPayload::default(),
+            authorization: RequestAuthorization::Basic {
+                username: "root".into(),
+                password: "admin".into(),
+            },
+        };
+
+        let content = super::write_endpoint_string(&data).unwrap();
+        assert!(content.contains("url = \"https://www.example.com\""));
+        assert!(content.contains("[authorization]"));
+        assert!(content.contains("type = \"basic\""));
+        assert!(content.contains("username = \"root\""));
+        assert!(content.contains("password = \"admin\""));
+    }
+
+    #[test]
+    fn test_serializes_bearer_authorization() {
+        let data = EndpointData {
+            url: "https://www.example.com".into(),
+            method: RequestMethod::Get,
+            headers: KeyValueTable::default(),
+            variables: KeyValueTable::default(),
+            parameters: KeyValueTable::default(),
+            body: RequestPayload::default(),
+            authorization: RequestAuthorization::Bearer("4uth0r1z4t10n_t0k3n".into()),
+        };
+
+        let content = super::write_endpoint_string(&data).unwrap();
+        assert!(content.contains("url = \"https://www.example.com\""));
+        assert!(content.contains("[authorization]"));
+        assert!(content.contains("type = \"bearer\""));
+        assert!(content.contains("token = \"4uth0r1z4t10n_t0k3n\""));
+    }
+
+    #[test]
+    fn test_deserializes_empty_auth() {
+        let toml = "
+            version = 1
+            url = 'https://www.example.com'
+            method = 'GET'
+        ";
+        let EndpointLoadResult::Success(endpoint) = super::read_endpoint_string(toml) else {
+            panic!("wrong read");
+        };
+        assert_eq!(RequestAuthorization::None, endpoint.authorization);
+    }
+
+    #[test]
+    fn test_deserializes_basic_auth() {
+        let toml = "
+            version = 1
+            url = 'https://www.example.com'
+            method = 'GET'
+
+            [authorization]
+            type = 'basic'
+            username = 'root'
+            password = 'admin'
+        ";
+        let EndpointLoadResult::Success(endpoint) = super::read_endpoint_string(toml) else {
+            panic!("wrong read");
+        };
+        let RequestAuthorization::Basic { username, password } = endpoint.authorization else {
+            panic!("wrong type");
+        };
+        assert_eq!("root", username);
+        assert_eq!("admin", password);
+    }
+
+    #[test]
+    fn test_deserializes_bearer_auth() {
+        let toml = "
+            version = 1
+            url = 'https://www.example.com'
+            method = 'GET'
+
+            [authorization]
+            type = 'bearer'
+            token = '4uth0r1z4t10n_t0k3n'
+        ";
+        let EndpointLoadResult::Success(endpoint) = super::read_endpoint_string(toml) else {
+            panic!("wrong read");
+        };
+        let RequestAuthorization::Bearer(token) = endpoint.authorization else {
+            panic!("wrong type");
+        };
+        assert_eq!("4uth0r1z4t10n_t0k3n", token);
     }
 }

--- a/src/widgets/authorization_pane.rs
+++ b/src/widgets/authorization_pane.rs
@@ -1,0 +1,270 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::sync::OnceLock;
+
+use glib::{object::ObjectExt, subclass::types::ObjectSubclassIsExt};
+use gtk::glib;
+
+use crate::entities::RequestAuthorization;
+
+mod imp {
+    use std::cell::RefCell;
+    use std::sync::OnceLock;
+
+    use adw::prelude::ComboRowExt;
+    use glib::subclass::{InitializingObject, Signal};
+    use glib::Properties;
+    use gtk::glib;
+    use gtk::prelude::{EditableExt, ObjectExt};
+    use gtk::subclass::prelude::*;
+    use gtk::CompositeTemplate;
+
+    use crate::entities::RequestAuthorization;
+
+    use super::AuthorizationMethod;
+
+    #[derive(Default, CompositeTemplate, Properties)]
+    #[template(resource = "/es/danirod/Cartero/authorization_pane.ui")]
+    #[properties(wrapper_type = super::AuthorizationPane)]
+    pub struct AuthorizationPane {
+        #[template_child]
+        combo: TemplateChild<adw::ComboRow>,
+
+        #[template_child]
+        stack: TemplateChild<gtk::Stack>,
+
+        #[template_child]
+        basic_username: TemplateChild<adw::EntryRow>,
+
+        #[template_child]
+        basic_password: TemplateChild<adw::PasswordEntryRow>,
+
+        #[template_child]
+        bearer_token: TemplateChild<adw::PasswordEntryRow>,
+
+        #[property(get, set, name = "read-only")]
+        read_only: RefCell<bool>,
+
+        #[property(
+            get,
+            set,
+            name = "auth-method",
+            builder(AuthorizationMethod::default())
+        )]
+        auth_method: RefCell<AuthorizationMethod>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for AuthorizationPane {
+        const NAME: &'static str = "CarteroAuthorizationPane";
+        type Type = super::AuthorizationPane;
+        type ParentType = gtk::Box;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+            klass.bind_template_callbacks();
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    #[glib::derived_properties]
+    impl ObjectImpl for AuthorizationPane {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            self.init_events();
+        }
+
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| vec![Signal::builder("changed").build()])
+        }
+    }
+
+    impl WidgetImpl for AuthorizationPane {}
+
+    impl BoxImpl for AuthorizationPane {}
+
+    #[gtk::template_callbacks]
+    impl AuthorizationPane {
+        fn init_events(&self) {
+            let obj = self.obj();
+            obj.connect_auth_method_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |pane: &super::AuthorizationPane| {
+                    let method = pane.auth_method();
+                    imp.on_auth_method_changed(method);
+                    pane.emit_by_name::<()>("changed", &[]);
+                }
+            ));
+
+            self.combo.connect_selected_notify(glib::clone!(
+                #[weak(rename_to = pane)]
+                self,
+                move |_| {
+                    pane.obj().emit_by_name::<()>("changed", &[]);
+                }
+            ));
+
+            self.basic_username.connect_changed(glib::clone!(
+                #[weak(rename_to = pane)]
+                self,
+                move |_| {
+                    pane.obj().emit_by_name::<()>("changed", &[]);
+                }
+            ));
+
+            self.basic_password.connect_changed(glib::clone!(
+                #[weak(rename_to = pane)]
+                self,
+                move |_| {
+                    pane.obj().emit_by_name::<()>("changed", &[]);
+                }
+            ));
+
+            self.bearer_token.connect_changed(glib::clone!(
+                #[weak(rename_to = pane)]
+                self,
+                move |_| {
+                    pane.obj().emit_by_name::<()>("changed", &[]);
+                }
+            ));
+        }
+
+        fn current_dropdown_method(&self) -> AuthorizationMethod {
+            let n_item = self.combo.selected();
+            AuthorizationMethod::types()[n_item as usize]
+        }
+
+        fn on_auth_method_changed(&self, method: AuthorizationMethod) {
+            // update the value presented in the combobox if needed
+            if self.current_dropdown_method() != method {
+                let pos = AuthorizationMethod::types()
+                    .iter()
+                    .position(|&t| t == method)
+                    .unwrap();
+                self.combo.set_selected(pos as u32);
+            }
+
+            // update the currently visible pane if needed
+            let new_stack_child = match method {
+                AuthorizationMethod::None => "none",
+                AuthorizationMethod::Bearer => "bearer",
+                AuthorizationMethod::Basic => "basic",
+            };
+            if !self
+                .stack
+                .visible_child_name()
+                .is_some_and(|m| m == new_stack_child)
+            {
+                self.stack.set_visible_child_name(new_stack_child);
+            }
+        }
+
+        // dropdown -> prop
+        #[template_callback]
+        fn on_selection_changed(&self) {
+            let obj = self.obj();
+            let method = self.current_dropdown_method();
+            if obj.auth_method() != method {
+                obj.set_auth_method(method);
+            }
+        }
+
+        pub fn assign_authorization(&self, auth: &RequestAuthorization) {
+            let obj = self.obj();
+            match auth {
+                RequestAuthorization::None => {
+                    obj.set_auth_method(AuthorizationMethod::None);
+                }
+                RequestAuthorization::Basic { username, password } => {
+                    obj.set_auth_method(AuthorizationMethod::Basic);
+                    self.basic_username.set_text(&username);
+                    self.basic_password.set_text(&password);
+                }
+                RequestAuthorization::Bearer(token) => {
+                    obj.set_auth_method(AuthorizationMethod::Bearer);
+                    self.bearer_token.set_text(&token);
+                }
+            }
+        }
+
+        pub fn extract_authorization(&self) -> RequestAuthorization {
+            let obj = self.obj();
+            match obj.auth_method() {
+                AuthorizationMethod::None => RequestAuthorization::None,
+                AuthorizationMethod::Basic => {
+                    let username = self.basic_username.text().to_string();
+                    let password = self.basic_password.text().to_string();
+                    RequestAuthorization::Basic { username, password }
+                }
+                AuthorizationMethod::Bearer => {
+                    let token = self.bearer_token.text().to_string();
+                    RequestAuthorization::Bearer(token)
+                }
+            }
+        }
+    }
+}
+
+glib::wrapper! {
+    pub struct AuthorizationPane(ObjectSubclass<imp::AuthorizationPane>)
+        @extends gtk::Widget, gtk::Box,
+        @implements gtk::Buildable;
+}
+
+impl AuthorizationPane {
+    pub fn connect_changed<F: Fn(&Self) + 'static>(&self, f: F) -> glib::SignalHandlerId {
+        self.connect_closure(
+            "changed",
+            true,
+            glib::closure_local!(|ref pane| {
+                f(pane);
+            }),
+        )
+    }
+
+    pub fn set_authorization(&self, auth: &RequestAuthorization) {
+        let imp = self.imp();
+        imp.assign_authorization(auth)
+    }
+
+    pub fn authorization(&self) -> RequestAuthorization {
+        let imp = self.imp();
+        imp.extract_authorization()
+    }
+}
+#[derive(Debug, Copy, Clone, Default, PartialEq, Eq, glib::Enum)]
+#[enum_type(name = "CarteroAuthorizationMethod")]
+pub enum AuthorizationMethod {
+    #[default]
+    None,
+    Basic,
+    Bearer,
+}
+
+impl AuthorizationMethod {
+    pub fn types() -> &'static [Self] {
+        static TYPES: OnceLock<Vec<AuthorizationMethod>> = OnceLock::new();
+        TYPES.get_or_init(|| vec![Self::None, Self::Basic, Self::Bearer])
+    }
+}

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -40,13 +40,12 @@ mod imp {
 
     use crate::app::CarteroApplication;
     use crate::client::BoundRequest;
-    use crate::entities::{
-        EndpointData, KeyValue, RequestAuthorization, RequestExportType, ResponseData,
-    };
+    use crate::entities::{EndpointData, KeyValue, RequestExportType, ResponseData};
     use crate::error::{RequestError, RequestPreconditionError};
     use crate::objects::KeyValueItem;
     use crate::widgets::{
-        ExportTab, ExportType, KeyValuePane, MethodDropdown, PayloadTab, ResponsePanel,
+        AuthorizationPane, ExportTab, ExportType, KeyValuePane, MethodDropdown, PayloadTab,
+        ResponsePanel,
     };
 
     #[derive(CompositeTemplate, Properties, Default)]
@@ -79,6 +78,9 @@ mod imp {
 
         #[template_child]
         pub export_pane: TemplateChild<ExportTab>,
+
+        #[template_child]
+        authorization_pane: TemplateChild<AuthorizationPane>,
 
         #[template_child]
         pub response: TemplateChild<ResponsePanel>,
@@ -329,6 +331,11 @@ mod imp {
                 obj,
                 move |_| obj.set_dirty(true)
             ));
+            self.authorization_pane.connect_changed(glib::clone!(
+                #[weak]
+                obj,
+                move |_| obj.set_dirty(true)
+            ));
             self.header_pane.connect_changed(glib::clone!(
                 #[weak]
                 obj,
@@ -436,6 +443,8 @@ mod imp {
             self.header_pane.set_entries(&headers);
             self.variable_pane.set_entries(&variables);
             self.payload_pane.set_payload(&endpoint.body);
+            self.authorization_pane
+                .set_authorization(&endpoint.authorization);
             self.export_pane_load_endpoint_data(endpoint);
 
             // Merge parameters
@@ -483,6 +492,7 @@ mod imp {
                 })
                 .collect();
             let body = self.payload_pane.payload();
+            let authorization = self.authorization_pane.authorization();
             EndpointData {
                 url,
                 method,
@@ -490,7 +500,7 @@ mod imp {
                 headers,
                 variables,
                 body,
-                authorization: RequestAuthorization::default(),
+                authorization,
             }
         }
 

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -40,7 +40,9 @@ mod imp {
 
     use crate::app::CarteroApplication;
     use crate::client::BoundRequest;
-    use crate::entities::{EndpointData, KeyValue, RequestExportType, ResponseData};
+    use crate::entities::{
+        EndpointData, KeyValue, RequestAuthorization, RequestExportType, ResponseData,
+    };
     use crate::error::{RequestError, RequestPreconditionError};
     use crate::objects::KeyValueItem;
     use crate::widgets::{
@@ -488,6 +490,7 @@ mod imp {
                 headers,
                 variables,
                 body,
+                authorization: RequestAuthorization::default(),
             }
         }
 

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -15,6 +15,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+mod authorization_pane;
 mod code_view;
 pub mod dialogs;
 mod endpoint_pane;
@@ -29,6 +30,7 @@ mod response_headers;
 mod response_panel;
 mod search_box;
 
+pub use authorization_pane::*;
 pub use code_view::CodeView;
 pub use endpoint_pane::EndpointPane;
 pub use error_pane::ErrorPane;


### PR DESCRIPTION
Implements #60, adding a new pane to set the Authorization details using a form rather than having to manually set the Authorization header manually in the headers pane. Currently supported authorization methods are Basic Auth and Bearer Tokens, but I'm very interested in adding more methods in the future, like JWT, OAuth 2.0 or AWS4.

![A screenshot of the new authorization pane](https://github.com/user-attachments/assets/9edcb220-1886-4f94-b1ec-c5017b1eb7ea)

Each authorization method can later modify the request when it's being bound for a request. This makes possible to also assign variables to the values of these headers.

![A screenshot of the authorization pane showing variables in the basic auth settings](https://github.com/user-attachments/assets/f6bfbbe6-e2cf-4eb7-ac6a-f082ccaa1342)
