### PR TITLE
Manually invoke InnoSetup Compiler in GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,10 +74,8 @@ jobs:
         rustup toolchain install stable-gnu
         rustup default stable-gnu
         build-aux/msys-build.sh devel
-    - uses: Minionguyjpro/Inno-Setup-Action@v1.2.2
-      name: Create Windows installer
-      with:
-        path: build/win32-installer.iss
+    - name: Create Windows installer
+      run: iscc.exe /O+ build/win32-installer.iss
     - uses: actions/upload-artifact@v4
       name: Upload Windows version
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,8 @@ jobs:
         rustup default stable-gnu
         build-aux/msys-build.sh devel
     - name: Create Windows installer
-      run: C:\Program Files (x86)\Inno Setup 6\iscc.exe /O+ build/win32-installer.iss
+      run: |
+        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" /O+ build/win32-installer.iss
     - uses: actions/upload-artifact@v4
       name: Upload Windows version
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
         rustup default stable-gnu
         build-aux/msys-build.sh devel
     - name: Create Windows installer
-      run: iscc.exe /O+ build/win32-installer.iss
+      run: C:\Program Files (x86)\Inno Setup 6\iscc.exe /O+ build/win32-installer.iss
     - uses: actions/upload-artifact@v4
       name: Upload Windows version
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
         build-aux/msys-build.sh devel
     - name: Create Windows installer
       run: |
-        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" /O+ build/win32-installer.iss
+        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" build\win32-installer.iss
     - uses: actions/upload-artifact@v4
       name: Upload Windows version
       with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
         build-aux/msys-build.sh devel
     - name: Create Windows installer
       run: |
-        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" build\win32-installer.iss
+        "C:\Program Files (x86)\Inno Setup 6\iscc.exe" build/win32-installer.iss
     - uses: actions/upload-artifact@v4
       name: Upload Windows version
       with:


### PR DESCRIPTION
It seems that the GitHub user that maintained the GitHub Action to do this has either closed their account, or been banned from GitHub, so it's not working anymore.

Now that I know how to use iscc.exe, I think I'd rather just call this manually.