### PR TITLE
Make the query params table less laggy

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -54,19 +54,21 @@ jobs:
           ninja -C build cartero-update-po
           ! git -c core.pager="" diff -U0 po | grep -v '^@@' | grep 'msgid'
           git checkout -- po
+      - name: glib-schema
+        run: glib-compile-schemas --targetdir build --strict data
+      - name: glib-desktop
+        run: meson devenv -C build desktop-file-validate data/es.danirod.Cartero.desktop
+      - name: glib-appstream
+        run: meson devenv -C build appstreamcli validate data/es.danirod.Cartero.appdata.xml
       - name: cargo-fmt
         run: meson devenv -C build cargo fmt --manifest-path=../Cargo.toml --check --all
       - name: cargo-test
-        run: xvfb-run meson devenv -C build cargo test --workspace --manifest-path=../Cargo.toml
+        run: |
+          export GSETTINGS_SCHEMA_DIR=$PWD/build
+          xvfb-run meson devenv -C build cargo test --workspace --manifest-path=../Cargo.toml
       - name: cargo-clippy
         run: meson devenv -C build cargo clippy --workspace --manifest-path=../Cargo.toml
       - name: cargo-deny
         run: |
           cargo install --locked cargo-deny
           meson devenv -C build cargo deny --workspace --manifest-path=../Cargo.toml check licenses
-      - name: glib-schema
-        run: glib-compile-schemas --dry-run --strict data
-      - name: glib-desktop
-        run: meson devenv -C build desktop-file-validate data/es.danirod.Cartero.desktop
-      - name: glib-appstream
-        run: meson devenv -C build appstreamcli validate data/es.danirod.Cartero.appdata.xml

