### PR TITLE
Fix bugs after updating to GNU gettext 0.24

### DIFF
--- a/data/cartero.appdata.xml.in.in
+++ b/data/cartero.appdata.xml.in.in
@@ -4,7 +4,7 @@
   <id>@app_id@</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
-  <name translate="no">Cartero</name>
+  <name translate="no" translatable="no">Cartero</name>
   <summary>Make HTTP requests and test APIs</summary>
   <launchable type="desktop-id">@app_id@.desktop</launchable>
   <description>
@@ -38,9 +38,9 @@
   <url type="homepage">https://cartero.danirod.es</url>
   <url type="vcs-browser">https://github.com/danirod/cartero</url>
   <url type="bugtracker">https://github.com/danirod/cartero/issues</url>
-  <developer_name translate="no">Dani Rodríguez</developer_name>
+  <developer_name translate="no" translatable="no">Dani Rodríguez</developer_name>
   <developer id="com.github.danirod">
-    <name translate="no">Dani Rodríguez</name>
+    <name translate="no" translatable="no">Dani Rodríguez</name>
   </developer>
   <update_contact>dani@danirod.es</update_contact>
   <content_rating type="oars-1.0"></content_rating>
@@ -51,7 +51,7 @@
   </branding>
   <releases>
     <release date="2024-07-30" version="0.1.1">
-      <description translate="no">
+      <description translate="no" translatable="no">
         <p>This is a minor release that addresses some issues and small changes found in the last couple of days. It accepts feedback from the community and even some pull requests received in the last days.</p>
         <p>Changed:</p>
         <ul>
@@ -70,7 +70,7 @@
       </description>
     </release>
     <release date="2024-07-26" version="0.1.0">
-      <description translate="no">
+      <description translate="no" translatable="no">
         <p>Initial release. I've crafted a MVP that consolidates the most important features to start using Cartero. Some features has been delayed for a future release, but there is already enough features for it to be useful.</p>
         <p>Added:</p>
         <ul>

--- a/po/ca.po
+++ b/po/ca.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 21:49+0100\n"
+"POT-Creation-Date: 2025-03-18 23:24+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -543,10 +543,12 @@ msgid "The specified URL is not valid"
 msgstr ""
 
 #: src/error.rs:34
+#, rust-format
 msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:37
+#, rust-format
 msgid "The value for header '{}' is not valid"
 msgstr ""
 
@@ -563,10 +565,12 @@ msgid "The given URL is missing a protocol"
 msgstr ""
 
 #: src/error.rs:72
+#, rust-format
 msgid "The protocol {}:// is not supported"
 msgstr ""
 
 #: src/error.rs:76
+#, rust-format
 msgid "The variable '{}' is not defined"
 msgstr ""
 
@@ -598,12 +602,14 @@ msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
 #: src/file.rs:411
+#, rust-format
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."
 msgstr ""
 
 #: src/widgets/dialogs.rs:48
+#, rust-format
 msgid "Cannot open '{}'"
 msgstr ""
 
@@ -618,6 +624,7 @@ msgid "Close"
 msgstr "Tancar pestanya"
 
 #: src/widgets/dialogs.rs:75
+#, rust-format
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
@@ -626,6 +633,7 @@ msgid "The requested file was loaded but had issues"
 msgstr ""
 
 #: src/widgets/dialogs.rs:109
+#, rust-format
 msgid "Cannot save '{}'"
 msgstr ""
 
@@ -663,7 +671,7 @@ msgid "Close anyway"
 msgstr "Tancar pestanya"
 
 #: src/widgets/dialogs.rs:179
-#, fuzzy
+#, fuzzy, rust-format
 msgid "Save changes in '{}'?"
 msgstr "¿Guardar cambis?"
 
@@ -721,12 +729,14 @@ msgstr ""
 #. TRANSLATORS: this string is used to build the search box ocurrences count; the first
 #. placeholder is the current ocurrence index, the second one is the total.
 #: src/widgets/search_box.rs:254
+#, rust-format
 msgid "{} of {}"
 msgstr ""
 
 #. TRANSLATORS: this string is used to build the search box ocurrences count when only
 #. the number of total ocurrences is known.
 #: src/widgets/search_box.rs:262
+#, rust-format
 msgid "{} result"
 msgid_plural "{} results"
 msgstr[0] ""
@@ -736,15 +746,15 @@ msgstr[1] ""
 msgid "(untitled)"
 msgstr "(sense títol)"
 
-#: src/win.rs:258
+#: src/win.rs:256
 msgid "Draft"
 msgstr "Esborrany"
 
