### PR TITLE
Deploy to Snapcraft-Edge every night

### DIFF
--- a/.github/workflows/snapcraft-edge.yaml
+++ b/.github/workflows/snapcraft-edge.yaml
@@ -1,14 +1,31 @@
 name: Snapcraft Edge
 on:
-  push:
-    branches:
-      - trunk
-  pull_request:
-    branches:
-      - trunk
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
   workflow_dispatch:
 jobs:
+  new-commits:
+    name: Check if there are new commits
+    runs-on: ubuntu-latest
+    outputs:
+      new-commits: ${{ steps.check.outputs.new-commits }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: get new commits
+        id: check
+        run: |
+          if [ -z "$(git rev-list --after="24 hours" HEAD)" ]; then
+            echo "new-commits=false" >> $GITHUB_OUTPUT
+          else
+            echo "new-commits=true" >> $GITHUB_OUTPUT
+          fi
+
   publish:
+    needs: new-commits
+    if: ${{ needs.new-commits.outputs.new-commits == 'true' }}
     strategy:
       matrix:
         platform:

--- a/.github/workflows/snapcraft-edge.yaml
+++ b/.github/workflows/snapcraft-edge.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: snapcore/action-build@v1
         id: build-snap
-      - uses: snapcore-action/publish@v1
+      - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_LOGIN }}
         with:

--- a/.github/workflows/snapcraft-edge.yaml
+++ b/.github/workflows/snapcraft-edge.yaml
@@ -28,3 +28,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_LOGIN }}
         with:
           snap: ${{ steps.build-snap.outputs.snap }}
+          release: edge

--- a/.github/workflows/snapcraft-edge.yaml
+++ b/.github/workflows/snapcraft-edge.yaml
@@ -9,7 +9,16 @@ on:
   workflow_dispatch:
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform:
+          - runs-on: ubuntu-latest
+            name: x86_64
+          - runs-on: ubuntu-24.04-arm
+            name: aarch64
+      fail-fast: false
+    runs-on: ${{ matrix.platform.runs-on }}
+    name: "Edge ${{ matrix.platform.name }}"
     steps:
       - uses: actions/checkout@v4
       - uses: snapcore/action-build@v1

--- a/.github/workflows/snapcraft-edge.yaml
+++ b/.github/workflows/snapcraft-edge.yaml
@@ -2,10 +2,10 @@ name: Snapcraft Edge
 on:
   push:
     branches:
-      - main
+      - trunk
   pull_request:
     branches:
-      - main
+      - trunk
   workflow_dispatch:
 jobs:
   publish:

--- a/.github/workflows/snapcraft-edge.yaml
+++ b/.github/workflows/snapcraft-edge.yaml
@@ -1,0 +1,21 @@
+name: Snapcraft Edge
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snapcore/action-build@v1
+        id: build-snap
+      - uses: snapcore-action/publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.build-snap.outputs.snap }}

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,66 @@
+# This is the development / nightly version of Cartero only!
+# For the stable version, check out http://github.com/danirod/cartero-snap
+
+name: cartero
+base: core24
+version: 0.0.0
+adopt-info: cartero
+summary: Make HTTP requests and test APIs
+description: |
+  Cartero is a graphical HTTP client that can be used as a developer tool to
+  test web APIs and perform all kind of HTTP requests to web servers. It is
+  compatible with any REST, SOAP or XML-RPC API and it supports multiple
+  request methods as well as attaching body payloads to compatible requests.
+grade: devel
+
+confinement: strict
+license: GPL-3.0-or-later
+compression: lzo
+website: https://cartero.danirod.es
+source-code: https://github.com/danirod/cartero
+issues: https://github.com/danirod/cartero/issues
+
+platforms:
+  amd64:
+  arm64:
+
+apps:
+  cartero:
+    extensions: [gnome]
+    command: usr/bin/cartero
+    desktop: usr/share/applications/es.danirod.Cartero.Devel.desktop
+    common-id: es.danirod.Cartero.Devel
+    plugs:
+      - home
+      - removable-media
+      - gsettings
+      - network
+      - network-status
+
+parts:
+  rust:
+    plugin: rust
+    source: .
+    rust-channel: "1.88"
+    override-build: "" # nop
+    override-prime: "" # nop
+  cartero:
+    plugin: meson
+    source: .
+    build-packages:
+      - libssl-dev
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+      - -Dprofile=development
+    parse-info: [usr/share/metainfo/es.danirod.Cartero.Devel.metainfo.xml]
+    override-pull: |
+      craftctl default
+      craftctl set version="$(build-aux/gen-nightly-version.py --nightly)"
+      sed -i.bak -e 's|Icon=@app_id@|Icon=/usr/share/icons/hicolor/scalable/apps/es.danirod.Cartero.Devel.svg|' data/cartero.desktop.in.in
+
+slots:
+  cartero:
+    interface: dbus
+    bus: session
+    name: es.danirod.Cartero

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -56,7 +56,7 @@ parts:
     parse-info: [usr/share/metainfo/es.danirod.Cartero.Devel.metainfo.xml]
     override-pull: |
       craftctl default
-      craftctl set version="$(build-aux/gen-nightly-version.py --nightly)"
+      craftctl set version="$(build-aux/gen-version.py --nightly)"
       sed -i.bak -e 's|Icon=@app_id@|Icon=/usr/share/icons/hicolor/scalable/apps/es.danirod.Cartero.Devel.svg|' data/cartero.desktop.in.in
 
 slots:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -47,6 +47,8 @@ parts:
   cartero:
     plugin: meson
     source: .
+    build-environment.
+      - CARTERO_NIGHTLY_VERSION: 1
     build-packages:
       - libssl-dev
     meson-parameters:


### PR DESCRIPTION
This change will add a GitHub Action that triggers every night. If there is any new commit in the repository, it will compile an updated Snapcraft package based on the snapcraft.yaml recipe and upload it to the latest/edge channel of the [Snapcraft package](https://snapcraft.io/cartero).

The recipe is marked with grade=devel to prevent accidentally releasing it to stable, because it is a development build that contains code that may not be finished.