### PR TITLE
Clean some GitHub Actions to save resources

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,8 @@ name: Build
 jobs:
   flatpak:
     runs-on: ubuntu-latest
-    if: false # disabled until https://github.com/flatpak/flatpak-github-actions/issues/214 is fixed
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-47
+      image: bilelmoussaoui/flatpak-github-actions:gnome-48
       options: --privileged
     strategy:
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,7 +49,7 @@ jobs:
   flatpak:
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-48
+      image: bilelmoussaoui/flatpak-github-actions:gnome-47
       options: --privileged
     strategy:
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
           git config --global user.name "GitHub Actions"
           git commit -am "clean working directory"
       - name: meson-dist
-        run: ninja -C build dist
+        run: xvfb-run ninja -C build dist
       - name: upload
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ on:
       - trunk
 name: Build
 concurrency:
-  group: ${{github.ref}}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   tarball:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
     name: "Tarball"
     steps:
       - name: dependencies
-        run: sudo apt update && sudo apt install -y --no-install-recommends gettext meson libgtk-4-dev libadwaita-1-dev libgtksourceview-5-dev desktop-file-utils xvfb at2-spi-core
+        run: sudo apt update && sudo apt install -y --no-install-recommends gettext meson libgtk-4-dev libadwaita-1-dev libgtksourceview-5-dev desktop-file-utils xvfb at-spi2-core
       - name: clone
         uses: actions/checkout@v4
       - name: meson-setup

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: meson-dist
         run: ninja -C build dist
       - name: upload