-#: src/win.rs:705
+#: src/win.rs:558
 msgid "The Cartero authors"
 msgstr "Els autors de Cartero"
 
-#: src/win.rs:706
+#: src/win.rs:559
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 Els autors de Cartero"
 

--- a/po/cartero.pot
+++ b/po/cartero.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 21:49+0100\n"
+"POT-Creation-Date: 2025-03-18 23:24+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -532,10 +532,12 @@ msgid "The specified URL is not valid"
 msgstr ""
 
 #: src/error.rs:34
+#, rust-format
 msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:37
+#, rust-format
 msgid "The value for header '{}' is not valid"
 msgstr ""
 
@@ -552,10 +554,12 @@ msgid "The given URL is missing a protocol"
 msgstr ""
 
 #: src/error.rs:72
+#, rust-format
 msgid "The protocol {}:// is not supported"
 msgstr ""
 
 #: src/error.rs:76
+#, rust-format
 msgid "The variable '{}' is not defined"
 msgstr ""
 
@@ -586,12 +590,14 @@ msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
 #: src/file.rs:411
+#, rust-format
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."
 msgstr ""
 
 #: src/widgets/dialogs.rs:48
+#, rust-format
 msgid "Cannot open '{}'"
 msgstr ""
 
@@ -605,6 +611,7 @@ msgid "Close"
 msgstr ""
 
 #: src/widgets/dialogs.rs:75
+#, rust-format
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
@@ -613,6 +620,7 @@ msgid "The requested file was loaded but had issues"
 msgstr ""
 
 #: src/widgets/dialogs.rs:109
+#, rust-format
 msgid "Cannot save '{}'"
 msgstr ""
 
@@ -649,6 +657,7 @@ msgid "Close anyway"
 msgstr ""
 
 #: src/widgets/dialogs.rs:179
+#, rust-format
 msgid "Save changes in '{}'?"
 msgstr ""
 
@@ -705,12 +714,14 @@ msgstr ""
 #. TRANSLATORS: this string is used to build the search box ocurrences count; the first
 #. placeholder is the current ocurrence index, the second one is the total.
 #: src/widgets/search_box.rs:254
+#, rust-format
 msgid "{} of {}"
 msgstr ""
 
 #. TRANSLATORS: this string is used to build the search box ocurrences count when only
 #. the number of total ocurrences is known.
 #: src/widgets/search_box.rs:262
+#, rust-format
 msgid "{} result"
 msgid_plural "{} results"
 msgstr[0] ""
@@ -720,14 +731,14 @@ msgstr[1] ""
 msgid "(untitled)"
 msgstr ""
 
-#: src/win.rs:258
+#: src/win.rs:256
 msgid "Draft"
 msgstr ""
 
-#: src/win.rs:705
+#: src/win.rs:558
 msgid "The Cartero authors"
 msgstr ""
 
-#: src/win.rs:706
+#: src/win.rs:559
 msgid "© 2024-2025 the Cartero authors"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 21:49+0100\n"
+"POT-Creation-Date: 2025-03-18 23:24+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: vesp <vesp@post.cz>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartero/cartero/cs/"
@@ -546,10 +546,12 @@ msgid "The specified URL is not valid"
 msgstr ""
 
 #: src/error.rs:34
+#, rust-format
 msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:37
+#, rust-format
 msgid "The value for header '{}' is not valid"
 msgstr ""
 
@@ -566,10 +568,12 @@ msgid "The given URL is missing a protocol"
 msgstr ""
 
 #: src/error.rs:72
+#, rust-format
 msgid "The protocol {}:// is not supported"
 msgstr ""
 
 #: src/error.rs:76
+#, rust-format
 msgid "The variable '{}' is not defined"
 msgstr ""
 
@@ -601,12 +605,14 @@ msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
 #: src/file.rs:411
+#, rust-format
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."
 msgstr ""
 
 #: src/widgets/dialogs.rs:48
+#, rust-format
 msgid "Cannot open '{}'"
 msgstr ""
 
@@ -621,6 +627,7 @@ msgid "Close"
 msgstr "Zavřít panel"
 
 #: src/widgets/dialogs.rs:75
+#, rust-format
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
@@ -629,6 +636,7 @@ msgid "The requested file was loaded but had issues"
 msgstr ""
 
 #: src/widgets/dialogs.rs:109
+#, rust-format
 msgid "Cannot save '{}'"
 msgstr ""
 
