### PR TITLE
Fix NixOS flake

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,7 @@ jobs:
             name: x86_64
           - runs-on: ubuntu-24.04-arm
             name: aarch64
+      fail-fast: false
     runs-on: ${{ matrix.platform.runs-on }}
     name: "Flake ${{ matrix.platform.name }}"
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,21 @@ on:
       - trunk
 name: Build
 jobs:
+  flake:
+    strategy:
+      matrix:
+        platform:
+          - runs-on: ubuntu-latest
+            name: x86_64
+          - runs-on: ubuntu-24.04-arm
+            name: aarch64
+    runs-on: ${{ matrix.platform.runs-on }}
+    name: "Flake ${{ matrix.platform.name }}"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - run: nix build
+      - run: nix flake check
   flatpak:
     strategy:
       matrix:

--- a/default.nix
+++ b/default.nix
@@ -20,6 +20,7 @@ in
     nativeBuildInputs = with pkgs; [
       meson
       ninja
+      python313
       cargo
       rustc
       pkg-config
@@ -36,7 +37,7 @@ in
       gtksourceview5
       pango
       gdk-pixbuf
-      openssl_3_3
+      openssl_3
       graphene
       libadwaita
     ];
@@ -55,6 +56,10 @@ in
         type = "Application";
       })
     ];
+
+    postPatch = ''
+      patchShebangs build-aux/gen-version.py
+    '';
 
     configurePhase = ''
       runHook cargoSetupHook

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
             nativeBuildInputs = [
               meson
               ninja
+              python313
               cargo
               rustc
               rustfmt

--- a/flake.nix
+++ b/flake.nix
@@ -72,7 +72,7 @@
               gtksourceview5
               pango
               gdk-pixbuf
-              openssl_3_3
+              openssl_3
               graphene
               libadwaita
             ];


### PR DESCRIPTION
After making meson.build depend on the build-aux/gen-version.py script, it is now required to have Python 3 available to compile Cartero.

Patching the build-aux/gen-version.py shebang is now required because it needs to point to the real python3.

This branch will also add GitHub Actions integrations to check that the flake.nix works correctly.