-        run: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         with:
           name: cartero-src
           path: build/meson-dist/*.tar.xz

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
     name: "Tarball"
     steps:
       - name: dependencies
-        run: sudo apt update && sudo apt install -y --no-install-recommends gettext meson libgtk-4-dev libadwaita-1-dev libgtksourceview-5-dev desktop-file-utils xvfb
+        run: sudo apt update && sudo apt install -y --no-install-recommends gettext meson libgtk-4-dev libadwaita-1-dev libgtksourceview-5-dev desktop-file-utils xvfb at2-spi-core
       - name: clone
         uses: actions/checkout@v4
       - name: meson-setup

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,6 +23,9 @@ on:
     branches:
       - trunk
 name: Build
+concurrency:
+  group: ${{github.ref}}
+  cancel-in-progress: true
 jobs:
   tarball:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,10 @@ jobs:
       - name: stamp
         run: build-aux/stamp-version.sh build
       - name: commit
-        run: git commit -am "clean working directory"
+        run: |
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "GitHub Actions"
+          git commit -am "clean working directory"
       - name: meson-setup
         run: meson setup build
       - name: meson-dist

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,8 @@ jobs:
         run: sudo apt update && sudo apt install -y --no-install-recommends gettext meson libgtk-4-dev libadwaita-1-dev libgtksourceview-5-dev desktop-file-utils xvfb
       - name: clone
         uses: actions/checkout@v4
+      - name: meson-setup
+        run: meson setup build
       - name: stamp
         run: build-aux/stamp-version.sh build
       - name: commit
@@ -39,8 +41,6 @@ jobs:
           git config --global user.email "noreply@github.com"
           git config --global user.name "GitHub Actions"
           git commit -am "clean working directory"
-      - name: meson-setup
-        run: meson setup build
       - name: meson-dist
         run: ninja -C build dist
       - name: upload

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: clone
         uses: actions/checkout@v4
       - name: stamp
-        run: build-aux/stamp-version.sh
+        run: build-aux/stamp-version.sh build
       - name: commit
         run: git commit -am "clean working directory"
       - name: meson-setup

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,28 @@ on:
       - trunk
 name: Build
 jobs:
+  tarball:
+    runs-on: ubuntu-latest
+    name: "Tarball"
+    steps:
+      - name: dependencies
+        run: sudo apt update && sudo apt install -y --no-install-recommends gettext meson libgtk-4-dev libadwaita-1-dev libgtksourceview-5-dev desktop-file-utils xvfb
+      - name: clone
+        uses: actions/checkout@v4
+      - name: stamp
+        run: build-aux/stamp-version.sh
+      - name: commit
+        run: git commit -am "clean working directory"
+      - name: meson-setup
+        run: meson setup build
+      - name: meson-dist
+        run: ninja -C build dist
+      - name: upload
+        run: actions/upload-artifact@v4
+        with:
+          name: cartero-src
+          path: build/meson-dist/*.tar.xz
+          retention-days: 7
   flatpak:
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -24,7 +24,7 @@ on:
       - trunk
 name: Check
 concurrency:
-  group: ${{github.ref}}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   check:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -34,6 +34,11 @@ jobs:
         uses: actions/checkout@v4
       - name: setup
         run: meson setup build
+      - name: cache-cargo-home
+        uses: actions/cache@v4
+        with:
+          path: build/cargo-home
+          key: check-cargo-home
       - name: blueprint
         run: subprojects/blueprint-compiler/blueprint-compiler.py format data/ui
       - name: build
@@ -55,11 +60,17 @@ jobs:
           ! git -c core.pager="" diff -U0 po | grep -v '^@@' | grep 'msgid'
           git checkout -- po
       - name: cargo-fmt
-        run: meson devenv -C build cargo fmt --manifest-path=../Cargo.toml --check --all
+        run: |
+          export CARGO_HOME=$(realpath build/cargo-home)
+          meson devenv -C build cargo fmt --manifest-path=../Cargo.toml --check --all
       - name: cargo-test
-        run: xvfb-run meson devenv -C build cargo test --workspace --manifest-path=../Cargo.toml
+        run: |
+          export CARGO_HOME=$(realpath build/cargo-home)
+          xvfb-run meson devenv -C build cargo test --workspace --manifest-path=../Cargo.toml
       - name: cargo-clippy
-        run: meson devenv -C build cargo clippy --workspace --manifest-path=../Cargo.toml
+        run: |
+          export CARGO_HOME=$(realpath build/cargo-home)
+          meson devenv -C build cargo clippy --workspace --manifest-path=../Cargo.toml
       - name: cargo-deny
         uses: EmbarkStudios/cargo-deny-action@v2
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -23,6 +23,9 @@ on:
     branches:
       - trunk
 name: Check
+concurrency:
+  group: ${{github.ref}}
+  cancel-in-progress: true
 jobs:
   check:
     name: Check

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -61,9 +61,10 @@ jobs:
       - name: cargo-clippy
         run: meson devenv -C build cargo clippy --workspace --manifest-path=../Cargo.toml
       - name: cargo-deny
-        run: |
-          cargo install --locked cargo-deny
-          meson devenv -C build cargo deny --workspace --manifest-path=../Cargo.toml check licenses
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check licenses
+          arguments: --workspace
       - name: glib-schema
         run: glib-compile-schemas --dry-run --strict data
       - name: glib-desktop

--- a/build-aux/stamp-version.sh
+++ b/build-aux/stamp-version.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+cd "$(dirname "$0")/.."
+
+if [[ -z "$1" ]]; then
+        echo "Please provide the build directory where you have made meson setup" >&2
+        echo "Usage: $0 [dir]"
+        exit 1
+fi
+
+version=$(meson introspect "$1" -a | jq -r '.projectinfo.version' | sed "s/git/nightly-$(date +"%Y%m%d")/")
+meson rewrite kwargs set project / version "$version"
+sed -i "s/^version = .*/version = \"$version\"/" Cargo.toml

--- a/meson.build
+++ b/meson.build
@@ -18,7 +18,7 @@
 project(
   'cartero',
   'rust',
-  version: '0.3-git',
+  version: '0.3.0-git',
   meson_version: '>= 0.64',
   license: 'GPL-3.0-or-later',
 )


### PR DESCRIPTION
I don't need to spawn 6 virtual machines every time I change a comma.

Goals of this PR:
* Use the precompiled action to run cargo-deny, saving minutes because it is not compiling cargo-deny on every push.
* Change the build action so that it runs every night using a cron schedule, because:
  - On one hand, I don't need to build an artifact after every push, specially in the middle of a pull request.
  - On the other, continuously testing every day even if the code doesn't change, can catch pipeline breaks if some system dependency breaks.
* Enable again the Flatpak build, because it seems that the issue is fixed.
* Let's see if I can create a Snap version.