@@ -667,7 +675,7 @@ msgid "Close anyway"
 msgstr "Zavřít panel"
 
 #: src/widgets/dialogs.rs:179
-#, fuzzy
+#, fuzzy, rust-format
 msgid "Save changes in '{}'?"
 msgstr "Uložit změny?"
 
@@ -725,12 +733,14 @@ msgstr ""
 #. TRANSLATORS: this string is used to build the search box ocurrences count; the first
 #. placeholder is the current ocurrence index, the second one is the total.
 #: src/widgets/search_box.rs:254
+#, rust-format
 msgid "{} of {}"
 msgstr "{} z {}"
 
 #. TRANSLATORS: this string is used to build the search box ocurrences count when only
 #. the number of total ocurrences is known.
 #: src/widgets/search_box.rs:262
+#, rust-format
 msgid "{} result"
 msgid_plural "{} results"
 msgstr[0] "{} požadavek"
@@ -741,14 +751,14 @@ msgstr[2] "{} požadavků"
 msgid "(untitled)"
 msgstr "(bez názvu)"
 
-#: src/win.rs:258
+#: src/win.rs:256
 msgid "Draft"
 msgstr "Koncept"
 
-#: src/win.rs:705
+#: src/win.rs:558
 msgid "The Cartero authors"
 msgstr "Autoři aplikace Cartero"
 
-#: src/win.rs:706
+#: src/win.rs:559
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 autoři aplikace Cartero"

--- a/po/eo.po
+++ b/po/eo.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 21:49+0100\n"
+"POT-Creation-Date: 2025-03-18 23:24+0100\n"
 "PO-Revision-Date: 2024-11-04 17:46+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/cartero/"
@@ -531,10 +531,12 @@ msgid "The specified URL is not valid"
 msgstr ""
 
 #: src/error.rs:34
+#, rust-format
 msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:37
+#, rust-format
 msgid "The value for header '{}' is not valid"
 msgstr ""
 
@@ -551,10 +553,12 @@ msgid "The given URL is missing a protocol"
 msgstr ""
 
 #: src/error.rs:72
+#, rust-format
 msgid "The protocol {}:// is not supported"
 msgstr ""
 
 #: src/error.rs:76
+#, rust-format
 msgid "The variable '{}' is not defined"
 msgstr ""
 
@@ -585,12 +589,14 @@ msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
 #: src/file.rs:411
+#, rust-format
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."
 msgstr ""
 
 #: src/widgets/dialogs.rs:48
+#, rust-format
 msgid "Cannot open '{}'"
 msgstr ""
 
@@ -604,6 +610,7 @@ msgid "Close"
 msgstr ""
 
 #: src/widgets/dialogs.rs:75
+#, rust-format
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
@@ -612,6 +619,7 @@ msgid "The requested file was loaded but had issues"
 msgstr ""
 
 #: src/widgets/dialogs.rs:109
+#, rust-format
 msgid "Cannot save '{}'"
 msgstr ""
 
@@ -648,6 +656,7 @@ msgid "Close anyway"
 msgstr ""
 
 #: src/widgets/dialogs.rs:179
+#, rust-format
 msgid "Save changes in '{}'?"
 msgstr ""
 
@@ -705,12 +714,14 @@ msgstr ""
 #. TRANSLATORS: this string is used to build the search box ocurrences count; the first
 #. placeholder is the current ocurrence index, the second one is the total.
 #: src/widgets/search_box.rs:254
+#, rust-format
 msgid "{} of {}"
 msgstr ""
 
 #. TRANSLATORS: this string is used to build the search box ocurrences count when only
 #. the number of total ocurrences is known.
 #: src/widgets/search_box.rs:262
+#, rust-format
 msgid "{} result"
 msgid_plural "{} results"
 msgstr[0] ""
@@ -720,15 +731,15 @@ msgstr[1] ""
 msgid "(untitled)"
 msgstr ""
 
-#: src/win.rs:258
+#: src/win.rs:256
 msgid "Draft"
 msgstr ""
 
-#: src/win.rs:705
+#: src/win.rs:558
 msgid "The Cartero authors"
 msgstr ""
 
-#: src/win.rs:706
+#: src/win.rs:559
 msgid "© 2024-2025 the Cartero authors"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 21:49+0100\n"
+"POT-Creation-Date: 2025-03-18 23:24+0100\n"
 "PO-Revision-Date: 2025-03-06 22:02+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -544,10 +544,12 @@ msgid "The specified URL is not valid"
 msgstr "La URL especificada no es válida"
 
 #: src/error.rs:34
