### PR TITLE
Add builders to the cartero-objects crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,6 +171,7 @@ dependencies = [
 name = "cartero_objects"
 version = "0.3.0"
 dependencies = [
+ "ctor",
  "gio",
  "glib",
 ]
@@ -220,6 +221,22 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "ctor"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4735f265ba6a1188052ca32d461028a7d1125868be18e287e756019da7607b5"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
 
 [[package]]
 name = "curl"
@@ -275,6 +292,21 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "encoding"
@@ -656,9 +688,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gio"
-version = "0.20.9"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4f00c70f8029d84ea7572dd0e1aaa79e5329667b4c17f329d79ffb1e6277487"
+checksum = "d2a5c3829f5794cb15120db87707b2ec03720edff7ad09eb7b711b532e3fe747"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -686,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.20.9"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707b819af8059ee5395a2de9f2317d87a53dbad8846a2f089f0bb44703f37686"
+checksum = "c501c495842c2b23cdacead803a5a343ca2a5d7a7ddaff14cc5f6cf22cfb92c2"
 dependencies = [
  "bitflags 2.9.0",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.3.0"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]
-glib = { version = "0.20.9", features = ["v2_72"] }
-gio = { version = "0.20.9", features = ["v2_72"] }
+glib = { version = "0.20.10", features = ["v2_72"] }
+gio = { version = "0.20.11", features = ["v2_72"] }
 
 [package]
 name = "cartero"

--- a/cartero-objects/Cargo.toml
+++ b/cartero-objects/Cargo.toml
@@ -7,3 +7,6 @@ license.workspace = true
 [dependencies]
 glib.workspace = true
 gio.workspace = true
+
+[dev-dependencies]
+ctor = "0.4.2"

--- a/cartero-objects/src/field.rs
+++ b/cartero-objects/src/field.rs
@@ -66,12 +66,8 @@ glib::wrapper! {
 }
 
 impl Field {
-    pub fn builder<K, V>(key: K, value: V) -> builder::FieldBuilder
-    where
-        K: AsRef<str>,
-        V: AsRef<str>,
-    {
-        builder::FieldBuilder::new(key, value)
+    pub fn builder() -> builder::FieldBuilder {
+        builder::FieldBuilder::default()
     }
 }
 
@@ -144,20 +140,33 @@ mod builder {
         builder: ObjectBuilder<'static, Field>,
     }
 
-    impl FieldBuilder {
-        pub fn new<K, V>(key: K, value: V) -> Self
-        where
-            K: AsRef<str>,
-            V: AsRef<str>,
-        {
-            let builder = glib::Object::builder()
-                .property("key", key.as_ref())
-                .property("value", value.as_ref());
-            Self { builder }
+    impl Default for FieldBuilder {
+        fn default() -> Self {
+            Self {
+                builder: Object::builder(),
+            }
         }
+    }
 
+    impl FieldBuilder {
         pub fn build(self) -> Field {
             self.builder.build()
+        }
+
+        pub fn key<T>(mut self, key: T) -> Self
+        where
+            T: AsRef<str>,
+        {
+            self.builder = self.builder.property("key", key.as_ref());
+            self
+        }
+
+        pub fn value<T>(mut self, value: T) -> Self
+        where
+            T: AsRef<str>,
+        {
+            self.builder = self.builder.property("value", value.as_ref());
+            self
         }
 
         pub fn active(mut self, active: bool) -> Self {
@@ -180,7 +189,10 @@ mod tests {
 
     #[test]
     pub fn test_valid_defaults() {
-        let field = Field::builder("User-Agent", "Mozilla/5.0").build();
+        let field = Field::builder()
+            .key("User-Agent")
+            .value("Mozilla/5.0")
+            .build();
         assert_eq!(field.key(), "User-Agent");
         assert_eq!(field.value(), "Mozilla/5.0");
         assert!(field.active());
@@ -189,7 +201,9 @@ mod tests {
 
     #[test]
     pub fn test_valid_builder() {
-        let field = Field::builder("User-Agent", "Mozilla/5.0")
+        let field = Field::builder()
+            .key("User-Agent")
+            .value("Mozilla/5.0")
             .active(false)
             .masked(true)
             .build();
@@ -201,7 +215,10 @@ mod tests {
 
     #[test]
     pub fn test_notifies_changes() {
-        let field = Field::builder("User-Agent", "Mozilla/5.0").build();
+        let field = Field::builder()
+            .key("User-Agent")
+            .value("Mozilla/5.0")
+            .build();
         assert_emits_signal(&field, "notify", || field.set_key("Accept"));
         assert_emits_signal(&field, "notify", || field.set_value("text/html"));
         assert_emits_signal(&field, "notify", || field.set_active(false));

--- a/cartero-objects/src/field.rs
+++ b/cartero-objects/src/field.rs
@@ -15,7 +15,6 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use glib::object::ObjectBuilder;
 use glib::subclass::prelude::*;
 use glib::{prelude::*, Object};
 
@@ -64,6 +63,16 @@ glib::wrapper! {
     /// assert_eq!(field.value(), "Mozilla/5.0");
     /// ```
     pub struct Field(ObjectSubclass<imp::Field>);
+}
+
+impl Field {
+    pub fn builder<K, V>(key: K, value: V) -> builder::FieldBuilder
+    where
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        builder::FieldBuilder::new(key, value)
+    }
 }
 
 impl<T> From<(T, T)> for Field
@@ -127,49 +136,51 @@ mod imp {
     impl ObjectImpl for Field {}
 }
 
-pub struct FieldBuilder {
-    builder: ObjectBuilder<'static, Field>,
-}
+mod builder {
+    use super::*;
+    use glib::object::ObjectBuilder;
 
-impl FieldBuilder {
-    pub fn new<K, V>(key: K, value: V) -> Self
-    where
-        K: AsRef<str>,
-        V: AsRef<str>,
-    {
-        let builder = glib::Object::builder()
-            .property("key", key.as_ref())
-            .property("value", value.as_ref());
-        Self { builder }
+    pub struct FieldBuilder {
+        builder: ObjectBuilder<'static, Field>,
     }
 
-    pub fn build(self) -> Field {
-        self.builder.build()
-    }
+    impl FieldBuilder {
+        pub fn new<K, V>(key: K, value: V) -> Self
+        where
+            K: AsRef<str>,
+            V: AsRef<str>,
+        {
+            let builder = glib::Object::builder()
+                .property("key", key.as_ref())
+                .property("value", value.as_ref());
+            Self { builder }
+        }
 
-    pub fn active(mut self, active: bool) -> Self {
-        self.builder = self.builder.property("active", active);
-        self
-    }
+        pub fn build(self) -> Field {
+            self.builder.build()
+        }
 
-    pub fn masked(mut self, masked: bool) -> Self {
-        self.builder = self.builder.property("masked", masked);
-        self
+        pub fn active(mut self, active: bool) -> Self {
+            self.builder = self.builder.property("active", active);
+            self
+        }
+
+        pub fn masked(mut self, masked: bool) -> Self {
+            self.builder = self.builder.property("masked", masked);
+            self
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-
-    use glib::Object;
-
     use crate::utils::test::assert_emits_signal;
 
     use super::*;
 
     #[test]
     pub fn test_valid_defaults() {
-        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0").build();
+        let field = Field::builder("User-Agent", "Mozilla/5.0").build();
         assert_eq!(field.key(), "User-Agent");
         assert_eq!(field.value(), "Mozilla/5.0");
         assert!(field.active());
@@ -178,7 +189,7 @@ mod tests {
 
     #[test]
     pub fn test_valid_builder() {
-        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0")
+        let field = Field::builder("User-Agent", "Mozilla/5.0")
             .active(false)
             .masked(true)
             .build();
@@ -190,7 +201,7 @@ mod tests {
 
     #[test]
     pub fn test_notifies_changes() {
-        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0").build();
+        let field = Field::builder("User-Agent", "Mozilla/5.0").build();
         assert_emits_signal(&field, "notify", || field.set_key("Accept"));
         assert_emits_signal(&field, "notify", || field.set_value("text/html"));
         assert_emits_signal(&field, "notify", || field.set_active(false));

--- a/cartero-objects/src/field.rs
+++ b/cartero-objects/src/field.rs
@@ -15,6 +15,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use glib::object::ObjectBuilder;
 use glib::subclass::prelude::*;
 use glib::{prelude::*, Object};
 
@@ -126,6 +127,37 @@ mod imp {
     impl ObjectImpl for Field {}
 }
 
+pub struct FieldBuilder {
+    builder: ObjectBuilder<'static, Field>,
+}
+
+impl FieldBuilder {
+    pub fn new<K, V>(key: K, value: V) -> Self
+    where
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let builder = glib::Object::builder()
+            .property("key", key.as_ref())
+            .property("value", value.as_ref());
+        Self { builder }
+    }
+
+    pub fn build(self) -> Field {
+        self.builder.build()
+    }
+
+    pub fn active(mut self, active: bool) -> Self {
+        self.builder = self.builder.property("active", active);
+        self
+    }
+
+    pub fn masked(mut self, masked: bool) -> Self {
+        self.builder = self.builder.property("masked", masked);
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -136,11 +168,8 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test_valid_builder() {
-        let field: Field = Object::builder()
-            .property("key", "User-Agent")
-            .property("value", "Mozilla/5.0")
-            .build();
+    pub fn test_valid_defaults() {
+        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0").build();
         assert_eq!(field.key(), "User-Agent");
         assert_eq!(field.value(), "Mozilla/5.0");
         assert!(field.active());
@@ -148,12 +177,20 @@ mod tests {
     }
 
     #[test]
-    pub fn test_notifies_changes() {
-        let field: Field = Object::builder()
-            .property("key", "User-Agent")
-            .property("value", "Mozilla/5.0")
+    pub fn test_valid_builder() {
+        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0")
+            .active(false)
+            .masked(true)
             .build();
+        assert_eq!(field.key(), "User-Agent");
+        assert_eq!(field.value(), "Mozilla/5.0");
+        assert!(!field.active());
+        assert!(field.masked());
+    }
 
+    #[test]
+    pub fn test_notifies_changes() {
+        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0").build();
         assert_emits_signal(&field, "notify", || field.set_key("Accept"));
         assert_emits_signal(&field, "notify", || field.set_value("text/html"));
         assert_emits_signal(&field, "notify", || field.set_active(false));

--- a/cartero-objects/src/field_table.rs
+++ b/cartero-objects/src/field_table.rs
@@ -181,8 +181,8 @@ mod tests {
     use super::*;
 
     #[test]
-    pub fn test_valid_builder() {
-        let table: FieldTable = Object::builder().build();
+    pub fn test_default() {
+        let table = FieldTable::default();
         assert_eq!(table.n_items(), 0);
     }
 

--- a/cartero-objects/src/field_table.rs
+++ b/cartero-objects/src/field_table.rs
@@ -188,8 +188,14 @@ mod tests {
 
     #[test]
     pub fn test_valid_from_iter_vec() {
-        let field = Field::builder("User-Agent", "Mozilla/5.0").build();
-        let field2 = Field::builder("Content-Type", "text/html").build();
+        let field = Field::builder()
+            .key("User-Agent")
+            .value("Mozilla/5.0")
+            .build();
+        let field2 = Field::builder()
+            .key("Content-Type")
+            .value("text/html")
+            .build();
         let fields = vec![field, field2];
         let table = FieldTable::from_iter(fields);
         assert_eq!(2, table.n_items());
@@ -199,8 +205,14 @@ mod tests {
 
     #[test]
     pub fn test_valid_from_iter_set() {
-        let field = Field::builder("User-Agent", "Mozilla/5.0").build();
-        let field2 = Field::builder("Content-Type", "text/html").build();
+        let field = Field::builder()
+            .key("User-Agent")
+            .value("Mozilla/5.0")
+            .build();
+        let field2 = Field::builder()
+            .key("Content-Type")
+            .value("text/html")
+            .build();
         let mut fields = HashSet::new();
         fields.insert(field);
         fields.insert(field2);
@@ -210,8 +222,14 @@ mod tests {
 
     #[test]
     pub fn test_insert_get_remove() {
-        let field = Field::builder("User-Agent", "Mozilla/5.0").build();
-        let field2 = Field::builder("Content-Type", "text/html").build();
+        let field = Field::builder()
+            .key("User-Agent")
+            .value("Mozilla/5.0")
+            .build();
+        let field2 = Field::builder()
+            .key("Content-Type")
+            .value("text/html")
+            .build();
         let table: FieldTable = Object::builder().build();
         let inserts = Arc::new(Mutex::new(Vec::new()));
         let local_inserts = inserts.clone();
@@ -262,13 +280,22 @@ mod tests {
     #[test]
     pub fn test_replace_field_table() {
         let table1 = FieldTable::from_iter(vec![
-            Field::builder("User-Agent", "Mozilla/5.0").build(),
-            Field::builder("Accept", "application/json").build(),
+            Field::builder()
+                .key("User-Agent")
+                .value("Mozilla/5.0")
+                .build(),
+            Field::builder()
+                .key("Accept")
+                .value("application/json")
+                .build(),
         ]);
         let table2 = FieldTable::from_iter(vec![
-            Field::builder("Content-Type", "text/html").build(),
-            Field::builder("Host", "example.com").build(),
-            Field::builder("Server", "nginx/1.0").build(),
+            Field::builder()
+                .key("Content-Type")
+                .value("text/html")
+                .build(),
+            Field::builder().key("Host").value("example.com").build(),
+            Field::builder().key("Server").value("nginx/1.0").build(),
         ]);
 
         assert_eq!(2, table1.n_items());

--- a/cartero-objects/src/field_table.rs
+++ b/cartero-objects/src/field_table.rs
@@ -89,6 +89,24 @@ impl FieldTable {
         self.items_changed(len as u32, 0, 1);
     }
 
+    pub fn field(&self, pos: u32) -> Option<Field> {
+        self.item(pos).and_downcast::<Field>()
+    }
+
+    pub fn replace(&self, table: &Self) {
+        let old_len = self.n_items();
+        let new_len = table.n_items();
+
+        {
+            let mut fields = self.imp().fields.borrow_mut();
+            let mut new_fields = { table.imp().fields.borrow().clone() };
+            fields.clear();
+            fields.append(&mut new_fields);
+        }
+
+        self.items_changed(0, old_len, new_len);
+    }
+
     /// Remove a field from the table.
     ///
     /// The position of the element to remove has to be given as a parameter,
@@ -160,8 +178,6 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
-    use crate::FieldBuilder;
-
     use super::*;
 
     #[test]
@@ -172,25 +188,19 @@ mod tests {
 
     #[test]
     pub fn test_valid_from_iter_vec() {
-        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0").build();
-        let field2 = FieldBuilder::new("Content-Type", "text/html").build();
+        let field = Field::builder("User-Agent", "Mozilla/5.0").build();
+        let field2 = Field::builder("Content-Type", "text/html").build();
         let fields = vec![field, field2];
         let table = FieldTable::from_iter(fields);
         assert_eq!(2, table.n_items());
-        assert_eq!(
-            "User-Agent",
-            table.item(0).and_downcast::<Field>().unwrap().key()
-        );
-        assert_eq!(
-            "Content-Type",
-            table.item(1).and_downcast::<Field>().unwrap().key()
-        );
+        assert_eq!("User-Agent", table.field(0).unwrap().key(),);
+        assert_eq!("Content-Type", table.field(1).unwrap().key(),);
     }
 
     #[test]
     pub fn test_valid_from_iter_set() {
-        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0").build();
-        let field2 = FieldBuilder::new("Content-Type", "text/html").build();
+        let field = Field::builder("User-Agent", "Mozilla/5.0").build();
+        let field2 = Field::builder("Content-Type", "text/html").build();
         let mut fields = HashSet::new();
         fields.insert(field);
         fields.insert(field2);
@@ -200,8 +210,8 @@ mod tests {
 
     #[test]
     pub fn test_insert_get_remove() {
-        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0").build();
-        let field2 = FieldBuilder::new("Content-Type", "text/html").build();
+        let field = Field::builder("User-Agent", "Mozilla/5.0").build();
+        let field2 = Field::builder("Content-Type", "text/html").build();
         let table: FieldTable = Object::builder().build();
         let inserts = Arc::new(Mutex::new(Vec::new()));
         let local_inserts = inserts.clone();
@@ -229,13 +239,9 @@ mod tests {
         }
 
         {
-            assert!(table
-                .item(0)
-                .is_some_and(|f| f.downcast::<Field>().is_ok_and(|f| f == field)));
-            assert!(table
-                .item(1)
-                .is_some_and(|f| f.downcast::<Field>().is_ok_and(|f| f == field2)));
-            assert!(table.item(2).is_none());
+            assert!(table.field(0).is_some_and(|f| f == field));
+            assert!(table.field(1).is_some_and(|f| f == field2));
+            assert!(table.field(2).is_none());
         }
 
         {
@@ -248,10 +254,32 @@ mod tests {
         }
 
         {
-            assert!(table
-                .item(0)
-                .is_some_and(|f| f.downcast::<Field>().is_ok_and(|f| f == field2)));
+            assert!(table.field(0).is_some_and(|f| f == field2));
             assert!(table.item(1).is_none());
         }
+    }
+
+    #[test]
+    pub fn test_replace_field_table() {
+        let table1 = FieldTable::from_iter(vec![
+            Field::builder("User-Agent", "Mozilla/5.0").build(),
+            Field::builder("Accept", "application/json").build(),
+        ]);
+        let table2 = FieldTable::from_iter(vec![
+            Field::builder("Content-Type", "text/html").build(),
+            Field::builder("Host", "example.com").build(),
+            Field::builder("Server", "nginx/1.0").build(),
+        ]);
+
+        assert_eq!(2, table1.n_items());
+        assert_eq!("User-Agent", table1.field(0).unwrap().key());
+        assert_eq!("Accept", table1.field(1).unwrap().key());
+
+        table1.replace(&table2);
+
+        assert_eq!(3, table1.n_items());
+        assert_eq!("Content-Type", table1.field(0).unwrap().key());
+        assert_eq!("Host", table1.field(1).unwrap().key());
+        assert_eq!("Server", table1.field(2).unwrap().key());
     }
 }

--- a/cartero-objects/src/field_table.rs
+++ b/cartero-objects/src/field_table.rs
@@ -160,6 +160,8 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
+    use crate::FieldBuilder;
+
     use super::*;
 
     #[test]
@@ -170,14 +172,8 @@ mod tests {
 
     #[test]
     pub fn test_valid_from_iter_vec() {
-        let field: Field = Object::builder()
-            .property("key", "User-Agent")
-            .property("value", "Mozilla/5.0")
-            .build();
-        let field2: Field = Object::builder()
-            .property("key", "Content-Type")
-            .property("value", "text/html")
-            .build();
+        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0").build();
+        let field2 = FieldBuilder::new("Content-Type", "text/html").build();
         let fields = vec![field, field2];
         let table = FieldTable::from_iter(fields);
         assert_eq!(2, table.n_items());
@@ -193,14 +189,8 @@ mod tests {
 
     #[test]
     pub fn test_valid_from_iter_set() {
-        let field: Field = Object::builder()
-            .property("key", "User-Agent")
-            .property("value", "Mozilla/5.0")
-            .build();
-        let field2: Field = Object::builder()
-            .property("key", "Content-Type")
-            .property("value", "text/html")
-            .build();
+        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0").build();
+        let field2 = FieldBuilder::new("Content-Type", "text/html").build();
         let mut fields = HashSet::new();
         fields.insert(field);
         fields.insert(field2);
@@ -210,14 +200,8 @@ mod tests {
 
     #[test]
     pub fn test_insert_get_remove() {
-        let field: Field = Object::builder()
-            .property("key", "User-Agent")
-            .property("value", "Mozilla/5.0")
-            .build();
-        let field2: Field = Object::builder()
-            .property("key", "Content-Type")
-            .property("value", "text/html")
-            .build();
+        let field = FieldBuilder::new("User-Agent", "Mozilla/5.0").build();
+        let field2 = FieldBuilder::new("Content-Type", "text/html").build();
         let table: FieldTable = Object::builder().build();
         let inserts = Arc::new(Mutex::new(Vec::new()));
         let local_inserts = inserts.clone();

--- a/cartero-objects/src/lib.rs
+++ b/cartero-objects/src/lib.rs
@@ -47,3 +47,11 @@ pub use crate::request_body_raw::*;
 pub use crate::request_body_urlencoded::*;
 pub use crate::request_method::*;
 pub use crate::response::*;
+
+#[cfg(test)]
+#[ctor::ctor]
+fn register_types() {
+    use glib::types::StaticType;
+
+    FieldTable::static_type();
+}

--- a/cartero-objects/src/request.rs
+++ b/cartero-objects/src/request.rs
@@ -18,6 +18,8 @@
 use glib::subclass::prelude::*;
 use glib::{prelude::*, Object};
 
+use crate::RequestMethod;
+
 glib::wrapper! {
     /// The high order class that represents a request.
     ///
@@ -66,6 +68,12 @@ impl Default for Request {
     }
 }
 
+impl Request {
+    pub fn builder(url: &str, method: RequestMethod) -> builder::RequestBuilder {
+        builder::RequestBuilder::new(url, method)
+    }
+}
+
 mod imp {
     use std::cell::RefCell;
 
@@ -108,4 +116,112 @@ mod imp {
 
     #[glib::derived_properties]
     impl ObjectImpl for Request {}
+}
+
+mod builder {
+    use crate::{RequestAuthentication, RequestBody};
+
+    use super::*;
+    use glib::object::ObjectBuilder;
+
+    pub struct RequestBuilder {
+        builder: ObjectBuilder<'static, Request>,
+        authentication: RequestAuthentication,
+        body: RequestBody,
+    }
+
+    impl RequestBuilder {
+        pub fn new(url: &str, method: RequestMethod) -> Self {
+            let builder = glib::Object::builder()
+                .property("url", url)
+                .property("method", method);
+            let authentication = RequestAuthentication::default();
+            let body = RequestBody::default();
+            Self {
+                builder,
+                authentication,
+                body,
+            }
+        }
+
+        pub fn with_auth(mut self, authentication: RequestAuthentication) -> Self {
+            self.authentication = authentication;
+            self
+        }
+
+        pub fn with_body(mut self, body: RequestBody) -> Self {
+            self.body = body;
+            self
+        }
+
+        pub fn build(self) -> Request {
+            let req = self.builder.build();
+            req.authentication()
+                .set_auth_type(self.authentication.auth_type());
+            req.authentication()
+                .set_auth_data(self.authentication.auth_data());
+            req.body().set_body_type(self.body.body_type());
+            req.body().set_body_data(self.body.body_data());
+            req
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        RequestAuthentication, RequestAuthenticationBearer, RequestAuthenticationType, RequestBody,
+        RequestBodyRaw, RequestBodyRawType, RequestBodyType,
+    };
+
+    use super::*;
+
+    #[test]
+    pub fn test_valid_builder() {
+        let request =
+            Request::builder("https://www.example.com/api/users", RequestMethod::Get).build();
+        assert_eq!(request.url(), "https://www.example.com/api/users");
+        assert_eq!(request.method(), RequestMethod::Get);
+        assert_eq!(
+            request.authentication().auth_type(),
+            RequestAuthenticationType::None
+        );
+        assert!(request.authentication().auth_data().is_none());
+    }
+
+    #[test]
+    pub fn test_builder_can_change_authentication() {
+        let bearer = RequestAuthenticationBearer::builder().token("1234").build();
+        let request = Request::builder("https://www.example.com/api/users", RequestMethod::Get)
+            .with_auth(
+                RequestAuthentication::builder()
+                    .bearer_token(&bearer)
+                    .build(),
+            )
+            .build();
+        assert_eq!(request.url(), "https://www.example.com/api/users");
+        assert_eq!(request.method(), RequestMethod::Get);
+        assert_eq!(
+            request.authentication().auth_type(),
+            RequestAuthenticationType::BearerToken
+        );
+        let bearer = request.authentication().bearer_token().unwrap();
+        assert_eq!(bearer.token(), "1234");
+    }
+
+    #[test]
+    pub fn test_builder_can_change_body() {
+        let body = RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
+            .payload(&glib::Bytes::from(b"hello world"))
+            .build();
+        let request = Request::builder("https://www.example.com/api/users", RequestMethod::Get)
+            .with_body(RequestBody::builder().raw(&body).build())
+            .build();
+        assert_eq!(request.url(), "https://www.example.com/api/users");
+        assert_eq!(request.method(), RequestMethod::Get);
+        assert_eq!(request.body().body_type(), RequestBodyType::Raw);
+        let bearer = request.body().raw().unwrap();
+        assert_eq!(bearer.payload_type(), RequestBodyRawType::OctetStream);
+        assert_eq!(bearer.payload().into_data().as_ref(), b"hello world");
+    }
 }

--- a/cartero-objects/src/request_authentication.rs
+++ b/cartero-objects/src/request_authentication.rs
@@ -240,6 +240,10 @@ impl RequestAuthentication {
             .build()
     }
 
+    pub fn builder() -> builder::RequestAuthenticationBuilder {
+        builder::RequestAuthenticationBuilder::default()
+    }
+
     /// Returns the basic authentication data, if it's the current type.
     pub fn basic_auth(&self) -> Option<RequestAuthenticationBasic> {
         if self.auth_type() == RequestAuthenticationType::BasicAuth {
@@ -350,6 +354,58 @@ mod imp {
     }
 }
 
+mod builder {
+    use super::*;
+    use glib::object::ObjectBuilder;
+
+    pub struct RequestAuthenticationBuilder {
+        builder: ObjectBuilder<'static, RequestAuthentication>,
+    }
+
+    impl Default for RequestAuthenticationBuilder {
+        fn default() -> Self {
+            let builder = Object::builder();
+            Self { builder }
+        }
+    }
+
+    impl RequestAuthenticationBuilder {
+        pub fn build(self) -> RequestAuthentication {
+            self.builder.build()
+        }
+
+        pub fn none(mut self) -> Self {
+            self.builder = self
+                .builder
+                .property("auth-type", RequestAuthenticationType::None);
+            self
+        }
+
+        pub fn inherit(mut self) -> Self {
+            self.builder = self
+                .builder
+                .property("auth-type", RequestAuthenticationType::Inherit);
+            self
+        }
+
+        pub fn basic_auth(mut self, basic_auth: &RequestAuthenticationBasic) -> Self {
+            self.builder = self
+                .builder
+                .property("auth-type", RequestAuthenticationType::BasicAuth)
+                .property("auth-data", Some(basic_auth));
+            self
+        }
+
+        pub fn bearer_token(mut self, bearer: &RequestAuthenticationBearer) -> Self {
+            self.builder = self
+                .builder
+                .property("auth-type", RequestAuthenticationType::BearerToken)
+                .property("auth-data", Some(bearer));
+            self
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -358,6 +414,46 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    pub fn builder_default() {
+        let auth = RequestAuthentication::builder().build();
+        assert_eq!(auth.auth_type(), RequestAuthenticationType::None);
+        assert!(auth.auth_data().is_none());
+    }
+
+    #[test]
+    pub fn builder_inherit() {
+        let auth = RequestAuthentication::builder().inherit().build();
+        assert_eq!(auth.auth_type(), RequestAuthenticationType::Inherit);
+        assert!(auth.auth_data().is_none());
+    }
+
+    #[test]
+    pub fn builder_basic_auth() {
+        let basic = RequestAuthenticationBasic::builder()
+            .username("user")
+            .password("pass")
+            .build();
+        let auth = RequestAuthentication::builder().basic_auth(&basic).build();
+        assert_eq!(auth.auth_type(), RequestAuthenticationType::BasicAuth);
+        let basic = auth.basic_auth().unwrap();
+        assert_eq!(basic.username(), "user");
+        assert_eq!(basic.password(), "pass");
+    }
+
+    #[test]
+    pub fn builder_bearer() {
+        let bearer = RequestAuthenticationBearer::builder()
+            .token("aabbccdd")
+            .build();
+        let auth = RequestAuthentication::builder()
+            .bearer_token(&bearer)
+            .build();
+        assert_eq!(auth.auth_type(), RequestAuthenticationType::BearerToken);
+        let bearer = auth.bearer_token().unwrap();
+        assert_eq!(bearer.token(), "aabbccdd");
+    }
 
     #[test]
     pub fn new_default() {

--- a/cartero-objects/src/request_authentication_basic.rs
+++ b/cartero-objects/src/request_authentication_basic.rs
@@ -56,6 +56,10 @@ impl RequestAuthenticationBasic {
             .property("password", password.as_ref())
             .build()
     }
+
+    pub fn builder() -> builder::RequestAuthenticationBasicBuilder {
+        builder::RequestAuthenticationBasicBuilder::default()
+    }
 }
 
 mod imp {
@@ -94,11 +98,50 @@ mod imp {
     }
 }
 
+mod builder {
+    use glib::object::ObjectBuilder;
+
+    use super::*;
+
+    pub struct RequestAuthenticationBasicBuilder {
+        builder: ObjectBuilder<'static, RequestAuthenticationBasic>,
+    }
+
+    impl Default for RequestAuthenticationBasicBuilder {
+        fn default() -> Self {
+            let builder = Object::builder();
+            Self { builder }
+        }
+    }
+
+    impl RequestAuthenticationBasicBuilder {
+        pub fn build(self) -> RequestAuthenticationBasic {
+            self.builder.build()
+        }
+
+        pub fn username<T>(mut self, username: T) -> Self
+        where
+            T: AsRef<str>,
+        {
+            self.builder = self.builder.property("username", username.as_ref());
+            self
+        }
+
+        pub fn password<T>(mut self, password: T) -> Self
+        where
+            T: AsRef<str>,
+        {
+            self.builder = self.builder.property("password", password.as_ref());
+            self
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{RequestAuthenticationDataExt, RequestAuthenticationType};
 
-    use super::RequestAuthenticationBasic;
+    use super::*;
 
     #[test]
     pub fn test_default() {
@@ -118,5 +161,24 @@ mod tests {
     pub fn test_auth_type() {
         let auth_type = RequestAuthenticationBasic::default().auth_type();
         assert_eq!(auth_type, RequestAuthenticationType::BasicAuth);
+    }
+
+    #[test]
+    pub fn test_builder_default() {
+        let basic = RequestAuthenticationBasic::builder().build();
+        assert_eq!(basic.username(), String::default());
+        assert_eq!(basic.password(), String::default());
+        assert_eq!(basic.auth_type(), RequestAuthenticationType::BasicAuth);
+    }
+
+    #[test]
+    pub fn test_builder_credentials() {
+        let basic = RequestAuthenticationBasic::builder()
+            .username("admin")
+            .password("1234")
+            .build();
+        assert_eq!(basic.username(), "admin");
+        assert_eq!(basic.password(), "1234");
+        assert_eq!(basic.auth_type(), RequestAuthenticationType::BasicAuth);
     }
 }

--- a/cartero-objects/src/request_authentication_bearer.rs
+++ b/cartero-objects/src/request_authentication_bearer.rs
@@ -53,6 +53,10 @@ impl RequestAuthenticationBearer {
     pub fn new(token: impl AsRef<str>) -> Self {
         Object::builder().property("token", token.as_ref()).build()
     }
+
+    pub fn builder() -> builder::RequestAuthenticationBearerBuilder {
+        builder::RequestAuthenticationBearerBuilder::default()
+    }
 }
 
 mod imp {
@@ -88,6 +92,37 @@ mod imp {
     }
 }
 
+mod builder {
+    use glib::object::ObjectBuilder;
+
+    use super::*;
+
+    pub struct RequestAuthenticationBearerBuilder {
+        builder: ObjectBuilder<'static, RequestAuthenticationBearer>,
+    }
+
+    impl Default for RequestAuthenticationBearerBuilder {
+        fn default() -> Self {
+            let builder = Object::builder();
+            Self { builder }
+        }
+    }
+
+    impl RequestAuthenticationBearerBuilder {
+        pub fn build(self) -> RequestAuthenticationBearer {
+            self.builder.build()
+        }
+
+        pub fn token<T>(mut self, token: T) -> Self
+        where
+            T: AsRef<str>,
+        {
+            self.builder = self.builder.property("token", token.as_ref());
+            self
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{RequestAuthenticationDataExt, RequestAuthenticationType};
@@ -110,5 +145,21 @@ mod tests {
     pub fn test_auth_type() {
         let auth_type = RequestAuthenticationBearer::default().auth_type();
         assert_eq!(auth_type, RequestAuthenticationType::BearerToken);
+    }
+
+    #[test]
+    pub fn test_builder_default() {
+        let bearer = RequestAuthenticationBearer::builder().build();
+        assert_eq!(bearer.token(), String::default());
+        assert_eq!(bearer.auth_type(), RequestAuthenticationType::BearerToken);
+    }
+
+    #[test]
+    pub fn test_builder_with_token() {
+        let bearer = RequestAuthenticationBearer::builder()
+            .token("aabbccdd")
+            .build();
+        assert_eq!(bearer.token(), "aabbccdd");
+        assert_eq!(bearer.auth_type(), RequestAuthenticationType::BearerToken);
     }
 }

--- a/cartero-objects/src/request_body.rs
+++ b/cartero-objects/src/request_body.rs
@@ -159,6 +159,12 @@ glib::wrapper! {
     pub struct RequestBody(ObjectSubclass<imp::RequestBody>);
 }
 
+impl RequestBody {
+    pub fn builder() -> builder::RequestBodyBuilder {
+        builder::RequestBodyBuilder::default()
+    }
+}
+
 impl Default for RequestBody {
     fn default() -> Self {
         Object::builder().build()
@@ -254,6 +260,57 @@ pub enum RequestBodyType {
     /// header.
     #[enum_value(name = "RAW", nick = "Raw")]
     Raw,
+}
+
+mod builder {
+    use glib::object::ObjectBuilder;
+
+    use super::*;
+
+    pub struct RequestBodyBuilder {
+        builder: ObjectBuilder<'static, RequestBody>,
+    }
+
+    impl RequestBodyBuilder {
+        pub fn default() -> Self {
+            Self {
+                builder: Object::builder(),
+            }
+        }
+
+        pub fn build(self) -> RequestBody {
+            self.builder.build()
+        }
+
+        pub fn none(mut self) -> Self {
+            self.builder = self.builder.property("body-type", RequestBodyType::None);
+            self
+        }
+
+        pub fn urlencoded(mut self, url: &RequestBodyUrlencoded) -> Self {
+            self.builder = self
+                .builder
+                .property("body-type", RequestBodyType::UrlEncoded)
+                .property("body-data", url);
+            self
+        }
+
+        pub fn multipart(mut self, mp: &RequestBodyMultipart) -> Self {
+            self.builder = self
+                .builder
+                .property("body-type", RequestBodyType::Multipart)
+                .property("body-data", mp);
+            self
+        }
+
+        pub fn raw(mut self, raw: &RequestBodyRaw) -> Self {
+            self.builder = self
+                .builder
+                .property("body-type", RequestBodyType::Raw)
+                .property("body-data", raw);
+            self
+        }
+    }
 }
 
 mod imp {
@@ -433,5 +490,47 @@ mod tests {
         assert_not_emits_signal(&body, "notify::body-data", || {
             body.set_body_data(Some(payload.as_ref()))
         });
+    }
+
+    #[test]
+    pub fn builder_default() {
+        let body = RequestBody::builder().build();
+        assert_eq!(body.body_type(), RequestBodyType::None);
+        assert!(body.body_data().is_none());
+    }
+
+    #[test]
+    pub fn builder_urlencoded() {
+        let urlencoded = RequestBodyUrlencoded::builder()
+            .field(&Field::builder("user_id", "1").build())
+            .build();
+        let body = RequestBody::builder().urlencoded(&urlencoded).build();
+        assert_eq!(body.body_type(), RequestBodyType::UrlEncoded);
+        let data = body.urlencoded().unwrap();
+        assert_eq!(1, data.params().n_items());
+    }
+
+    #[test]
+    pub fn builder_multipart() {
+        let multipart = RequestBodyMultipart::builder()
+            .field(&Field::builder("user_id", "1").build())
+            .build();
+        let body = RequestBody::builder().multipart(&multipart).build();
+        assert_eq!(body.body_type(), RequestBodyType::Multipart);
+        let data = body.multipart().unwrap();
+        assert_eq!(1, data.params().n_items());
+    }
+
+    #[test]
+    pub fn test_raw() {
+        let raw = RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
+            .payload(&glib::Bytes::from(b"hello world"))
+            .build();
+        let body = RequestBody::builder().raw(&raw).build();
+        assert_eq!(body.body_type(), RequestBodyType::Raw);
+        let data = body.raw().unwrap();
+        assert_eq!(data.payload_type(), RequestBodyRawType::OctetStream);
+        let bytes = data.payload().into_data();
+        assert_eq!(bytes.as_ref(), b"hello world");
     }
 }

--- a/cartero-objects/src/request_body.rs
+++ b/cartero-objects/src/request_body.rs
@@ -502,7 +502,7 @@ mod tests {
     #[test]
     pub fn builder_urlencoded() {
         let urlencoded = RequestBodyUrlencoded::builder()
-            .field(&Field::builder("user_id", "1").build())
+            .field(&Field::builder().key("user_id").value("1").build())
             .build();
         let body = RequestBody::builder().urlencoded(&urlencoded).build();
         assert_eq!(body.body_type(), RequestBodyType::UrlEncoded);
@@ -513,7 +513,7 @@ mod tests {
     #[test]
     pub fn builder_multipart() {
         let multipart = RequestBodyMultipart::builder()
-            .field(&Field::builder("user_id", "1").build())
+            .field(&Field::builder().key("user_id").value("1").build())
             .build();
         let body = RequestBody::builder().multipart(&multipart).build();
         assert_eq!(body.body_type(), RequestBodyType::Multipart);

--- a/cartero-objects/src/request_body_multipart.rs
+++ b/cartero-objects/src/request_body_multipart.rs
@@ -60,6 +60,10 @@ impl RequestBodyMultipart {
         Self::default()
     }
 
+    pub fn builder() -> builder::RequestBodyMultipartBuilder {
+        builder::RequestBodyMultipartBuilder::default()
+    }
+
     /// Create a new payload with the given table as initial data.
     pub fn from_table(table: &FieldTable) -> Self {
         Object::builder().property("params", table).build()
@@ -99,14 +103,88 @@ mod imp {
     }
 }
 
+mod builder {
+    use glib::object::ObjectBuilder;
+
+    use crate::Field;
+
+    use super::*;
+
+    pub struct RequestBodyMultipartBuilder {
+        builder: ObjectBuilder<'static, RequestBodyMultipart>,
+        field_table: FieldTable,
+    }
+
+    impl Default for RequestBodyMultipartBuilder {
+        fn default() -> Self {
+            let builder = Object::builder();
+            Self {
+                builder,
+                field_table: FieldTable::default(),
+            }
+        }
+    }
+
+    impl RequestBodyMultipartBuilder {
+        pub fn build(self) -> RequestBodyMultipart {
+            let object = self.builder.build();
+            object.set_params(&self.field_table);
+            object
+        }
+
+        pub fn field(self, field: &Field) -> Self {
+            self.field_table.insert(field);
+            self
+        }
+
+        pub fn params(self, params: &FieldTable) -> Self {
+            self.field_table.replace(params);
+            self
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use gio::prelude::ListModelExt;
     use glib::object::CastNone;
 
-    use crate::{Field, RequestBodyDataExt, RequestBodyType};
+    use crate::{Field, FieldTable, RequestBodyDataExt, RequestBodyType};
 
     use super::RequestBodyMultipart;
+
+    // TODO: This test sometimes lock the test suite.
+    #[test]
+    pub fn test_builder_empty() {
+        let body = RequestBodyMultipart::builder().build();
+        assert_eq!(0, body.params().n_items());
+    }
+
+    // TODO: This test sometimes lock the test suite.
+    #[test]
+    pub fn test_builder_from_fields_table() {
+        let field1 = Field::builder("User-Agent", "Mozilla/5.0").build();
+        let field2 = Field::builder("Accept", "application/json").build();
+        let field_table = FieldTable::from_iter(vec![field1, field2]);
+        let body = RequestBodyMultipart::builder().params(&field_table).build();
+        assert_eq!(2, body.params().n_items());
+        assert_eq!("User-Agent", body.params().field(0).unwrap().key());
+        assert_eq!("Accept", body.params().field(1).unwrap().key());
+    }
+
+    // TODO: This test sometimes lock the test suite.
+    #[test]
+    pub fn test_builder_adding_fields() {
+        let field1 = Field::builder("User-Agent", "Mozilla/5.0").build();
+        let field2 = Field::builder("Accept", "application/json").build();
+        let body = RequestBodyMultipart::builder()
+            .field(&field1)
+            .field(&field2)
+            .build();
+        assert_eq!(2, body.params().n_items());
+        assert_eq!("User-Agent", body.params().field(0).unwrap().key());
+        assert_eq!("Accept", body.params().field(1).unwrap().key());
+    }
 
     #[test]
     pub fn test_default() {

--- a/cartero-objects/src/request_body_multipart.rs
+++ b/cartero-objects/src/request_body_multipart.rs
@@ -163,8 +163,14 @@ mod tests {
     // TODO: This test sometimes lock the test suite.
     #[test]
     pub fn test_builder_from_fields_table() {
-        let field1 = Field::builder("User-Agent", "Mozilla/5.0").build();
-        let field2 = Field::builder("Accept", "application/json").build();
+        let field1 = Field::builder()
+            .key("User-Agent")
+            .value("Mozilla/5.0")
+            .build();
+        let field2 = Field::builder()
+            .key("Accept")
+            .value("application/json")
+            .build();
         let field_table = FieldTable::from_iter(vec![field1, field2]);
         let body = RequestBodyMultipart::builder().params(&field_table).build();
         assert_eq!(2, body.params().n_items());
@@ -175,8 +181,14 @@ mod tests {
     // TODO: This test sometimes lock the test suite.
     #[test]
     pub fn test_builder_adding_fields() {
-        let field1 = Field::builder("User-Agent", "Mozilla/5.0").build();
-        let field2 = Field::builder("Accept", "application/json").build();
+        let field1 = Field::builder()
+            .key("User-Agent")
+            .value("Mozilla/5.0")
+            .build();
+        let field2 = Field::builder()
+            .key("Accept")
+            .value("application/json")
+            .build();
         let body = RequestBodyMultipart::builder()
             .field(&field1)
             .field(&field2)

--- a/cartero-objects/src/request_body_multipart.rs
+++ b/cartero-objects/src/request_body_multipart.rs
@@ -50,7 +50,7 @@ glib::wrapper! {
 
 impl Default for RequestBodyMultipart {
     fn default() -> Self {
-        Object::builder().build()
+        Object::new()
     }
 }
 

--- a/cartero-objects/src/request_body_raw.rs
+++ b/cartero-objects/src/request_body_raw.rs
@@ -68,6 +68,10 @@ impl RequestBodyRaw {
             .property("payload", bytes)
             .build()
     }
+
+    pub fn builder(payload_type: RequestBodyRawType) -> builder::RequestBodyRawBuilder {
+        builder::RequestBodyRawBuilder::new(payload_type)
+    }
 }
 
 /// Define the semantics of a [RequestBodyRaw] payload.
@@ -147,6 +151,33 @@ mod imp {
     }
 }
 
+mod builder {
+    use glib::object::ObjectBuilder;
+
+    use super::*;
+
+    pub struct RequestBodyRawBuilder {
+        builder: ObjectBuilder<'static, RequestBodyRaw>,
+    }
+
+    impl RequestBodyRawBuilder {
+        pub fn new(raw_type: RequestBodyRawType) -> Self {
+            Self {
+                builder: glib::Object::builder().property("payload-type", raw_type),
+            }
+        }
+
+        pub fn build(self) -> RequestBodyRaw {
+            self.builder.build()
+        }
+
+        pub fn payload(mut self, payload: &glib::Bytes) -> Self {
+            self.builder = self.builder.property("payload", payload);
+            self
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{
@@ -154,6 +185,18 @@ mod tests {
     };
 
     use super::RequestBodyRaw;
+
+    #[test]
+    fn test_builder() {
+        let raw = RequestBodyRaw::builder(RequestBodyRawType::Xml)
+            .payload(&glib::Bytes::from(br#"<?xml version="1.0" ?><document />"#))
+            .build();
+        assert_eq!(raw.payload_type(), RequestBodyRawType::Xml);
+        assert_eq!(
+            String::from_utf8_lossy(&raw.payload().into_data()),
+            r#"<?xml version="1.0" ?><document />"#
+        );
+    }
 
     #[test]
     fn test_defaults() {

--- a/cartero-objects/src/request_body_urlencoded.rs
+++ b/cartero-objects/src/request_body_urlencoded.rs
@@ -55,6 +55,10 @@ impl RequestBodyUrlencoded {
         Self::default()
     }
 
+    pub fn builder() -> builder::RequestBodyUrlencodedBuilder {
+        builder::RequestBodyUrlencodedBuilder::default()
+    }
+
     /// Create a new payload with the given table as initial data.
     pub fn from_table(table: &FieldTable) -> Self {
         Object::builder().property("params", table).build()
@@ -94,14 +98,94 @@ mod imp {
     }
 }
 
+mod builder {
+    use std::cell::RefCell;
+
+    use glib::object::ObjectBuilder;
+
+    use crate::Field;
+
+    use super::*;
+
+    pub struct RequestBodyUrlencodedBuilder {
+        builder: ObjectBuilder<'static, RequestBodyUrlencoded>,
+        field_table: RefCell<FieldTable>,
+    }
+
+    impl Default for RequestBodyUrlencodedBuilder {
+        fn default() -> Self {
+            let builder = Object::builder();
+            let field_table = RefCell::new(FieldTable::default());
+            Self {
+                builder,
+                field_table,
+            }
+        }
+    }
+
+    impl RequestBodyUrlencodedBuilder {
+        pub fn build(self) -> RequestBodyUrlencoded {
+            let field_table = self.field_table.borrow().clone();
+            let object = self.builder.build();
+            object.set_params(&field_table);
+            object
+        }
+
+        pub fn field(self, field: &Field) -> Self {
+            self.field_table.borrow().insert(field);
+            self
+        }
+
+        pub fn params(self, params: &FieldTable) -> Self {
+            self.field_table.replace(params.clone());
+            self
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use gio::prelude::ListModelExt;
     use glib::object::CastNone;
 
-    use crate::{Field, RequestBodyDataExt, RequestBodyType};
+    use crate::{Field, FieldTable, RequestBodyDataExt, RequestBodyType};
 
     use super::RequestBodyUrlencoded;
+
+    #[test]
+    pub fn test_builder() {
+        let body = RequestBodyUrlencoded::builder().build();
+        assert_eq!(body.body_type(), RequestBodyType::UrlEncoded);
+        assert_eq!(body.params().n_items(), 0);
+    }
+
+    #[test]
+    pub fn test_builder_from_table() {
+        let fields = vec![
+            Field::builder("user_id", "1").build(),
+            Field::builder("cat_id", "10").build(),
+        ];
+        let table = FieldTable::from_iter(fields);
+        let body = RequestBodyUrlencoded::builder().params(&table).build();
+        assert_eq!(body.body_type(), RequestBodyType::UrlEncoded);
+        assert_eq!(body.params().n_items(), 2);
+        assert_eq!(body.params().field(0).unwrap().key(), "user_id");
+        assert_eq!(body.params().field(1).unwrap().key(), "cat_id");
+    }
+
+    #[test]
+    pub fn test_builder_with_field() {
+        let field1 = Field::builder("user_id", "1").build();
+        let field2 = Field::builder("cat_id", "10").build();
+        let body = RequestBodyUrlencoded::builder()
+            .field(&field1)
+            .field(&field2)
+            .build();
+        assert_eq!(body.body_type(), RequestBodyType::UrlEncoded);
+        assert_eq!(body.params().n_items(), 2);
+        assert_eq!(body.params().field(0).unwrap().key(), "user_id");
+        assert_eq!(body.params().field(1).unwrap().key(), "cat_id");
+    }
 
     #[test]
     pub fn test_default() {

--- a/cartero-objects/src/request_body_urlencoded.rs
+++ b/cartero-objects/src/request_body_urlencoded.rs
@@ -99,8 +99,6 @@ mod imp {
 }
 
 mod builder {
-    use std::cell::RefCell;
-
     use glib::object::ObjectBuilder;
 
     use crate::Field;
@@ -109,35 +107,33 @@ mod builder {
 
     pub struct RequestBodyUrlencodedBuilder {
         builder: ObjectBuilder<'static, RequestBodyUrlencoded>,
-        field_table: RefCell<FieldTable>,
+        field_table: FieldTable,
     }
 
     impl Default for RequestBodyUrlencodedBuilder {
         fn default() -> Self {
             let builder = Object::builder();
-            let field_table = RefCell::new(FieldTable::default());
             Self {
                 builder,
-                field_table,
+                field_table: FieldTable::default(),
             }
         }
     }
 
     impl RequestBodyUrlencodedBuilder {
         pub fn build(self) -> RequestBodyUrlencoded {
-            let field_table = self.field_table.borrow().clone();
             let object = self.builder.build();
-            object.set_params(&field_table);
+            object.set_params(&self.field_table);
             object
         }
 
         pub fn field(self, field: &Field) -> Self {
-            self.field_table.borrow().insert(field);
+            self.field_table.insert(field);
             self
         }
 
-        pub fn params(self, params: &FieldTable) -> Self {
-            self.field_table.replace(params.clone());
+        pub fn params(mut self, params: &FieldTable) -> Self {
+            self.field_table = params.clone();
             self
         }
     }

--- a/cartero-objects/src/request_body_urlencoded.rs
+++ b/cartero-objects/src/request_body_urlencoded.rs
@@ -162,8 +162,8 @@ mod tests {
     #[test]
     pub fn test_builder_from_table() {
         let fields = vec![
-            Field::builder("user_id", "1").build(),
-            Field::builder("cat_id", "10").build(),
+            Field::builder().key("user_id").value("1").build(),
+            Field::builder().key("cat_id").value("10").build(),
         ];
         let table = FieldTable::from_iter(fields);
         let body = RequestBodyUrlencoded::builder().params(&table).build();
@@ -175,8 +175,8 @@ mod tests {
 
     #[test]
     pub fn test_builder_with_field() {
-        let field1 = Field::builder("user_id", "1").build();
-        let field2 = Field::builder("cat_id", "10").build();
+        let field1 = Field::builder().key("user_id").value("1").build();
+        let field2 = Field::builder().key("cat_id").value("10").build();
         let body = RequestBodyUrlencoded::builder()
             .field(&field1)
             .field(&field2)

--- a/cartero-objects/src/response.rs
+++ b/cartero-objects/src/response.rs
@@ -18,6 +18,8 @@
 use glib::prelude::*;
 use glib::subclass::prelude::*;
 
+use crate::{FieldTable, Request};
+
 glib::wrapper! {
     /// The high order class that represents a response.
     ///
@@ -35,6 +37,12 @@ glib::wrapper! {
     /// - `size`: the amount in bytes of data contained in the body.
     /// - `status-code`: the numerical status code returned by the server.
     pub struct Response(ObjectSubclass<imp::Response>);
+}
+
+impl Response {
+    pub fn builder(request: &Request) -> builder::ResponseBuilder {
+        builder::ResponseBuilder::new(request)
+    }
 }
 
 mod imp {
@@ -70,4 +78,96 @@ mod imp {
 
     #[glib::derived_properties]
     impl ObjectImpl for Response {}
+}
+
+mod builder {
+    use glib::{object::ObjectBuilder, Object};
+
+    use super::*;
+
+    pub struct ResponseBuilder {
+        builder: ObjectBuilder<'static, Response>,
+    }
+
+    impl ResponseBuilder {
+        pub fn new(request: &Request) -> Self {
+            Self {
+                builder: Object::builder().property("request", request),
+            }
+        }
+
+        pub fn build(self) -> Response {
+            self.builder.build()
+        }
+
+        pub fn status_code(mut self, code: u32) -> Self {
+            self.builder = self.builder.property("status-code", code);
+            self
+        }
+
+        pub fn duration(mut self, duration: u64) -> Self {
+            self.builder = self.builder.property("duration", duration);
+            self
+        }
+
+        pub fn size(mut self, size: u64) -> Self {
+            self.builder = self.builder.property("size", size);
+            self
+        }
+
+        pub fn headers(mut self, table: &FieldTable) -> Self {
+            self.builder = self.builder.property("headers", table);
+            self
+        }
+
+        pub fn body(mut self, body: &[u8]) -> Self {
+            let bytes = glib::Bytes::from(body);
+            self.builder = self.builder.property("body", bytes);
+            self
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use gio::prelude::ListModelExt;
+
+    use crate::{Field, RequestMethod};
+
+    use super::*;
+
+    fn request() -> Request {
+        Request::builder("https://www.example.com/api/users", RequestMethod::Get).build()
+    }
+
+    #[test]
+    pub fn test_builder() {
+        let response = Response::builder(&request()).build();
+        assert_eq!(response.status_code(), 0);
+        assert_eq!(response.duration(), 0);
+        assert_eq!(response.size(), 0);
+        assert_eq!(response.headers().n_items(), 0);
+        assert!(response.body().is_none());
+    }
+
+    #[test]
+    pub fn test_builder_full() {
+        let response_headers = FieldTable::from_iter(vec![
+            Field::builder("Server", "nginx/1.0").build(),
+            Field::builder("Content-Type", "text/plain").build(),
+        ]);
+        let response = Response::builder(&request())
+            .status_code(404)
+            .duration(532)
+            .size(1234)
+            .headers(&response_headers)
+            .body(b"Not found!")
+            .build();
+        assert_eq!(response.status_code(), 404);
+        assert_eq!(response.duration(), 532);
+        assert_eq!(response.size(), 1234);
+        assert_eq!(response.headers().n_items(), 2);
+        let data = response.body().unwrap().into_data();
+        assert_eq!(data.as_ref(), b"Not found!");
+    }
 }

--- a/cartero-objects/src/response.rs
+++ b/cartero-objects/src/response.rs
@@ -153,8 +153,11 @@ mod tests {
     #[test]
     pub fn test_builder_full() {
         let response_headers = FieldTable::from_iter(vec![
-            Field::builder("Server", "nginx/1.0").build(),
-            Field::builder("Content-Type", "text/plain").build(),
+            Field::builder().key("Server").value("nginx/1.0").build(),
+            Field::builder()
+                .key("Content-Type")
+                .value("text/plain")
+                .build(),
         ]);
         let response = Response::builder(&request())
             .status_code(404)


### PR DESCRIPTION
Writing GObject builder chains is tiresome:

```rust
let basic: RequestAuthenticationBasic = glib::Object::builder()
  .property("username", "admin")
  .property("password", "1234")
  .build();
```

This PR will introduce custom builders that map methods to properties, allowing to write it better like:

```rust
let basic = RequestAuthenticationBasic::builder()
  .username("admin")
  .password("1234")
  .build();
```