### PR TITLE
Fix crash when gsettings-desktop-schemas is not present

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,8 @@ dependency('gtksourceview-5', version: '>= 5.4')
 dependency('libadwaita-1', version: '>= 1.5')
 dependency('openssl', version: '>= 1.0')
 
+dependency('gsettings-desktop-schemas')
+
 glib_compile_resources = find_program('glib-compile-resources', required: true)
 glib_compile_schemas = find_program('glib-compile-schemas', required: true)
 desktop_file_validate = find_program('desktop-file-validate', required: false)

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,12 @@ dependency('gtksourceview-5', version: '>= 5.4')
 dependency('libadwaita-1', version: '>= 1.5')
 dependency('openssl', version: '>= 1.0')
 
-dependency('gsettings-desktop-schemas')
+if host_machine.system() == 'linux'
+  schemas = dependency('gsettings-desktop-schemas', required: false)
+  if not schemas.found()
+    message('gsettings-desktop-schemas is not found: the default monospace font may look odd')
+  endif
+endif
 
 glib_compile_resources = find_program('glib-compile-resources', required: true)
 glib_compile_schemas = find_program('glib-compile-schemas', required: true)

--- a/src/widgets/code_view.rs
+++ b/src/widgets/code_view.rs
@@ -327,8 +327,15 @@ fn get_monospace_font_descriptor() -> FontDescription {
         } else if cfg!(target_os = "windows") {
             "Consolas 11".to_string()
         } else {
-            let settings = gtk::gio::Settings::new("org.gnome.desktop.interface");
-            settings.get::<String>("monospace-font-name")
+            if gtk::gio::SettingsSchemaSource::default()
+                .and_then(|source| source.lookup("org.gnome.desktop.interface", true))
+                .is_some()
+            {
+                let settings = gtk::gio::Settings::new("org.gnome.desktop.interface");
+                settings.get::<String>("monospace-font-name")
+            } else {
+                "Monospace 10".to_string()
+            }
         }
     } else {
         settings.get::<String>("custom-font")


### PR DESCRIPTION
The org.gnome.desktop.interface schema is used to get the default system font when running in GNU/Linux. However, the application should still run even when this schema is not enabled, I believe. In this PR I provide a fallback in case the schema is not found.