+#, rust-format
 msgid "The header '{}' is not valid"
 msgstr "La cabecera '{}' no es válida"
 
 #: src/error.rs:37
+#, rust-format
 msgid "The value for header '{}' is not valid"
 msgstr "El valor de la cabecera '{}' no es válido"
 
@@ -564,10 +566,12 @@ msgid "The given URL is missing a protocol"
 msgstr "La URL indicada no tiene un protocolo"
 
 #: src/error.rs:72
+#, rust-format
 msgid "The protocol {}:// is not supported"
 msgstr "El protocolo {}:// no está soportado"
 
 #: src/error.rs:76
+#, rust-format
 msgid "The variable '{}' is not defined"
 msgstr "La variable '{}' no está definida"
 
@@ -601,6 +605,7 @@ msgstr ""
 "El archivo está corrupto o no contiene datos válidos para esta aplicación"
 
 #: src/file.rs:411
+#, rust-format
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."
@@ -609,6 +614,7 @@ msgstr ""
 "se reestablecerá a '{}'."
 
 #: src/widgets/dialogs.rs:48
+#, rust-format
 msgid "Cannot open '{}'"
 msgstr "No se puede abrir '{}'"
 
@@ -622,6 +628,7 @@ msgid "Close"
 msgstr "Cerrar"
 
 #: src/widgets/dialogs.rs:75
+#, rust-format
 msgid "The file '{}' was loaded but had issues"
 msgstr "El archivo '{}' fue cargado pero tenía problemas"
 
@@ -630,6 +637,7 @@ msgid "The requested file was loaded but had issues"
 msgstr "El archivo solicitado fue cargado pero tenía problemas"
 
 #: src/widgets/dialogs.rs:109
+#, rust-format
 msgid "Cannot save '{}'"
 msgstr "No se puede guardar '{}'"
 
@@ -670,6 +678,7 @@ msgid "Close anyway"
 msgstr "Cerrar de todos modos"
 
 #: src/widgets/dialogs.rs:179
+#, rust-format
 msgid "Save changes in '{}'?"
 msgstr "¿Guardar cambios en '{}'?"
 
@@ -728,12 +737,14 @@ msgstr ""
 #. TRANSLATORS: this string is used to build the search box ocurrences count; the first
 #. placeholder is the current ocurrence index, the second one is the total.
 #: src/widgets/search_box.rs:254
+#, rust-format
 msgid "{} of {}"
 msgstr "{} de {}"
 
 #. TRANSLATORS: this string is used to build the search box ocurrences count when only
 #. the number of total ocurrences is known.
 #: src/widgets/search_box.rs:262
+#, rust-format
 msgid "{} result"
 msgid_plural "{} results"
 msgstr[0] "{} resultado"
@@ -743,15 +754,15 @@ msgstr[1] "{} resultados"
 msgid "(untitled)"
 msgstr "(sin título)"
 
-#: src/win.rs:258
+#: src/win.rs:256
 msgid "Draft"
 msgstr "Borrador"
 
-#: src/win.rs:705
+#: src/win.rs:558
 msgid "The Cartero authors"
 msgstr "Los autores de Cartero"
 
-#: src/win.rs:706
+#: src/win.rs:559
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 los autores de Cartero"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 21:49+0100\n"
+"POT-Creation-Date: 2025-03-18 23:24+0100\n"
 "PO-Revision-Date: 2025-02-11 11:02+0000\n"
 "Last-Translator: Altero <aurelien.reinert4@gmail.com>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -540,10 +540,12 @@ msgid "The specified URL is not valid"
 msgstr ""
 
 #: src/error.rs:34
+#, rust-format
 msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:37
+#, rust-format
 msgid "The value for header '{}' is not valid"
 msgstr ""
 
@@ -560,10 +562,12 @@ msgid "The given URL is missing a protocol"
 msgstr ""
 
 #: src/error.rs:72
+#, rust-format
 msgid "The protocol {}:// is not supported"
 msgstr ""
 
 #: src/error.rs:76
+#, rust-format
 msgid "The variable '{}' is not defined"
 msgstr ""
 
@@ -594,12 +598,14 @@ msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
 #: src/file.rs:411
+#, rust-format
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."
 msgstr ""
 
 #: src/widgets/dialogs.rs:48
+#, rust-format
 msgid "Cannot open '{}'"
 msgstr ""
 
@@ -614,6 +620,7 @@ msgid "Close"
 msgstr "Fermer l'onglet"
 
 #: src/widgets/dialogs.rs:75
