### PR TITLE
Fix nix build since cartero now expects updated rust version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,63 +1,73 @@
-{ pkgs ? import <nixpkgs> {} }:
-
-pkgs.rustPlatform.buildRustPackage rec {
-  pname = "cartero";
-  version = "git";
-
-  src = ./.;
-  cargoLock.lockFile = ./Cargo.lock;
-
-  nativeBuildInputs = with pkgs; [
-    meson
-    ninja
-    cargo
-    rustc
-    pkg-config
-    blueprint-compiler
-    desktop-file-utils
-    gtk4
-    shared-mime-info
-    glib
-    wrapGAppsHook
-    hicolor-icon-theme
-  ];
-
-  buildInputs = with pkgs; [
-    gtksourceview5
-    pango
-    gdk-pixbuf
-    openssl_3_3
-    graphene
-    libadwaita
-  ];
-
-  desktopItems = with pkgs; [
-    (makeDesktopItem rec {
-      desktopName = "Cartero";
-      name = lib.toLower desktopName;
-      comment = "Make HTTP requests and test APIs";
-      exec = "cartero";
-      tryExec = exec;
-      icon = "es.danirod.Cartero.svg";
-      keywords = [ "Gnome" "GTK" "HTTP" "RESET" ];
-      categories = [ "GNOME" "GTK" "Network" "Development" ];
-      terminal = false;
-      type = "Application";
-    })
-  ];
-
-  configurePhase = ''
-    runHook cargoSetupHook
-    runHook mesonConfigurePhase
-  '';
-
-  meta = with pkgs.lib; {
-    description = "Make HTTP requests and test APIs";
-    license = licenses.gpl3Only;
-    mainProgram = "cartero";
-    maintainers = with maintainers; [
-      danirod
-      alphatechnolog
-    ];
+{
+  pkgs ? import <nixpkgs> {},
+  rustc ? pkgs.rustc,
+  cargo ? pkgs.cargo,
+}:
+with pkgs; let
+  rustPlatform = makeRustPlatform {
+    inherit cargo rustc;
   };
-}
+in
+  rustPlatform.buildRustPackage rec {
+    pname = "cartero";
+    version = "git";
+
+    src = ./.;
+
+    useFetchCargoVendor = true;
+    cargoLock.lockFile = ./Cargo.lock;
+
+    nativeBuildInputs = with pkgs; [
+      meson
+      ninja
+      cargo
+      rustc
+      pkg-config
+      blueprint-compiler
+      desktop-file-utils
+      gtk4
+      shared-mime-info
+      glib
+      wrapGAppsHook
+      hicolor-icon-theme
+    ];
+
+    buildInputs = with pkgs; [
+      gtksourceview5
+      pango
+      gdk-pixbuf
+      openssl_3_3
+      graphene
+      libadwaita
+    ];
+
+    desktopItems = with pkgs; [
+      (makeDesktopItem rec {
+        desktopName = "Cartero";
+        name = lib.toLower desktopName;
+        comment = "Make HTTP requests and test APIs";
+        exec = "cartero";
+        tryExec = exec;
+        icon = "es.danirod.Cartero.svg";
+        keywords = ["Gnome" "GTK" "HTTP" "RESET"];
+        categories = ["GNOME" "GTK" "Network" "Development"];
+        terminal = false;
+        type = "Application";
+      })
+    ];
+
+    configurePhase = ''
+      runHook cargoSetupHook
+      runHook mesonConfigurePhase
+    '';
+
+    meta = with pkgs.lib; {
+      description = "Make HTTP requests and test APIs";
+      license = licenses.gpl3Only;
+      mainProgram = "cartero";
+      maintainers = with maintainers; [
+        danirod
+        alphatechnolog
+      ];
+    };
+  }

--- a/flake.lock
+++ b/flake.lock
@@ -37,7 +37,28 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1745116541,
+        "narHash": "sha256-5xzA6dTfqCfTTDCo3ipPZzrg3wp01xmcr73y4cTNMP8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e2142ef330a61c02f274ac9a9cb6f8487a5d0080",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,109 +4,128 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }: flake-utils.lib.eachDefaultSystem(
-    system: let
-      overlays = [
-        (_: final: {
-          cartero = final.callPackage ./default.nix {
-            pkgs = final;
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        overlays = [
+          rust-overlay.overlays.default
+          (_: final: {
+            cartero = final.callPackage ./default.nix {
+              pkgs = final;
+              rustc = final.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
+              cargo = final.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
+            };
+          })
+        ];
+
+        pkgs = import nixpkgs {
+          inherit
+            system
+            overlays
+            ;
+        };
+      in {
+        packages = rec {
+          inherit (pkgs) cartero;
+          default = cartero;
+        };
+
+        devShells = with pkgs; let
+          buildShellRecipe = {
+            LD_LIBRARY_PATH = lib.makeLibraryPath [
+              gtk4
+              libadwaita
+              glib
+            ];
+
+            nativeBuildInputs = [
+              meson
+              ninja
+              cargo
+              rustc
+              rustfmt
+              pkg-config
+              blueprint-compiler
+              desktop-file-utils
+              gtk4
+              shared-mime-info
+              glib
+              wrapGAppsHook
+              hicolor-icon-theme
+            ];
+
+            buildInputs = [
+              gtksourceview5
+              pango
+              gdk-pixbuf
+              openssl_3_3
+              graphene
+              libadwaita
+            ];
           };
-        })
-      ];
 
-      pkgs = import nixpkgs {
-        inherit
-          system
-          overlays
-        ;
-      };
-    in {
-      packages = rec {
-        inherit (pkgs) cartero;
-        default = cartero;
-      };
+          launchShellRecipe = {
+            buildInputs = [cartero];
+          };
+        in rec {
+          # use by default the full dev env.
+          default = mixedShell;
 
-      devShells = with pkgs; let
-        buildShellRecipe = {
-          LD_LIBRARY_PATH = lib.makeLibraryPath [
-            gtk4
-            libadwaita
-            glib
-          ];
+          # a dev shell which helps to only build cartero manually without installing the dependencies.
+          buildingShell = mkShell (buildShellRecipe
+            // {
+              name = "building-shell";
 
-          nativeBuildInputs = [
-            meson
-            ninja
-            cargo
-            rustc
-            rustfmt
-            pkg-config
-            blueprint-compiler
-            desktop-file-utils
-            gtk4
-            shared-mime-info
-            glib
-            wrapGAppsHook
-            hicolor-icon-theme
-          ];
+              shellHook = ''
+                echo "> In this shell you should be able to build cartero manually without installing"
+                echo "> the dependencies since they already come installed automatically."
+              '';
+            });
 
-          buildInputs = [
-            gtksourceview5
-            pango
-            gdk-pixbuf
-            openssl_3_3
-            graphene
-            libadwaita
-          ];
+          # useful to test cartero by using nix develop --command cartero
+          launchShell = mkShell (launchShellRecipe
+            // {
+              name = "launch-shell";
+
+              shellHook = ''
+                echo "> Here you can launch cartero by typing \`cartero\` in this interactive shell"
+                echo "> or by using nix develop --command cartero instead"
+              '';
+            });
+
+          # both
+          mixedShell = mkShell {
+            name = "full-dev-env";
+
+            inherit
+              (buildShellRecipe)
+              LD_LIBRARY_PATH
+              ;
+
+            buildInputs =
+              []
+              ++ buildShellRecipe.buildInputs
+              ++ launchShellRecipe.buildInputs;
+
+            shellHook = ''
+              echo "> In this shell you should be able to either build cartero manually without installing"
+              echo "> the dependencies manually, or by running \`cartero\` you could launch a prebuilt version instead"
+            '';
+          };
         };
-
-        launchShellRecipe = {
-          buildInputs = [ cartero ];
-        };
-      in rec {
-        # use by default the full dev env.
-        default = mixedShell;
-
-        # a dev shell which helps to only build cartero manually without installing the dependencies.
-        buildingShell = mkShell (buildShellRecipe // {
-          name = "building-shell";
-
-          shellHook = ''
-            echo "> In this shell you should be able to build cartero manually without installing"
-            echo "> the dependencies since they already come installed automatically."
-          '';
-        });
-
-        # useful to test cartero by using nix develop --command cartero
-        launchShell = mkShell (launchShellRecipe // {
-          name = "launch-shell";
-
-          shellHook = ''
-            echo "> Here you can launch cartero by typing \`cartero\` in this interactive shell"
-            echo "> or by using nix develop --command cartero instead"
-          '';
-        });
-
-        # both
-        mixedShell = mkShell {
-          name = "full-dev-env";
-
-          inherit (buildShellRecipe)
-            LD_LIBRARY_PATH
-          ;
-
-          buildInputs = []
-            ++ buildShellRecipe.buildInputs
-            ++ launchShellRecipe.buildInputs;
-
-          shellHook = ''
-            echo "> In this shell you should be able to either build cartero manually without installing"
-            echo "> the dependencies manually, or by running \`cartero\` you could launch a prebuilt version instead"
-          '';
-        };
-      };
-    }
-  );
+      }
+    );
 }


