### PR TITLE
Add Sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+---
+
+ko_fi: danirod


### PR DESCRIPTION
I may have accidentally configured my Ko-Fi account. (Not a joke, all I wanted to do was see if I could donate to _other_ projects using PayPal, but in the process I think I actually just linked PayPal with my own page). So this means that technically the donation page is ready.