+#, rust-format
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
@@ -622,6 +629,7 @@ msgid "The requested file was loaded but had issues"
 msgstr ""
 
 #: src/widgets/dialogs.rs:109
+#, rust-format
 msgid "Cannot save '{}'"
 msgstr ""
 
@@ -660,7 +668,7 @@ msgid "Close anyway"
 msgstr "Fermer l'onglet"
 
 #: src/widgets/dialogs.rs:179
-#, fuzzy
+#, fuzzy, rust-format
 msgid "Save changes in '{}'?"
 msgstr "Enregistrer les modifications ?"
 
@@ -720,12 +728,14 @@ msgstr ""
 #. TRANSLATORS: this string is used to build the search box ocurrences count; the first
 #. placeholder is the current ocurrence index, the second one is the total.
 #: src/widgets/search_box.rs:254
+#, rust-format
 msgid "{} of {}"
 msgstr "{} sur {}"
 
 #. TRANSLATORS: this string is used to build the search box ocurrences count when only
 #. the number of total ocurrences is known.
 #: src/widgets/search_box.rs:262
+#, rust-format
 msgid "{} result"
 msgid_plural "{} results"
 msgstr[0] "{} résultat"
@@ -735,14 +745,14 @@ msgstr[1] "{} résultats"
 msgid "(untitled)"
 msgstr "(sans titre)"
 
-#: src/win.rs:258
+#: src/win.rs:256
 msgid "Draft"
 msgstr "Brouillon"
 
-#: src/win.rs:705
+#: src/win.rs:558
 msgid "The Cartero authors"
 msgstr "Les auteurs de Cartero"
 
-#: src/win.rs:706
+#: src/win.rs:559
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 les auteurs de Cartero"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 21:49+0100\n"
+"POT-Creation-Date: 2025-03-18 23:24+0100\n"
 "PO-Revision-Date: 2025-02-01 23:50-0300\n"
 "Last-Translator: john peter <johnppetersa@gmail.com>\n"
 "Language-Team: \n"
@@ -547,10 +547,12 @@ msgid "The specified URL is not valid"
 msgstr ""
 
 #: src/error.rs:34
+#, rust-format
 msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:37
+#, rust-format
 msgid "The value for header '{}' is not valid"
 msgstr ""
 
@@ -567,10 +569,12 @@ msgid "The given URL is missing a protocol"
 msgstr ""
 
 #: src/error.rs:72
+#, rust-format
 msgid "The protocol {}:// is not supported"
 msgstr ""
 
 #: src/error.rs:76
+#, rust-format
 msgid "The variable '{}' is not defined"
 msgstr ""
 
@@ -602,12 +606,14 @@ msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
 #: src/file.rs:411
+#, rust-format
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."
 msgstr ""
 
 #: src/widgets/dialogs.rs:48
+#, rust-format
 msgid "Cannot open '{}'"
 msgstr ""
 
@@ -622,6 +628,7 @@ msgid "Close"
 msgstr "Beche a guia"
 
 #: src/widgets/dialogs.rs:75
+#, rust-format
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
@@ -630,6 +637,7 @@ msgid "The requested file was loaded but had issues"
 msgstr ""
 
 #: src/widgets/dialogs.rs:109
+#, rust-format
 msgid "Cannot save '{}'"
 msgstr ""
 
@@ -668,7 +676,7 @@ msgid "Close anyway"
 msgstr "Beche a guia"
 
 #: src/widgets/dialogs.rs:179
-#, fuzzy
+#, fuzzy, rust-format
 msgid "Save changes in '{}'?"
 msgstr "Salvar mudanças?"
 
@@ -726,12 +734,14 @@ msgstr ""
 #. TRANSLATORS: this string is used to build the search box ocurrences count; the first
 #. placeholder is the current ocurrence index, the second one is the total.
 #: src/widgets/search_box.rs:254
+#, rust-format
 msgid "{} of {}"
 msgstr "{} de {}"
 
 #. TRANSLATORS: this string is used to build the search box ocurrences count when only
 #. the number of total ocurrences is known.
 #: src/widgets/search_box.rs:262
+#, rust-format
 msgid "{} result"
 msgid_plural "{} results"
 msgstr[0] "{} resultado"
@@ -741,14 +751,14 @@ msgstr[1] "{} resultados"
 msgid "(untitled)"
 msgstr "(sem título)"
 
-#: src/win.rs:258
+#: src/win.rs:256
 msgid "Draft"
 msgstr "Rascunho"
 