### PR DESCRIPTION
This PR addresses an issue on the nix build that appeared after some packages required more recents versions of rustc to be able to build the project, the error looks like this:
```
$ nix build '.#default'
error: builder for '/nix/store/rd2vr1rvqs49qinchk7fkni54lsnpljv-cartero-git.drv' failed with exit code 1;
       last 25 log lines:
       > [7/19] Building translation po/fr/LC_MESSAGES/cartero-fr.mo
       > [8/19] Building translation po/gl/LC_MESSAGES/cartero-gl.mo
       > [9/19] Building translation po/pt/LC_MESSAGES/cartero-pt.mo
       > [10/19] Building translation po/pt_BR/LC_MESSAGES/cartero-pt_BR.mo
       > [11/19] Building translation po/ro/LC_MESSAGES/cartero-ro.mo
       > [12/19] Building translation po/ru/LC_MESSAGES/cartero-ru.mo
       > [13/19] Building translation po/ta/LC_MESSAGES/cartero-ta.mo
       > [14/19] Merging translations for data/es.danirod.Cartero.desktop
       > [15/19] Merging translations for data/es.danirod.Cartero.appdata.xml
       > [16/19] Generating data/blueprints with a custom command
       > [17/19] Generating data/cartero_gresource with a custom command
       > xml-stripblanks preprocessing requested, but XMLLINT is not set, and xmllint is not in PATH
       > [17/19] Generating src/cargo-build with a custom command (wrapped by meson to set env)
       > warning: `/build/.cargo/config` is deprecated in favor of `config.toml`
       > note: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
       > error: rustc 1.78.0 is not supported by the following packages:
       >   litemap@0.7.5 requires rustc 1.81
       >   zerofrom@0.1.6 requires rustc 1.81
       > Either upgrade rustc or select compatible dependency versions with
       > `cargo update <name>@<current-ver> --precise <compatible-ver>`
       > where `<compatible-ver>` is the latest version supporting rustc 1.78.0
       >
       > FAILED: src/release
       > env CARGO_HOME=/build/sa73n12wlcshxb1wkbfgr6idd0b548hd-source/build/cargo-home /nix/store/kshky69v2yk4id89xdq649rymyx6cn8n-cargo-1.78.0/bin/cargo build --manifest-path /build/sa73n12wlcshxb1wkbfgr6idd0b548hd-source/Cargo.toml --target-dir /build/sa73n12wlcshxb1wkbfgr6idd0b548hd-source/build/src --release --no-default-features --features csd
       > ninja: build stopped: subcommand failed.
       For full logs, run:
         nix log /nix/store/rd2vr1rvqs49qinchk7fkni54lsnpljv-cartero-git.drv
```

What this PR does is accept appropiate rustc & cargo packages on the derivation parameters, and then builds the project using those versions, i also used the [oxalica's](https://github.com/oxalica/rust-overlay) to pull newer versions of rustc and cargo as [recommended by the nix documentation on rust packaging](https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/rust.section.md#using-rust-nightly-in-a-derivation-with-buildrustpackage-using-rust-nightly-in-a-derivation-with-buildrustpackage)