--- a/src/objects/key_value_item.rs
+++ b/src/objects/key_value_item.rs
@@ -74,6 +74,17 @@ glib::wrapper! {
 }
 
 impl KeyValueItem {
+    pub fn cloned(&self) -> Self {
+        glib::Object::builder()
+            .property("header-name", self.header_name())
+            .property("header-value", self.header_value())
+            .property("dirty", self.dirty())
+            .property("active", self.active())
+            .property("secret", self.secret())
+            .property("ignored", self.ignored())
+            .build()
+    }
+
     pub(self) fn setup_signals(&self) {
         self.connect_header_name_notify(|item| {
             if !item.dirty() {

--- a/src/widgets/endpoint_pane.rs
+++ b/src/widgets/endpoint_pane.rs
@@ -297,6 +297,7 @@ mod imp {
             let old_entries: Vec<KeyValueItem> = old_entries
                 .into_iter()
                 .filter(|entry| !entry.active())
+                .map(|entry| entry.cloned())
                 .collect();
             new_query_entries.extend(old_entries);
 
@@ -597,6 +598,153 @@ mod imp {
                 Ok(data) => self.response.assign_from_response(&data),
                 Err(e) => self.response.show_request_error(e),
             };
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use glib::subclass::types::ObjectSubclassIsExt;
+        use gtk::prelude::EditableExt;
+        use sourceview5::prelude::ListModelExt;
+
+        use crate::{app::CarteroApplication, objects::KeyValueItem};
+
+        use super::super::EndpointPane;
+
+        fn assert_row(row: &KeyValueItem, name: &str, value: &str, active: bool, secret: bool) {
+            assert_eq!(row.header_name(), name);
+            assert_eq!(row.header_value(), value);
+            assert_eq!(row.active(), active);
+            assert_eq!(row.secret(), secret);
+        }
+
+        #[gtk::test]
+        fn test_setting_the_url_address_updates_params() {
+            crate::init_test_resources();
+            let _app = CarteroApplication::new();
+
+            let pane = EndpointPane::default();
+            let imp = pane.imp();
+
+            /* So far, only the placeholder row in the param pane. */
+            assert_eq!(1, imp.parameter_pane.model().n_items());
+
+            imp.request_url
+                .set_text("https://www.example.com/foobar.html?a=1&b=2&c=3&d=4");
+            assert_eq!(5, imp.parameter_pane.model().n_items());
+            assert_row(
+                &imp.parameter_pane.item_at(0).unwrap(),
+                "a",
+                "1",
+                true,
+                false,
+            );
+            assert_row(
+                &imp.parameter_pane.item_at(1).unwrap(),
+                "b",
+                "2",
+                true,
+                false,
+            );
+            assert_row(
+                &imp.parameter_pane.item_at(2).unwrap(),
+                "c",
+                "3",
+                true,
+                false,
+            );
+            assert_row(
+                &imp.parameter_pane.item_at(3).unwrap(),
+                "d",
+                "4",
+                true,
+                false,
+            );
+        }
+
+        #[gtk::test]
+        fn test_updating_parameter_row_changes_url() {
+            crate::init_test_resources();
+            let _app = CarteroApplication::new();
+
+            let pane = EndpointPane::default();
+            let imp = pane.imp();
+            imp.request_url
+                .set_text("https://www.example.com/foobar.html?a=1&b=2&c=3&d=4");
+
+            imp.parameter_pane.item_at(2).unwrap().set_header_value("9");
+            assert_eq!(
+                imp.request_url.text(),
+                "https://www.example.com/foobar.html?a=1&b=2&c=9&d=4"
+            );
+        }
+
+        #[gtk::test]
+        fn test_disabling_parameter_row_changes_url() {
+            crate::init_test_resources();
+            let _app = CarteroApplication::new();
+
+            let pane = EndpointPane::default();
+            let imp = pane.imp();
+            imp.request_url
+                .set_text("https://www.example.com/foobar.html?a=1&b=2&c=3&d=4");
+
+            imp.parameter_pane.item_at(2).unwrap().set_active(false);
+            assert_eq!(
+                imp.request_url.text(),
+                "https://www.example.com/foobar.html?a=1&b=2&d=4"
+            );
+        }
+
+        #[gtk::test]
+        fn test_updating_url_moves_disabled_params_to_bottom() {
+            crate::init_test_resources();
+            let _app = CarteroApplication::new();
+
+            let pane = EndpointPane::default();
+            let imp = pane.imp();
+            imp.request_url
+                .set_text("https://www.example.com/foobar.html?a=1&b=2&c=3&d=4");
+            imp.parameter_pane.item_at(2).unwrap().set_active(false);
+            imp.request_url
+                .set_text("https://www.example.com/foobar.html?a=1&b=2&d=4&e=5");
+
+            assert_eq!(6, imp.parameter_pane.model().n_items());
+            assert_row(
+                &imp.parameter_pane.item_at(0).unwrap(),
+                "a",
+                "1",
+                true,
+                false,
+            );
+            assert_row(
+                &imp.parameter_pane.item_at(1).unwrap(),
+                "b",
+                "2",
+                true,
+                false,
+            );
+            assert_row(
+                &imp.parameter_pane.item_at(2).unwrap(),
+                "d",
+                "4",
+                true,
+                false,
+            );
+            assert_row(
+                &imp.parameter_pane.item_at(3).unwrap(),
+                "e",
+                "5",
+                true,
+                false,
+            );
+            assert_row(
+                &imp.parameter_pane.item_at(4).unwrap(),
+                "c",
+                "3",
+                false,
+                false,
+            );
         }
     }
 }

--- a/src/widgets/key_value_pane.rs
+++ b/src/widgets/key_value_pane.rs
@@ -61,11 +61,45 @@ mod imp {
 
     #[gtk::template_callbacks]
     impl KeyValuePane {
-        fn set_model(&self, model: &ListStore) {
-            let this_model = self.model.get().unwrap();
-            let items = Vec::from_iter(model.iter::<glib::Object>().map(Result::unwrap));
-            this_model.remove_all();
-            this_model.splice(0, 0, &items);
+        fn set_model(&self, next_model: &ListStore) {
+            let current_model = self.model.get().unwrap();
+
+            for (idx, next_row) in next_model.iter::<KeyValueItem>().enumerate() {
+                let next_row = next_row.expect("next_model was modified during iteration");
+                let idx = idx as u32;
+                match current_model.item(idx) {
+                    Some(current_row) => {
+                        let current_row = current_row
+                            .downcast::<KeyValueItem>()
+                            .expect("No KeyValueItem?");
+                        current_row.set_header_name(next_row.header_name());
+                        current_row.set_header_value(next_row.header_value());
+                        current_row.set_active(next_row.active());
+                        current_row.set_ignored(next_row.ignored());
+                        current_row.set_dirty(next_row.dirty());
+                    }
+                    None => {
+                        /* This row is new in the table. */
+                        let new_row = KeyValueItem::new();
+                        new_row.set_header_name(next_row.header_name());
+                        new_row.set_header_value(next_row.header_value());
+                        new_row.set_active(next_row.active());
+                        new_row.set_ignored(next_row.ignored());
+                        new_row.set_dirty(next_row.dirty());
+                        current_model.append(&new_row);
+                    }
+                }
+            }
+
+            if current_model.n_items() > next_model.n_items() {
+                /* Delete the rest of the table. */
+                let empty: Vec<glib::Object> = vec![];
+                current_model.splice(
+                    next_model.n_items(),
+                    current_model.n_items() - next_model.n_items(),
+                    &empty,
+                );
+            }
         }
     }
 
@@ -254,6 +288,10 @@ impl KeyValuePane {
         }
     }
 
+    pub fn item_at(&self, pos: u32) -> Option<KeyValueItem> {
+        self.model().item(pos).and_downcast::<KeyValueItem>()
+    }
+
     pub fn get_entries(&self) -> Vec<KeyValueItem> {
         let model = &self.model();
         let iter = model.iter::<KeyValueItem>();
@@ -307,6 +345,474 @@ mod tests {
         let pane = KeyValuePane::default();
         pane.set_model(&list);
         assert_eq!(pane.model().n_items(), 2);
+    }
+
+    #[gtk::test]
+    pub fn test_set_model_again_with_same_items() {
+        crate::init_test_resources();
+
+        // [ ] Content-Type: application/json
+        // [x] Content-Length: 42
+        let ctype = KeyValueItem::from(("Content-Type", "application/json"));
+        ctype.set_active(false);
+        let clen = KeyValueItem::from(("Content-Length", "42"));
+        let list = ListStore::with_type(KeyValueItem::static_type());
+        list.append(&ctype);
+        list.append(&clen);
+        let pane = KeyValuePane::default();
+        pane.set_model(&list);
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Content-Type"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "application/json"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            false
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Content-Length"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "42"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            true
+        );
+
+        // [x] Accept: text/html
+        // [ ] Accept-Encoding: br
+        let accept = KeyValueItem::from(("Accept", "text/html"));
+        let enc = KeyValueItem::from(("Accept-Encoding", "br"));
+        enc.set_active(false);
+        let list2 = ListStore::with_type(KeyValueItem::static_type());
+        list2.append(&accept);
+        list2.append(&enc);
+        pane.set_model(&list2);
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Accept"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "text/html"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            true
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Accept-Encoding"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "br"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            false
+        );
+    }
+
+    #[gtk::test]
+    pub fn test_set_model_again_with_more_items() {
+        crate::init_test_resources();
+
+        // [ ] Content-Type: application/json
+        // [x] Content-Length: 42
+        let ctype = KeyValueItem::from(("Content-Type", "application/json"));
+        ctype.set_active(false);
+        let clen = KeyValueItem::from(("Content-Length", "42"));
+        let list = ListStore::with_type(KeyValueItem::static_type());
+        list.append(&ctype);
+        list.append(&clen);
+        let pane = KeyValuePane::default();
+        pane.set_model(&list);
+        assert_eq!(pane.model().n_items(), 2);
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Content-Type"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "application/json"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            false
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Content-Length"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "42"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            true
+        );
+
+        let accept = KeyValueItem::from(("Accept", "text/html"));
+        let enc = KeyValueItem::from(("Accept-Encoding", "br"));
+        let auth = KeyValueItem::from(("Authorization", "Bearer 1234"));
+        let refer = KeyValueItem::from(("Referer", "example.com"));
+        enc.set_active(false);
+        let list2 = ListStore::with_type(KeyValueItem::static_type());
+        list2.append(&accept);
+        list2.append(&enc);
+        list2.append(&auth);
+        list2.append(&refer);
+        pane.set_model(&list2);
+        assert_eq!(pane.model().n_items(), 4);
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Accept"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "text/html"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            true
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Accept-Encoding"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "br"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            false
+        );
+        assert_eq!(
+            pane.model()
+                .item(2)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Authorization"
+        );
+        assert_eq!(
+            pane.model()
+                .item(2)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "Bearer 1234"
+        );
+        assert_eq!(
+            pane.model()
+                .item(2)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            true
+        );
+        assert_eq!(
+            pane.model()
+                .item(3)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Referer"
+        );
+        assert_eq!(
+            pane.model()
+                .item(3)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "example.com"
+        );
+        assert_eq!(
+            pane.model()
+                .item(3)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            true
+        );
+    }
+
+    #[gtk::test]
+    pub fn test_set_model_again_with_less_items() {
+        crate::init_test_resources();
+
+        let pane = KeyValuePane::default();
+        let accept = KeyValueItem::from(("Accept", "text/html"));
+        let enc = KeyValueItem::from(("Accept-Encoding", "br"));
+        let auth = KeyValueItem::from(("Authorization", "Bearer 1234"));
+        let refer = KeyValueItem::from(("Referer", "example.com"));
+        enc.set_active(false);
+        let list = ListStore::with_type(KeyValueItem::static_type());
+        list.append(&accept);
+        list.append(&enc);
+        list.append(&auth);
+        list.append(&refer);
+        pane.set_model(&list);
+        assert_eq!(pane.model().n_items(), 4);
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Accept"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "text/html"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            true
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Accept-Encoding"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "br"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            false
+        );
+        assert_eq!(
+            pane.model()
+                .item(2)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Authorization"
+        );
+        assert_eq!(
+            pane.model()
+                .item(2)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "Bearer 1234"
+        );
+        assert_eq!(
+            pane.model()
+                .item(2)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            true
+        );
+        assert_eq!(
+            pane.model()
+                .item(3)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Referer"
+        );
+        assert_eq!(
+            pane.model()
+                .item(3)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "example.com"
+        );
+        assert_eq!(
+            pane.model()
+                .item(3)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            true
+        );
+
+        let ctype = KeyValueItem::from(("Content-Type", "application/json"));
+        ctype.set_active(false);
+        let clen = KeyValueItem::from(("Content-Length", "42"));
+        let list2 = ListStore::with_type(KeyValueItem::static_type());
+        list2.append(&ctype);
+        list2.append(&clen);
+        pane.set_model(&list2);
+        assert_eq!(pane.model().n_items(), 2);
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Content-Type"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "application/json"
+        );
+        assert_eq!(
+            pane.model()
+                .item(0)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            false
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_name(),
+            "Content-Length"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .header_value(),
+            "42"
+        );
+        assert_eq!(
+            pane.model()
+                .item(1)
+                .and_downcast::<KeyValueItem>()
+                .unwrap()
+                .active(),
+            true
+        );
     }
 
     #[gtk::test]
@@ -367,6 +873,7 @@ mod tests {
         assert!(connected.get());
     }
 
+    #[test]
     #[gtk::test]
     pub fn test_model_get_set_entries() {
         crate::init_test_resources();


### PR DESCRIPTION
It seems the reason why the URL field and the tables feel so laggy sometimes is because destroying and re-creating every row every time KeyValuePane.set_model() is called is not efficient (who could guess).

Therefore, the more queryparams your URL has, the more rows has to destroy and then recreate, which causes the textfield used to set the URL to behave more laggy, as it has to wait until the table updates to finish the event handler.

To fix this, the setter for KeyValuePane:model will not destroy the ListStore and create it again. Instead, if possible, it will try to update the values of existing rows in the ListStore, and then only create new rows if the size has grown, or delete the remaining rows if the size has shrunk.

I've added tests to check that the behaviour of set_model() is consistent and doesn't lose information. This includes some UI tests at EndpointPane that assert the connection between the address bar and the parameters table.