-#: src/win.rs:705
+#: src/win.rs:558
 msgid "The Cartero authors"
 msgstr "Os autores de Cartero"
 
-#: src/win.rs:706
+#: src/win.rs:559
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 Os autores Cartero"

--- a/po/ro.po
+++ b/po/ro.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 21:49+0100\n"
+"POT-Creation-Date: 2025-03-18 23:24+0100\n"
 "PO-Revision-Date: 2024-07-30 15:00+0200\n"
 "Last-Translator:  <>\n"
 "Language-Team: Romanian\n"
@@ -533,10 +533,12 @@ msgid "The specified URL is not valid"
 msgstr ""
 
 #: src/error.rs:34
+#, rust-format
 msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:37
+#, rust-format
 msgid "The value for header '{}' is not valid"
 msgstr ""
 
@@ -553,10 +555,12 @@ msgid "The given URL is missing a protocol"
 msgstr ""
 
 #: src/error.rs:72
+#, rust-format
 msgid "The protocol {}:// is not supported"
 msgstr ""
 
 #: src/error.rs:76
+#, rust-format
 msgid "The variable '{}' is not defined"
 msgstr ""
 
@@ -588,12 +592,14 @@ msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
 #: src/file.rs:411
+#, rust-format
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."
 msgstr ""
 
 #: src/widgets/dialogs.rs:48
+#, rust-format
 msgid "Cannot open '{}'"
 msgstr ""
 
@@ -608,6 +614,7 @@ msgid "Close"
 msgstr "Închideți tab-ul"
 
 #: src/widgets/dialogs.rs:75
+#, rust-format
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
@@ -616,6 +623,7 @@ msgid "The requested file was loaded but had issues"
 msgstr ""
 
 #: src/widgets/dialogs.rs:109
+#, rust-format
 msgid "Cannot save '{}'"
 msgstr ""
 
@@ -654,7 +662,7 @@ msgid "Close anyway"
 msgstr "Închideți tab-ul"
 
 #: src/widgets/dialogs.rs:179
-#, fuzzy
+#, fuzzy, rust-format
 msgid "Save changes in '{}'?"
 msgstr "Salvați modificările?"
 
@@ -712,12 +720,14 @@ msgstr ""
 #. TRANSLATORS: this string is used to build the search box ocurrences count; the first
 #. placeholder is the current ocurrence index, the second one is the total.
 #: src/widgets/search_box.rs:254
+#, rust-format
 msgid "{} of {}"
 msgstr ""
 
 #. TRANSLATORS: this string is used to build the search box ocurrences count when only
 #. the number of total ocurrences is known.
 #: src/widgets/search_box.rs:262
+#, rust-format
 msgid "{} result"
 msgid_plural "{} results"
 msgstr[0] ""
@@ -727,14 +737,14 @@ msgstr[1] ""
 msgid "(untitled)"
 msgstr "(fără titlu)"
 
-#: src/win.rs:258
+#: src/win.rs:256
 msgid "Draft"
 msgstr "Proiect"
 
-#: src/win.rs:705
+#: src/win.rs:558
 msgid "The Cartero authors"
 msgstr "Autorii Cartero"
 
-#: src/win.rs:706
+#: src/win.rs:559
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 autorii Cartero"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 21:49+0100\n"
+"POT-Creation-Date: 2025-03-18 23:24+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -545,10 +545,12 @@ msgid "The specified URL is not valid"
 msgstr ""
 
 #: src/error.rs:34
+#, rust-format
 msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:37
+#, rust-format
 msgid "The value for header '{}' is not valid"
 msgstr ""
 
@@ -565,10 +567,12 @@ msgid "The given URL is missing a protocol"
 msgstr ""
 
 #: src/error.rs:72
+#, rust-format
 msgid "The protocol {}:// is not supported"
 msgstr ""
 
 #: src/error.rs:76
+#, rust-format
 msgid "The variable '{}' is not defined"
 msgstr ""
 
@@ -600,12 +604,14 @@ msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
 #: src/file.rs:411
+#, rust-format
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."
 msgstr ""
 
 #: src/widgets/dialogs.rs:48
+#, rust-format
 msgid "Cannot open '{}'"
 msgstr ""
 
@@ -620,6 +626,7 @@ msgid "Close"
 msgstr "Закрыть вкладку"
 
 #: src/widgets/dialogs.rs:75
+#, rust-format
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
@@ -628,6 +635,7 @@ msgid "The requested file was loaded but had issues"
 msgstr ""
 
 #: src/widgets/dialogs.rs:109
+#, rust-format
 msgid "Cannot save '{}'"
 msgstr ""
 
@@ -666,7 +674,7 @@ msgid "Close anyway"
 msgstr "Закрыть вкладку"
 
 #: src/widgets/dialogs.rs:179
-#, fuzzy
+#, fuzzy, rust-format
 msgid "Save changes in '{}'?"
 msgstr "Сохранить изменения?"
 
@@ -724,12 +732,14 @@ msgstr ""
 #. TRANSLATORS: this string is used to build the search box ocurrences count; the first
 #. placeholder is the current ocurrence index, the second one is the total.
 #: src/widgets/search_box.rs:254
+#, rust-format
 msgid "{} of {}"
 msgstr ""
 
 #. TRANSLATORS: this string is used to build the search box ocurrences count when only
 #. the number of total ocurrences is known.
 #: src/widgets/search_box.rs:262
+#, rust-format
 msgid "{} result"
 msgid_plural "{} results"
 msgstr[0] ""
@@ -740,14 +750,14 @@ msgstr[2] ""
 msgid "(untitled)"
 msgstr "(без названия)"
 
-#: src/win.rs:258
+#: src/win.rs:256
 msgid "Draft"
 msgstr "Черновик"
 
-#: src/win.rs:705
+#: src/win.rs:558
 msgid "The Cartero authors"
 msgstr "Авторы Cartero"
 
-#: src/win.rs:706
+#: src/win.rs:559
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 Авторы Cartero"

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-03-16 21:49+0100\n"
+"POT-Creation-Date: 2025-03-18 23:24+0100\n"
 "PO-Revision-Date: 2024-12-22 20:55+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartero/cartero/ta/"
@@ -542,10 +542,12 @@ msgid "The specified URL is not valid"
 msgstr ""
 
 #: src/error.rs:34
+#, rust-format
 msgid "The header '{}' is not valid"
 msgstr ""
 
 #: src/error.rs:37
+#, rust-format
 msgid "The value for header '{}' is not valid"
 msgstr ""
 
@@ -562,10 +564,12 @@ msgid "The given URL is missing a protocol"
 msgstr ""
 
 #: src/error.rs:72
+#, rust-format
 msgid "The protocol {}:// is not supported"
 msgstr ""
 
 #: src/error.rs:76
+#, rust-format
 msgid "The variable '{}' is not defined"
 msgstr ""
 
@@ -597,12 +601,14 @@ msgid "The file is corrupt or does not contain valid data for this application"
 msgstr ""
 
 #: src/file.rs:411
+#, rust-format
 msgid ""
 "The HTTP verb found in the file was '{}'. It is not valid, it will fallback "
 "to '{}'."
 msgstr ""
 
 #: src/widgets/dialogs.rs:48
+#, rust-format
 msgid "Cannot open '{}'"
 msgstr ""
 
@@ -617,6 +623,7 @@ msgid "Close"
 msgstr "தாவலை மூடு"
 
 #: src/widgets/dialogs.rs:75
+#, rust-format
 msgid "The file '{}' was loaded but had issues"
 msgstr ""
 
@@ -625,6 +632,7 @@ msgid "The requested file was loaded but had issues"
 msgstr ""
 
 #: src/widgets/dialogs.rs:109
+#, rust-format
 msgid "Cannot save '{}'"
 msgstr ""
 
@@ -663,7 +671,7 @@ msgid "Close anyway"
 msgstr "தாவலை மூடு"
 
 #: src/widgets/dialogs.rs:179
-#, fuzzy
+#, fuzzy, rust-format
 msgid "Save changes in '{}'?"
 msgstr "மாற்றங்களைச் சேமிக்கவா?"
 
@@ -721,12 +729,14 @@ msgstr ""
 #. TRANSLATORS: this string is used to build the search box ocurrences count; the first
 #. placeholder is the current ocurrence index, the second one is the total.
 #: src/widgets/search_box.rs:254
+#, rust-format
 msgid "{} of {}"
 msgstr ""
 
 #. TRANSLATORS: this string is used to build the search box ocurrences count when only
 #. the number of total ocurrences is known.
 #: src/widgets/search_box.rs:262
+#, rust-format
 msgid "{} result"
 msgid_plural "{} results"
 msgstr[0] ""
@@ -736,14 +746,14 @@ msgstr[1] ""
 msgid "(untitled)"
 msgstr "(பெயரிடப்படாதது)"
 
-#: src/win.rs:258
+#: src/win.rs:256
 msgid "Draft"
 msgstr "வரைவு"
 
-#: src/win.rs:705
+#: src/win.rs:558
 msgid "The Cartero authors"
 msgstr "கார்டெரோ ஆசிரியர்கள்"
 
-#: src/win.rs:706
+#: src/win.rs:559
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 கார்டெரோ ஆசிரியர்கள்"

--- a/src/win.rs
+++ b/src/win.rs
@@ -233,31 +233,28 @@ mod imp {
             let dirty = pane.property_expression("dirty");
 
             // Bind title
-            ClosureExpression::new::<String>(
-                [&file, &dirty],
-                glib::closure!(|_: EndpointPane, file: Option<gio::File>, dirty: bool| {
-                    let path = file
-                        .and_then(|f| f.basename())
-                        .map(|bn| bn.file_stem().unwrap().to_str().unwrap().to_string())
-                        .unwrap_or(gettext("(untitled)"));
-                    if dirty {
-                        format!("• {}", &path)
-                    } else {
-                        path
-                    }
-                }),
-            )
+            ClosureExpression::with_callback([&file, &dirty], |args| {
+                let file = args[1].get::<Option<gio::File>>().unwrap();
+                let dirty = args[2].get::<bool>().unwrap();
+                let path = file
+                    .and_then(|f| f.basename())
+                    .map(|bn| bn.file_stem().unwrap().to_str().unwrap().to_string())
+                    .unwrap_or(gettext("(untitled)"));
+                if dirty {
+                    format!("• {}", &path)
+                } else {
+                    path
+                }
+            })
             .bind(&page, "title", Some(pane));
 
             // Bind subtitle
-            ClosureExpression::new::<String>(
-                [&file],
-                glib::closure!(|_: EndpointPane, file: Option<gio::File>| {
-                    file.and_then(|f| f.path())
-                        .map(|bn| bn.display().to_string())
-                        .unwrap_or(gettext("Draft"))
-                }),
-            )
+            ClosureExpression::with_callback([&file], |args| {
+                let file = args[1].get::<Option<gio::File>>().unwrap();
+                file.and_then(|f| f.path())
+                    .map(|bn| bn.display().to_string())
+                    .unwrap_or(gettext("Draft"))
+            })
             .bind(&page, "tooltip", Some(pane));
 
             page
@@ -548,6 +545,26 @@ mod imp {
             }
         }
 
+        fn action_about(&self) {
+            let about = AboutWindow::builder()
+                .transient_for(&*self.obj())
+                .modal(true)
+                .application_name("Cartero")
+                .application_icon(config::APP_ID)
+                .version(config::VERSION)
+                .website("https://github.com/danirod/cartero")
+                .issue_url("https://github.com/danirod/cartero/issues")
+                .support_url("https://github.com/danirod/cartero/discussions")
+                .developer_name(gettext("The Cartero authors"))
+                .copyright(gettext("© 2024-2025 the Cartero authors"))
+                .license_type(gtk::License::Gpl30)
+                .build();
+            if cfg!(target_os = "macos") {
+                about.add_css_class("macos");
+            }
+            about.present();
+        }
+
         pub(super) fn toast_message(&self, msg: &str) {
             let toast = adw::Toast::new(msg);
             self.toaster.add_toast(toast);
@@ -693,23 +710,7 @@ mod imp {
                     #[weak(rename_to = window)]
                     self,
                     move |_, _, _| {
-                        let about = AboutWindow::builder()
-                            .transient_for(&*window.obj())
-                            .modal(true)
-                            .application_name("Cartero")
-                            .application_icon(config::APP_ID)
-                            .version(config::VERSION)
-                            .website("https://github.com/danirod/cartero")
-                            .issue_url("https://github.com/danirod/cartero/issues")
-                            .support_url("https://github.com/danirod/cartero/discussions")
-                            .developer_name(gettext("The Cartero authors"))
-                            .copyright(gettext("© 2024-2025 the Cartero authors"))
-                            .license_type(gtk::License::Gpl30)
-                            .build();
-                        if cfg!(target_os = "macos") {
-                            about.add_css_class("macos");
-                        }
-                        about.present();
+                        window.action_about();
                     }
                 ))
                 .build();


### PR DESCRIPTION
* gettext is now more strict when validating `translate="no"` nodes in XML files like AppData. Add `translatable="no"` to fix it, but keep the old `translate="no"` in case there are tools using it.
* The new Rust parser is unable to parse strings inside macros that make use of closures. To keep it simple, move everything that can be moved outside of the glib::clone!() or glib::closure!() macros that is currently using translatable strings inside.