### PR TITLE
Move HTTP client to a separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,10 +183,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "cartero_http"
+version = "0.3.0"
+dependencies = [
+ "base64 0.22.1",
+ "cartero_objects",
+ "formdata",
+ "gio",
+ "glib",
+ "serde_urlencoded",
+ "srtemplate",
+ "url 2.5.4",
+]
+
+[[package]]
 name = "cartero_interop"
 version = "0.3.0"
 dependencies = [
  "cartero_objects",
+]
+
+[[package]]
+name = "cartero_isahc_client"
+version = "0.3.0"
+dependencies = [
+ "cartero_objects",
+ "isahc",
 ]
 
 [[package]]
@@ -196,6 +218,7 @@ dependencies = [
  "ctor",
  "gio",
  "glib",
+ "srtemplate",
 ]
 
 [[package]]
@@ -1849,9 +1872,9 @@ dependencies = [
 
 [[package]]
 name = "srtemplate"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ad90c2a5c43001b6daf78bd7757b78fea66ee1fb9fbda3458e470b4657701f"
+checksum = "e41fff3c5e0a3d397a26a90c6611eb922b771c02d353171224fc26798ae93789"
 dependencies = [
  "dashmap",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,10 @@ dependencies = [
 name = "cartero_isahc_client"
 version = "0.3.0"
 dependencies = [
+ "cartero_http",
  "cartero_objects",
+ "curl",
+ "futures-lite 2.6.0",
  "isahc",
 ]
 
@@ -285,9 +288,9 @@ checksum = "4f211af61d8efdd104f96e57adf5e426ba1bc3ed7a4ead616e15e5881fd79c4d"
 
 [[package]]
 name = "curl"
-version = "0.4.47"
+version = "0.4.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9fb4d13a1be2b58f14d60adba57c9834b78c62fd86c3e76a148f732686e9265"
+checksum = "9e2d5c8f48d9c0c23250e52b55e82a6ab4fdba6650c931f5a0a57a43abda812b"
 dependencies = [
  "curl-sys",
  "libc",
@@ -295,7 +298,7 @@ dependencies = [
  "openssl-sys",
  "schannel",
  "socket2",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/cartero-http/Cargo.toml
+++ b/cartero-http/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cartero_http"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+base64 = "0.22.1"
+cartero_objects = { path = "../cartero-objects" }
+url = "2.5.4"
+srtemplate = "0.3.3"
+glib.workspace = true
+gio.workspace = true
+serde_urlencoded = "0.7.1"
+formdata = "0.13.0"
+

--- a/cartero-http/README.md
+++ b/cartero-http/README.md
@@ -1,0 +1,8 @@
+cartero-http is the base library for working with the BoundRequest type, which
+is the kind of request that has been already processed and converted into a
+normalized HTTP request.
+
+You can use cartero-http as the basis to write an actual HTTP client that
+sends a Request object and gets a Response, or you can use cartero-http to
+write request exporters, such as "export to cURL", "export to HAR",
+"export to code"...

--- a/cartero-http/src/auth.rs
+++ b/cartero-http/src/auth.rs
@@ -1,0 +1,126 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use base64::prelude::*;
+use cartero_objects::{Request, RequestAuthenticationType};
+
+use crate::RequestPreconditionError;
+
+pub(crate) struct BoundHeaders(Vec<(String, String)>);
+
+impl BoundHeaders {
+    pub fn headers(&self) -> Vec<(String, String)> {
+        self.0.clone()
+    }
+}
+
+impl TryFrom<&Request> for BoundHeaders {
+    type Error = RequestPreconditionError;
+
+    fn try_from(value: &Request) -> Result<Self, Self::Error> {
+        let processor = value.template_processor();
+
+        let auth_type = value.authentication().auth_type();
+        let headers: Vec<(String, String)> = match auth_type {
+            RequestAuthenticationType::None | RequestAuthenticationType::Inherit => vec![],
+            RequestAuthenticationType::BasicAuth => {
+                let auth = value.authentication().basic_auth().unwrap();
+                let username = processor.render(auth.username())?;
+                let password = processor.render(auth.password())?;
+                basic_auth_headers(&username, &password)
+            }
+            RequestAuthenticationType::BearerToken => {
+                let bearer = value.authentication().bearer_token().unwrap();
+                let token = processor.render(bearer.token())?;
+                vec![("Authorization".to_string(), format!("Bearer {token}"))]
+            }
+        };
+        Ok(BoundHeaders(headers))
+    }
+}
+
+fn basic_auth_headers(username: &str, password: &str) -> Vec<(String, String)> {
+    let input = format!("{username}:{password}");
+    let hash = BASE64_STANDARD.encode(input);
+    let hashed = format!("Basic {hash}");
+    vec![("Authorization".to_string(), hashed)]
+}
+
+#[cfg(test)]
+mod tests {
+    use cartero_objects::{
+        Request, RequestAuthentication, RequestAuthenticationBasic, RequestAuthenticationBearer,
+        RequestMethod,
+    };
+
+    use crate::auth::BoundHeaders;
+
+    #[test]
+    fn test_authentication_none() {
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_auth(RequestAuthentication::builder().none().build())
+            .build();
+
+        let BoundHeaders(headers) = BoundHeaders::try_from(&req).unwrap();
+        assert_eq!(headers.len(), 0);
+    }
+
+    #[test]
+    fn test_authentication_inherit() {
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_auth(RequestAuthentication::builder().inherit().build())
+            .build();
+
+        let BoundHeaders(headers) = BoundHeaders::try_from(&req).unwrap();
+        assert_eq!(headers.len(), 0);
+    }
+
+    #[test]
+    fn test_authentication_token() {
+        let bearer = RequestAuthenticationBearer::builder()
+            .token("12341234")
+            .build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_auth(
+                RequestAuthentication::builder()
+                    .bearer_token(&bearer)
+                    .build(),
+            )
+            .build();
+
+        let BoundHeaders(headers) = BoundHeaders::try_from(&req).unwrap();
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].0, "Authorization");
+        assert_eq!(headers[0].1, "Bearer 12341234");
+    }
+
+    #[test]
+    fn test_authentication_basic() {
+        let basic = RequestAuthenticationBasic::builder()
+            .username("admin")
+            .password("1234")
+            .build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_auth(RequestAuthentication::builder().basic_auth(&basic).build())
+            .build();
+
+        let BoundHeaders(headers) = BoundHeaders::try_from(&req).unwrap();
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0].0, "Authorization");
+        assert_eq!(headers[0].1, "Basic YWRtaW46MTIzNA==");
+    }
+}

--- a/cartero-http/src/auth.rs
+++ b/cartero-http/src/auth.rs
@@ -18,7 +18,7 @@
 use base64::prelude::*;
 use cartero_objects::{Request, RequestAuthenticationType};
 
-use crate::RequestPreconditionError;
+use crate::RequestError;
 
 pub(crate) struct BoundHeaders(Vec<(String, String)>);
 
@@ -29,7 +29,7 @@ impl BoundHeaders {
 }
 
 impl TryFrom<&Request> for BoundHeaders {
-    type Error = RequestPreconditionError;
+    type Error = RequestError;
 
     fn try_from(value: &Request) -> Result<Self, Self::Error> {
         let processor = value.template_processor();

--- a/cartero-http/src/body.rs
+++ b/cartero-http/src/body.rs
@@ -1,0 +1,445 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::io::{BufWriter, Write};
+
+use cartero_objects::{Request, RequestBodyRawType, RequestBodyType};
+
+use crate::{active_pairs, RequestPreconditionError};
+
+#[derive(Default)]
+pub(crate) struct BoundBody {
+    content: Option<Vec<u8>>,
+    headers: Vec<(String, String)>,
+}
+
+impl BoundBody {
+    pub fn headers(&self) -> Vec<(String, String)> {
+        self.headers.clone()
+    }
+
+    pub fn body(&self) -> Option<Vec<u8>> {
+        self.content.clone()
+    }
+}
+
+impl TryFrom<&Request> for BoundBody {
+    type Error = RequestPreconditionError;
+
+    fn try_from(value: &Request) -> Result<Self, Self::Error> {
+        let body_type = value.body().body_type();
+
+        match body_type {
+            RequestBodyType::None => Ok(BoundBody::default()),
+            RequestBodyType::UrlEncoded => Self::try_from_urlencoded(value),
+            RequestBodyType::Multipart => Self::try_from_multipart(value),
+            RequestBodyType::Raw => Self::try_from_raw(value),
+        }
+    }
+}
+
+impl BoundBody {
+    fn try_from_urlencoded(value: &Request) -> Result<Self, RequestPreconditionError> {
+        let urlencoded = value.body().urlencoded().unwrap();
+
+        let context = value.template_processor();
+        let values = urlencoded.params().render(&context)?;
+        let pairs = active_pairs(&values);
+        let body = serde_urlencoded::to_string(pairs)
+            .map_err(|_| RequestPreconditionError::EncodingError)?;
+        let raw = Vec::from(body.as_str());
+
+        let headers = vec![(
+            "Content-Type".into(),
+            "application/x-www-form-urlencoded".into(),
+        )];
+        Ok(Self {
+            headers,
+            content: Some(raw),
+        })
+    }
+
+    fn try_from_multipart(value: &Request) -> Result<Self, RequestPreconditionError> {
+        let multipart = value.body().multipart().unwrap();
+
+        let context = value.template_processor();
+        let values = multipart.params().render(&context)?;
+        let pairs = active_pairs(&values);
+
+        let boundary = formdata::generate_boundary();
+        let formdata = formdata::FormData {
+            fields: pairs,
+            // TODO: as soon as we have collections, add files
+            files: vec![],
+        };
+        let mut stream = BufWriter::new(Vec::new());
+        formdata::write_formdata(&mut stream, &boundary, &formdata).map_err(|e| {
+            glib::g_error!("cartero", "form data error: {}", e);
+            RequestPreconditionError::EncodingError
+        })?;
+        stream
+            .flush()
+            .map_err(|_| RequestPreconditionError::EncodingError)?;
+
+        let body = stream.get_ref().clone();
+        let content_type = format!(
+            "multipart/form-data; boundary={}",
+            String::from_utf8_lossy(&boundary)
+        );
+        let headers = vec![("Content-Type".into(), content_type)];
+        Ok(Self {
+            headers,
+            content: Some(body),
+        })
+    }
+
+    fn try_from_raw(value: &Request) -> Result<Self, RequestPreconditionError> {
+        let raw = value.body().raw().unwrap();
+        let content = raw.payload();
+        let encoding = raw.payload_type();
+
+        let processor = value.template_processor();
+        let body = String::from_utf8_lossy(&content);
+        let interpolated = processor.render(&body)?;
+
+        let content_type = match encoding {
+            RequestBodyRawType::OctetStream => "application/octet-stream",
+            RequestBodyRawType::Xml => "application/xml",
+            RequestBodyRawType::Json => "application/json",
+        };
+        Ok(Self {
+            content: Some(Vec::from(interpolated.as_str())),
+            headers: vec![("Content-Type".into(), content_type.into())],
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cartero_objects::*;
+
+    use super::*;
+
+    #[test]
+    fn test_urlencoded() {
+        let field_table = FieldTable::from_iter(vec![
+            Field::builder().key("category").value("10").build(),
+            Field::builder()
+                .key("user_id")
+                .value("200")
+                .active(false)
+                .build(),
+            Field::builder().key("superuser").value("true").build(),
+        ]);
+
+        let urlenc = RequestBodyUrlencoded::builder()
+            .params(&field_table)
+            .build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_body(RequestBody::builder().urlencoded(&urlenc).build())
+            .build();
+
+        let result = BoundBody::try_from(&req).unwrap();
+
+        assert_eq!(1, result.headers.len());
+        assert_eq!("Content-Type", result.headers[0].0);
+        assert_eq!("application/x-www-form-urlencoded", result.headers[0].1);
+
+        assert!(result.content.is_some());
+        assert_eq!(
+            b"category=10&superuser=true",
+            result.content.unwrap().as_slice()
+        );
+    }
+
+    #[test]
+    fn test_urlencoded_with_variables() {
+        let field_table = FieldTable::from_iter(vec![
+            Field::builder()
+                .key("category")
+                .value("{{CATEGORY}}")
+                .build(),
+            Field::builder()
+                .key("user_id")
+                .value("200")
+                .active(false)
+                .build(),
+            Field::builder().key("superuser").value("true").build(),
+        ]);
+
+        let urlenc = RequestBodyUrlencoded::builder()
+            .params(&field_table)
+            .build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_body(RequestBody::builder().urlencoded(&urlenc).build())
+            .variable(&Field::builder().key("CATEGORY").value("30").build())
+            .build();
+
+        let result = BoundBody::try_from(&req).unwrap();
+
+        assert_eq!(1, result.headers.len());
+        assert_eq!("Content-Type", result.headers[0].0);
+        assert_eq!("application/x-www-form-urlencoded", result.headers[0].1);
+
+        assert!(result.content.is_some());
+        assert_eq!(
+            b"category=30&superuser=true",
+            result.content.unwrap().as_slice()
+        );
+    }
+
+    #[test]
+    fn test_multipart() {
+        let field_table = FieldTable::from_iter(vec![
+            Field::builder().key("category").value("10").build(),
+            Field::builder()
+                .key("user_id")
+                .value("200")
+                .active(false)
+                .build(),
+            Field::builder().key("superuser").value("true").build(),
+        ]);
+
+        let mpart = RequestBodyMultipart::builder().params(&field_table).build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_body(RequestBody::builder().multipart(&mpart).build())
+            .build();
+
+        let result = BoundBody::try_from(&req).unwrap();
+
+        assert_eq!(1, result.headers.len());
+        assert_eq!("Content-Type", result.headers[0].0);
+
+        assert!(result.headers[0]
+            .1
+            .starts_with("multipart/form-data; boundary="));
+        let boundary = result.headers[0]
+            .1
+            .replace("multipart/form-data; boundary=", "");
+
+        let Some(content) = result.content else {
+            panic!("expected some content");
+        };
+        let body = String::from_utf8_lossy(&content);
+        let expected = {
+            let lines = vec![
+                format!("--{boundary}"),
+                "Content-Type: text/plain".into(),
+                "Content-Disposition: form-data; name=\"category\"".into(),
+                "".into(),
+                "10".into(),
+                format!("--{boundary}"),
+                "Content-Type: text/plain".into(),
+                "Content-Disposition: form-data; name=\"superuser\"".into(),
+                "".into(),
+                "true".into(),
+                format!("--{boundary}--"),
+            ];
+            lines.join("\r\n")
+        };
+        assert_eq!(expected, body);
+    }
+
+    #[test]
+    fn test_multipart_with_variables() {
+        let field_table = FieldTable::from_iter(vec![
+            Field::builder()
+                .key("category")
+                .value("{{CATEGORY}}")
+                .build(),
+            Field::builder()
+                .key("user_id")
+                .value("200")
+                .active(false)
+                .build(),
+            Field::builder().key("superuser").value("true").build(),
+        ]);
+
+        let mpart = RequestBodyMultipart::builder().params(&field_table).build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_body(RequestBody::builder().multipart(&mpart).build())
+            .variable(&Field::builder().key("CATEGORY").value("30").build())
+            .build();
+
+        let result = BoundBody::try_from(&req).unwrap();
+
+        assert_eq!(1, result.headers.len());
+        assert_eq!("Content-Type", result.headers[0].0);
+
+        assert!(result.headers[0]
+            .1
+            .starts_with("multipart/form-data; boundary="));
+        let boundary = result.headers[0]
+            .1
+            .replace("multipart/form-data; boundary=", "");
+
+        let Some(content) = result.content else {
+            panic!("expected some content");
+        };
+        let body = String::from_utf8_lossy(&content);
+        let expected = {
+            let lines = vec![
+                format!("--{boundary}"),
+                "Content-Type: text/plain".into(),
+                "Content-Disposition: form-data; name=\"category\"".into(),
+                "".into(),
+                "30".into(),
+                format!("--{boundary}"),
+                "Content-Type: text/plain".into(),
+                "Content-Disposition: form-data; name=\"superuser\"".into(),
+                "".into(),
+                "true".into(),
+                format!("--{boundary}--"),
+            ];
+            lines.join("\r\n")
+        };
+        assert_eq!(expected, body);
+    }
+
+    #[test]
+    fn test_octet_stream() {
+        let raw = RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
+            .payload(&glib::Bytes::from(b"the payload"))
+            .build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_body(RequestBody::builder().raw(&raw).build())
+            .build();
+
+        let result = BoundBody::try_from(&req).unwrap();
+
+        assert_eq!(1, result.headers.len());
+        assert_eq!("Content-Type", result.headers[0].0);
+        assert_eq!("application/octet-stream", result.headers[0].1);
+
+        assert!(result.content.is_some());
+        assert_eq!(b"the payload", result.content.unwrap().as_slice());
+    }
+
+    #[test]
+    fn test_octet_stream_with_variables() {
+        let raw = RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
+            .payload(&glib::Bytes::from(b"Hello {{NAME}}!"))
+            .build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_body(RequestBody::builder().raw(&raw).build())
+            .variable(&Field::builder().key("NAME").value("world").build())
+            .build();
+
+        let result = BoundBody::try_from(&req).unwrap();
+
+        assert_eq!(1, result.headers.len());
+        assert_eq!("Content-Type", result.headers[0].0);
+        assert_eq!("application/octet-stream", result.headers[0].1);
+
+        assert!(result.content.is_some());
+        assert_eq!(b"Hello world!", result.content.unwrap().as_slice());
+    }
+
+    #[test]
+    fn test_xml() {
+        let raw = RequestBodyRaw::builder(RequestBodyRawType::Xml)
+            .payload(&glib::Bytes::from(
+                b"<?xml version=\"1.0\" ?><hello who=\"world\" />",
+            ))
+            .build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_body(RequestBody::builder().raw(&raw).build())
+            .build();
+
+        let result = BoundBody::try_from(&req).unwrap();
+
+        assert_eq!(1, result.headers.len());
+        assert_eq!("Content-Type", result.headers[0].0);
+        assert_eq!("application/xml", result.headers[0].1);
+
+        assert!(result.content.is_some());
+        assert_eq!(
+            b"<?xml version=\"1.0\" ?><hello who=\"world\" />",
+            result.content.unwrap().as_slice()
+        );
+    }
+
+    #[test]
+    fn test_xml_with_variables() {
+        let raw = RequestBodyRaw::builder(RequestBodyRawType::Xml)
+            .payload(&glib::Bytes::from(
+                b"<?xml version=\"1.0\" ?><hello who=\"{{USER}}\" />",
+            ))
+            .build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_body(RequestBody::builder().raw(&raw).build())
+            .variable(&Field::builder().key("USER").value("world").build())
+            .build();
+
+        let result = BoundBody::try_from(&req).unwrap();
+
+        assert_eq!(1, result.headers.len());
+        assert_eq!("Content-Type", result.headers[0].0);
+        assert_eq!("application/xml", result.headers[0].1);
+
+        assert!(result.content.is_some());
+        assert_eq!(
+            b"<?xml version=\"1.0\" ?><hello who=\"world\" />",
+            result.content.unwrap().as_slice()
+        );
+    }
+
+    #[test]
+    fn test_json() {
+        let raw = RequestBodyRaw::builder(RequestBodyRawType::Json)
+            .payload(&glib::Bytes::from(b"{\"hello\": \"world\"}"))
+            .build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_body(RequestBody::builder().raw(&raw).build())
+            .build();
+
+        let result = BoundBody::try_from(&req).unwrap();
+
+        assert_eq!(1, result.headers.len());
+        assert_eq!("Content-Type", result.headers[0].0);
+        assert_eq!("application/json", result.headers[0].1);
+
+        assert!(result.content.is_some());
+        assert_eq!(
+            b"{\"hello\": \"world\"}",
+            result.content.unwrap().as_slice()
+        );
+    }
+
+    #[test]
+    fn test_json_with_variables() {
+        let raw = RequestBodyRaw::builder(RequestBodyRawType::Json)
+            .payload(&glib::Bytes::from(b"{\"hello\": \"{{USER}}\"}"))
+            .build();
+        let req = Request::builder("https://www.example.com", RequestMethod::Get)
+            .with_body(RequestBody::builder().raw(&raw).build())
+            .variable(&Field::builder().key("USER").value("world").build())
+            .build();
+
+        let result = BoundBody::try_from(&req).unwrap();
+
+        assert_eq!(1, result.headers.len());
+        assert_eq!("Content-Type", result.headers[0].0);
+        assert_eq!("application/json", result.headers[0].1);
+
+        assert!(result.content.is_some());
+        assert_eq!(
+            b"{\"hello\": \"world\"}",
+            result.content.unwrap().as_slice()
+        );
+    }
+}

--- a/cartero-http/src/body.rs
+++ b/cartero-http/src/body.rs
@@ -19,7 +19,7 @@ use std::io::{BufWriter, Write};
 
 use cartero_objects::{Request, RequestBodyRawType, RequestBodyType};
 
-use crate::{active_pairs, RequestPreconditionError};
+use crate::{active_pairs, RequestError};
 
 #[derive(Default)]
 pub(crate) struct BoundBody {
@@ -38,7 +38,7 @@ impl BoundBody {
 }
 
 impl TryFrom<&Request> for BoundBody {
-    type Error = RequestPreconditionError;
+    type Error = RequestError;
 
     fn try_from(value: &Request) -> Result<Self, Self::Error> {
         let body_type = value.body().body_type();
@@ -53,14 +53,13 @@ impl TryFrom<&Request> for BoundBody {
 }
 
 impl BoundBody {
-    fn try_from_urlencoded(value: &Request) -> Result<Self, RequestPreconditionError> {
+    fn try_from_urlencoded(value: &Request) -> Result<Self, RequestError> {
         let urlencoded = value.body().urlencoded().unwrap();
 
         let context = value.template_processor();
         let values = urlencoded.params().render(&context)?;
         let pairs = active_pairs(&values);
-        let body = serde_urlencoded::to_string(pairs)
-            .map_err(|_| RequestPreconditionError::EncodingError)?;
+        let body = serde_urlencoded::to_string(pairs).map_err(|_| RequestError::EncodingError)?;
         let raw = Vec::from(body.as_str());
 
         let headers = vec![(
@@ -73,7 +72,7 @@ impl BoundBody {
         })
     }
 
-    fn try_from_multipart(value: &Request) -> Result<Self, RequestPreconditionError> {
+    fn try_from_multipart(value: &Request) -> Result<Self, RequestError> {
         let multipart = value.body().multipart().unwrap();
 
         let context = value.template_processor();
@@ -89,11 +88,9 @@ impl BoundBody {
         let mut stream = BufWriter::new(Vec::new());
         formdata::write_formdata(&mut stream, &boundary, &formdata).map_err(|e| {
             glib::g_error!("cartero", "form data error: {}", e);
-            RequestPreconditionError::EncodingError
+            RequestError::EncodingError
         })?;
-        stream
-            .flush()
-            .map_err(|_| RequestPreconditionError::EncodingError)?;
+        stream.flush().map_err(|_| RequestError::EncodingError)?;
 
         let body = stream.get_ref().clone();
         let content_type = format!(
@@ -107,7 +104,7 @@ impl BoundBody {
         })
     }
 
-    fn try_from_raw(value: &Request) -> Result<Self, RequestPreconditionError> {
+    fn try_from_raw(value: &Request) -> Result<Self, RequestError> {
         let raw = value.body().raw().unwrap();
         let content = raw.payload();
         let encoding = raw.payload_type();

--- a/cartero-http/src/environment.rs
+++ b/cartero-http/src/environment.rs
@@ -1,0 +1,26 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pub struct ClientConfig {
+    pub validate_tls: bool,
+    pub redirects: u64,
+    pub timeout: f64,
+}
+
+pub struct RequestEnvironment {
+    pub config: ClientConfig,
+}

--- a/cartero-http/src/from.rs
+++ b/cartero-http/src/from.rs
@@ -1,0 +1,273 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::collections::HashMap;
+
+use cartero_objects::{FieldTable, Request};
+
+use crate::{
+    active_pairs, auth::BoundHeaders, body::BoundBody, url::normalize_url, BoundRequest,
+    RequestPreconditionError,
+};
+
+impl TryFrom<Request> for BoundRequest {
+    type Error = RequestPreconditionError;
+
+    fn try_from(value: Request) -> Result<Self, Self::Error> {
+        let processor = value.template_processor();
+
+        let url = processor.render(&value.url())?;
+        let url = normalize_url(&url)?;
+
+        let method = value.method().clone();
+
+        let user_headers = value.headers().render(&processor)?;
+        let auth = BoundHeaders::try_from(&value)?;
+        let body = BoundBody::try_from(&value)?;
+        let headers = combine_headers(&user_headers, &auth, &body);
+
+        Ok(Self {
+            url,
+            method,
+            headers,
+            body: body.body(),
+        })
+    }
+}
+
+fn combine_headers(
+    headers: &FieldTable,
+    auth: &BoundHeaders,
+    body: &BoundBody,
+) -> HashMap<String, String> {
+    // Priority: auth + body < headers. So first we process auth and body, and
+    // then maybe override the pregenerated headers with whatever the user has
+    // typed in the Headers tab.
+
+    let mut combined = HashMap::new();
+    combined.extend(auth.headers());
+    combined.extend(body.headers());
+
+    let pairs = active_pairs(&headers);
+    combined.extend(pairs);
+    combined
+}
+
+#[cfg(test)]
+mod tests {
+    use cartero_objects::{
+        Field, Request, RequestAuthentication, RequestAuthenticationBasic, RequestBody,
+        RequestBodyUrlencoded, RequestMethod,
+    };
+
+    use crate::BoundRequest;
+
+    #[test]
+    fn test_convert() {
+        let req = Request::builder(
+            "https://www.example.com/api/v1/users",
+            cartero_objects::RequestMethod::Get,
+        )
+        .build();
+
+        let bound = BoundRequest::try_from(req).unwrap();
+        assert_eq!(bound.url, "https://www.example.com/api/v1/users");
+        assert_eq!(bound.method, RequestMethod::Get);
+        assert_eq!(0, bound.headers.len());
+        assert!(bound.body.is_none());
+    }
+
+    #[test]
+    fn test_convert_variable_in_url() {
+        let req = Request::builder(
+            "{{ API_ROOT }}/api/v1/users",
+            cartero_objects::RequestMethod::Get,
+        )
+        .variable(
+            &Field::builder()
+                .key("API_ROOT")
+                .value("https://www.example.com")
+                .build(),
+        )
+        .build();
+
+        let bound = BoundRequest::try_from(req).unwrap();
+        assert_eq!(bound.url, "https://www.example.com/api/v1/users");
+        assert_eq!(bound.method, RequestMethod::Get);
+        assert_eq!(0, bound.headers.len());
+        assert!(bound.body.is_none());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_convert_variable_in_url_without_variable() {
+        let req = Request::builder(
+            "{{ API_ROOT }}/api/v1/users",
+            cartero_objects::RequestMethod::Get,
+        )
+        .build();
+
+        BoundRequest::try_from(req).unwrap();
+    }
+
+    #[test]
+    fn test_auth_is_added_to_headers() {
+        let auth = RequestAuthenticationBasic::builder()
+            .username("admin")
+            .password("admin")
+            .build();
+        let auth = RequestAuthentication::builder().basic_auth(&auth).build();
+        let req = Request::builder(
+            "https://www.example.com/api/v1/users",
+            cartero_objects::RequestMethod::Get,
+        )
+        .with_auth(auth)
+        .build();
+        let bound = BoundRequest::try_from(req).unwrap();
+        assert_eq!(bound.url, "https://www.example.com/api/v1/users");
+        assert_eq!(RequestMethod::Get, bound.method);
+        assert!(bound.body.is_none());
+        assert_eq!(bound.headers["Authorization"], "Basic YWRtaW46YWRtaW4=");
+    }
+
+    #[test]
+    fn test_headers_can_override_auth() {
+        // It's dumb, but yeah, you totally can.
+        let auth = RequestAuthenticationBasic::builder()
+            .username("admin")
+            .password("admin")
+            .build();
+        let auth = RequestAuthentication::builder().basic_auth(&auth).build();
+        let req = Request::builder(
+            "https://www.example.com/api/v1/users",
+            cartero_objects::RequestMethod::Get,
+        )
+        .with_auth(auth)
+        .header(
+            &Field::builder()
+                .key("Authorization")
+                .value("Bearer 1234")
+                .build(),
+        )
+        .build();
+        let bound = BoundRequest::try_from(req).unwrap();
+        assert_eq!(bound.url, "https://www.example.com/api/v1/users");
+        assert_eq!(RequestMethod::Get, bound.method);
+        assert!(bound.body.is_none());
+        assert_eq!(bound.headers["Authorization"], "Bearer 1234");
+    }
+
+    #[test]
+    fn test_headers_cannot_override_auth_if_disabled() {
+        let auth = RequestAuthenticationBasic::builder()
+            .username("admin")
+            .password("admin")
+            .build();
+        let auth = RequestAuthentication::builder().basic_auth(&auth).build();
+        let req = Request::builder(
+            "https://www.example.com/api/v1/users",
+            cartero_objects::RequestMethod::Get,
+        )
+        .with_auth(auth)
+        .header(
+            &Field::builder()
+                .key("Authorization")
+                .value("Bearer 1234")
+                .active(false)
+                .build(),
+        )
+        .build();
+        let bound = BoundRequest::try_from(req).unwrap();
+        assert_eq!(bound.url, "https://www.example.com/api/v1/users");
+        assert_eq!(RequestMethod::Get, bound.method);
+        assert!(bound.body.is_none());
+        assert_eq!(bound.headers["Authorization"], "Basic YWRtaW46YWRtaW4=");
+    }
+
+    #[test]
+    fn test_body_is_added_to_headers() {
+        let body = RequestBodyUrlencoded::builder()
+            .field(&Field::builder().key("user_id").value("10").build())
+            .field(&Field::builder().key("category_id").value("2").build())
+            .build();
+        let body = RequestBody::builder().urlencoded(&body).build();
+        let req = Request::builder("https://www.example.com/api/v1/users", RequestMethod::Post)
+            .with_body(body)
+            .build();
+        let bound = BoundRequest::try_from(req).unwrap();
+        assert_eq!(bound.url, "https://www.example.com/api/v1/users");
+        assert_eq!(RequestMethod::Post, bound.method);
+        assert_eq!(
+            bound.headers["Content-Type"],
+            "application/x-www-form-urlencoded"
+        );
+        let body = bound.body.unwrap();
+        assert_eq!(b"user_id=10&category_id=2", body.as_slice());
+    }
+
+    #[test]
+    fn test_headers_can_override_body() {
+        let body = RequestBodyUrlencoded::builder()
+            .field(&Field::builder().key("user_id").value("10").build())
+            .field(&Field::builder().key("category_id").value("2").build())
+            .build();
+        let body = RequestBody::builder().urlencoded(&body).build();
+        let req = Request::builder("https://www.example.com/api/v1/users", RequestMethod::Post)
+            .with_body(body)
+            .header(
+                &Field::builder()
+                    .key("Content-Type")
+                    .value("application/octet-stream")
+                    .build(),
+            )
+            .build();
+        let bound = BoundRequest::try_from(req).unwrap();
+        assert_eq!(bound.url, "https://www.example.com/api/v1/users");
+        assert_eq!(RequestMethod::Post, bound.method);
+        assert_eq!(bound.headers["Content-Type"], "application/octet-stream");
+        let body = bound.body.unwrap();
+        assert_eq!(b"user_id=10&category_id=2", body.as_slice());
+    }
+
+    #[test]
+    fn test_headers_cannot_override_body_if_disabled() {
+        let body = RequestBodyUrlencoded::builder()
+            .field(&Field::builder().key("user_id").value("10").build())
+            .field(&Field::builder().key("category_id").value("2").build())
+            .build();
+        let body = RequestBody::builder().urlencoded(&body).build();
+        let req = Request::builder("https://www.example.com/api/v1/users", RequestMethod::Post)
+            .with_body(body)
+            .header(
+                &Field::builder()
+                    .key("Content-Type")
+                    .value("application/octet-stream")
+                    .active(false)
+                    .build(),
+            )
+            .build();
+        let bound = BoundRequest::try_from(req).unwrap();
+        assert_eq!(bound.url, "https://www.example.com/api/v1/users");
+        assert_eq!(RequestMethod::Post, bound.method);
+        assert_eq!(
+            bound.headers["Content-Type"],
+            "application/x-www-form-urlencoded"
+        );
+        let body = bound.body.unwrap();
+        assert_eq!(b"user_id=10&category_id=2", body.as_slice());
+    }
+}

--- a/cartero-http/src/lib.rs
+++ b/cartero-http/src/lib.rs
@@ -1,0 +1,89 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::collections::HashMap;
+
+use cartero_objects::{Field, FieldTable, RequestMethod};
+
+mod auth;
+mod body;
+mod from;
+mod url;
+
+pub struct BoundRequest {
+    pub url: String,
+    pub method: RequestMethod,
+    pub headers: HashMap<String, String>,
+    pub body: Option<Vec<u8>>,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum RequestPreconditionError {
+    UrlBadParse,
+    MissingProtocol,
+    UnsupportedProtocol(String),
+    EncodingError,
+    VariableNotFound(String),
+    BadInterpolation,
+}
+
+impl From<srtemplate::Error> for RequestPreconditionError {
+    fn from(value: srtemplate::Error) -> Self {
+        match value {
+            srtemplate::Error::VariableNotFound(var) => Self::VariableNotFound(var),
+            _ => Self::BadInterpolation,
+        }
+    }
+}
+
+use gio::prelude::ListModelExtManual;
+
+pub(crate) fn active_pairs(table: &FieldTable) -> Vec<(String, String)> {
+    table
+        .iter::<Field>()
+        .filter_map(|elem| elem.ok())
+        .filter(Field::active)
+        .map(|field| (field.key(), field.value()))
+        .collect::<Vec<(String, String)>>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_active_pairs() {
+        let field_table = FieldTable::from_iter(vec![
+            Field::builder().key("category").value("10").build(),
+            Field::builder()
+                .key("user_id")
+                .value("200")
+                .active(false)
+                .build(),
+            Field::builder().key("superuser").value("true").build(),
+        ]);
+
+        let pairs = active_pairs(&field_table);
+        assert_eq!(2, pairs.len());
+
+        // The order is important at this point since there might be overrides.
+        assert_eq!("category", pairs[0].0);
+        assert_eq!("10", pairs[0].1);
+        assert_eq!("superuser", pairs[1].0);
+        assert_eq!("true", pairs[1].1);
+    }
+}

--- a/cartero-http/src/lib.rs
+++ b/cartero-http/src/lib.rs
@@ -15,33 +15,38 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use std::collections::HashMap;
-
-use cartero_objects::{Field, FieldTable, RequestMethod};
+use cartero_objects::{Field, FieldTable};
+use std::error::Error as StdError;
 
 mod auth;
 mod body;
-mod from;
+mod environment;
+mod request;
 mod url;
 
-pub struct BoundRequest {
-    pub url: String,
-    pub method: RequestMethod,
-    pub headers: HashMap<String, String>,
-    pub body: Option<Vec<u8>>,
-}
+pub use environment::*;
+pub use request::BoundRequest;
 
-#[derive(Debug, Eq, PartialEq)]
-pub enum RequestPreconditionError {
+#[derive(Debug)]
+pub enum RequestError {
     UrlBadParse,
     MissingProtocol,
-    UnsupportedProtocol(String),
-    EncodingError,
-    VariableNotFound(String),
-    BadInterpolation,
+    UnsupportedProtocol(String), // Protocol {} not supported
+
+    VariableNotFound(String), // Variable {} not found
+    BadInterpolation,         // (variable interpolation)
+
+    InvalidHeaderName(String),  // Header {} is invalid
+    InvalidHeaderValue(String), // Header {} has an invalid value
+
+    EncodingError, // (body encoding)
+
+    // network error during the request (the type is up to the implementor)
+    NetworkError(Box<dyn StdError>),
+    IOError(Box<dyn StdError>),
 }
 
-impl From<srtemplate::Error> for RequestPreconditionError {
+impl From<srtemplate::Error> for RequestError {
     fn from(value: srtemplate::Error) -> Self {
         match value {
             srtemplate::Error::VariableNotFound(var) => Self::VariableNotFound(var),

--- a/cartero-http/src/request.rs
+++ b/cartero-http/src/request.rs
@@ -17,23 +17,27 @@
 
 use std::collections::HashMap;
 
-use cartero_objects::{FieldTable, Request};
+use cartero_objects::{FieldTable, Request, RequestMethod};
 
-use crate::{
-    active_pairs, auth::BoundHeaders, body::BoundBody, url::normalize_url, BoundRequest,
-    RequestPreconditionError,
-};
+use crate::{active_pairs, auth::BoundHeaders, body::BoundBody, url::normalize_url, RequestError};
+
+pub struct BoundRequest {
+    pub url: String,
+    pub method: RequestMethod,
+    pub headers: HashMap<String, String>,
+    pub body: Option<Vec<u8>>,
+}
 
 impl TryFrom<Request> for BoundRequest {
-    type Error = RequestPreconditionError;
+    type Error = RequestError;
 
     fn try_from(value: Request) -> Result<Self, Self::Error> {
         let processor = value.template_processor();
 
-        let url = processor.render(&value.url())?;
+        let url = processor.render(value.url())?;
         let url = normalize_url(&url)?;
 
-        let method = value.method().clone();
+        let method = value.method();
 
         let user_headers = value.headers().render(&processor)?;
         let auth = BoundHeaders::try_from(&value)?;
@@ -62,7 +66,7 @@ fn combine_headers(
     combined.extend(auth.headers());
     combined.extend(body.headers());
 
-    let pairs = active_pairs(&headers);
+    let pairs = active_pairs(headers);
     combined.extend(pairs);
     combined
 }

--- a/cartero-http/src/url.rs
+++ b/cartero-http/src/url.rs
@@ -17,32 +17,28 @@
 
 use url::Url;
 
-use crate::RequestPreconditionError;
+use crate::RequestError;
 
-pub(crate) fn normalize_url(url: &str) -> Result<String, RequestPreconditionError> {
+pub(crate) fn normalize_url(url: &str) -> Result<String, RequestError> {
     if !url.contains("://") {
-        return Err(RequestPreconditionError::MissingProtocol);
+        return Err(RequestError::MissingProtocol);
     }
     match Url::parse(url) {
         Ok(url) => {
             // Check for protocol as well.
             match url.scheme() {
                 "http" | "https" => Ok(url.to_string()),
-                other => Err(RequestPreconditionError::UnsupportedProtocol(
-                    other.to_owned(),
-                )),
+                other => Err(RequestError::UnsupportedProtocol(other.to_owned())),
             }
         }
-        Err(url::ParseError::RelativeUrlWithoutBase) => {
-            Err(RequestPreconditionError::MissingProtocol)
-        }
-        Err(_) => Err(RequestPreconditionError::UrlBadParse),
+        Err(url::ParseError::RelativeUrlWithoutBase) => Err(RequestError::MissingProtocol),
+        Err(_) => Err(RequestError::UrlBadParse),
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{url::normalize_url, RequestPreconditionError};
+    use crate::{url::normalize_url, RequestError};
 
     #[test]
     pub fn test_url_normalization() {
@@ -102,14 +98,14 @@ mod tests {
 
         for url in wrong_protocol {
             let result = normalize_url(url);
-            let Err(RequestPreconditionError::UnsupportedProtocol(_)) = result else {
+            let Err(RequestError::UnsupportedProtocol(_)) = result else {
                 panic!("{} should have been an unsupported protocol", url);
             };
         }
 
         for url in missing_protocol {
             let result = normalize_url(url);
-            assert_eq!(Err(RequestPreconditionError::MissingProtocol), result);
+            assert!(result.is_err());
         }
     }
 

--- a/cartero-http/src/url.rs
+++ b/cartero-http/src/url.rs
@@ -1,0 +1,136 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use url::Url;
+
+use crate::RequestPreconditionError;
+
+pub(crate) fn normalize_url(url: &str) -> Result<String, RequestPreconditionError> {
+    if !url.contains("://") {
+        return Err(RequestPreconditionError::MissingProtocol);
+    }
+    match Url::parse(url) {
+        Ok(url) => {
+            // Check for protocol as well.
+            match url.scheme() {
+                "http" | "https" => Ok(url.to_string()),
+                other => Err(RequestPreconditionError::UnsupportedProtocol(
+                    other.to_owned(),
+                )),
+            }
+        }
+        Err(url::ParseError::RelativeUrlWithoutBase) => {
+            Err(RequestPreconditionError::MissingProtocol)
+        }
+        Err(_) => Err(RequestPreconditionError::UrlBadParse),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{url::normalize_url, RequestPreconditionError};
+
+    #[test]
+    pub fn test_url_normalization() {
+        let positive = vec![
+            // These are straightforward.
+            "https://example.com/api/users",
+            "http://example.com/api/users",
+            "http://example.com:8080/api/users",
+            "https://example.com:8043/api/users",
+            // IP address
+            "https://192.168.1.4/api/users",
+            "http://192.168.1.4/api/users",
+            "http://192.168.1.4",
+            "https://192.168.1.4",
+            "http://192.168.1.4:4000",
+            "https://192.168.1.4:4000/api/users",
+            // These should work too.
+            "https://localhost:3000/api/users",
+            "http://localhost:3000/api/users",
+            "http://localhost:3000",
+            "http://localhost",
+            "http://localhost/api/users",
+            // Basic authentication in the URL
+            "http://admin:admin@router/login",
+            "http://admin:admin@router.home/login",
+            "http://admin:admin@192.168.1.1/login",
+        ];
+
+        let wrong_protocol = vec!["gemini://geminiprotocol.net", "ws://localhost:8000/socket"];
+
+        let missing_protocol = vec![
+            // Typical use in development
+            "example.com/api/users",
+            "example.com",
+            "example.com:8000",
+            "192.168.1.4",
+            "192.168.1.4/api/users",
+            "192.168.1.4:8000",
+            "localhost",
+            "localhost/users",
+            "localhost:3000/users",
+            // This is open to discussion but for this use case, it's an HTTP request to example.com
+            // using user=mailto and pass=foobar as a basic authentication, and not an email request.
+            "mailto:foobar@example.com",
+            "mailto:foobar@example.com/api/users",
+        ];
+
+        for url in positive {
+            let result = normalize_url(url);
+            assert!(
+                result.is_ok(),
+                "{} should have been accepted, was {:?}",
+                url,
+                result
+            );
+        }
+
+        for url in wrong_protocol {
+            let result = normalize_url(url);
+            let Err(RequestPreconditionError::UnsupportedProtocol(_)) = result else {
+                panic!("{} should have been an unsupported protocol", url);
+            };
+        }
+
+        for url in missing_protocol {
+            let result = normalize_url(url);
+            assert_eq!(Err(RequestPreconditionError::MissingProtocol), result);
+        }
+    }
+
+    #[test]
+    pub fn test_remove_leading_space() {
+        let url = " https://example.com/api/v1/users";
+        let actual = normalize_url(url).unwrap();
+        assert_eq!(actual, "https://example.com/api/v1/users");
+    }
+
+    #[test]
+    pub fn test_remove_trailing_space() {
+        let url = "https://example.com/api/v1/users ";
+        let actual = normalize_url(url).unwrap();
+        assert_eq!(actual, "https://example.com/api/v1/users");
+    }
+
+    #[test]
+    pub fn test_remove_leading_and_trailing_space() {
+        let url = " https://example.com/api/v1/users ";
+        let actual = normalize_url(url).unwrap();
+        assert_eq!(actual, "https://example.com/api/v1/users");
+    }
+}

--- a/cartero-isahc-client/Cargo.toml
+++ b/cartero-isahc-client/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "cartero_isahc_client"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+cartero_objects = { path = "../cartero-objects" }
+cartero_http = { path = "../cartero-http" }
+isahc = "1.7.2"
+curl = "0.4.48"
+futures-lite = "2.6.0"

--- a/cartero-isahc-client/README.md
+++ b/cartero-isahc-client/README.md
@@ -1,0 +1,2 @@
+cartero-isahc-client is the integration code that generates isahc request
+instances based on a Request GObject, as defined by the cartero_objects crate.

--- a/cartero-isahc-client/src/lib.rs
+++ b/cartero-isahc-client/src/lib.rs
@@ -1,0 +1,154 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#![doc = include_str!("../README.md")]
+
+use futures_lite::io::AsyncReadExt;
+use std::time::{Duration, Instant};
+
+use cartero_http::{BoundRequest, RequestEnvironment, RequestError};
+use cartero_objects::{Field, FieldTable, Request, RequestMethod, Response};
+use isahc::{
+    config::{Configurable, RedirectPolicy, SslOption},
+    http::{HeaderName, HeaderValue},
+    AsyncBody, RequestExt,
+};
+
+fn default_user_agent() -> String {
+    let cartero_version = env!("CARGO_PKG_VERSION");
+    let curl_version = {
+        let version = curl::Version::get();
+        version.version().to_string()
+    };
+    format!("Cartero/{cartero_version} (curl/{curl_version})")
+}
+
+pub async fn request(
+    request: &Request,
+    env: &RequestEnvironment,
+) -> Result<Response, RequestError> {
+    // Craft an isahc request.
+    let isahc_request = build_request(request, env)?;
+
+    // Execute the request to get the response.
+    let start = Instant::now();
+    let mut response = isahc_request
+        .send_async()
+        .await
+        .map_err(|e| RequestError::NetworkError(Box::new(e)))?;
+    build_response(request, &mut response, &start).await
+}
+
+async fn build_response(
+    request: &Request,
+    isahc_request: &mut isahc::Response<AsyncBody>,
+    start: &Instant,
+) -> Result<Response, RequestError> {
+    let status_code = isahc_request.status().as_u16();
+    let headers = isahc_request.headers().iter().map(|(k, v)| {
+        let name = k.to_string();
+        let value = String::from(v.to_str().unwrap());
+        Field::builder().key(name).value(value).build()
+    });
+    let headers = FieldTable::from_iter(headers);
+    let body = {
+        let mut buffer = Vec::new();
+        let body = isahc_request.body_mut();
+        body.read_to_end(&mut buffer)
+            .await
+            .map_err(|e| RequestError::IOError(Box::new(e)))?;
+        buffer
+    };
+
+    let duration = start.elapsed();
+
+    let response = Response::builder(request)
+        .status_code(status_code as u32)
+        .headers(&headers)
+        .size(body.len() as u64)
+        .body(&body)
+        .duration(duration.as_millis() as u64)
+        .build();
+    Ok(response)
+}
+
+fn build_request(
+    request: &Request,
+    env: &RequestEnvironment,
+) -> Result<isahc::Request<Vec<u8>>, RequestError> {
+    // Extract isahc settings from the environment
+    let ssl_mode = if env.config.validate_tls {
+        SslOption::NONE
+    } else {
+        SslOption::DANGER_ACCEPT_INVALID_CERTS
+    };
+    let redirect_policy = if env.config.redirects > 0 {
+        RedirectPolicy::Limit(env.config.redirects as u32)
+    } else {
+        RedirectPolicy::None
+    };
+    let request_timeout = Duration::from_secs_f64(env.config.timeout);
+
+    // Build the request entity.
+    let bound_request = BoundRequest::try_from(request.clone())?;
+
+    let mut builder = isahc::Request::builder()
+        .uri(bound_request.url)
+        .method(isahc_request_method(&request.method()))
+        .ssl_options(ssl_mode)
+        .redirect_policy(redirect_policy)
+        .timeout(request_timeout);
+    let headers = builder.headers_mut().unwrap();
+    for (key, value) in &bound_request.headers {
+        let header_key = HeaderName::try_from(key)
+            .map_err(|_| RequestError::InvalidHeaderName(key.to_string()))?;
+        let header_value = HeaderValue::try_from(value)
+            .map_err(|_| RequestError::InvalidHeaderValue(key.to_string()))?;
+
+        // Doubule check that the header is actually valid UTF-8. I don't care about
+        // the result, I just want to check if it fails to convert or not.
+        // isahc will do this later, but instead of returning an error they just
+        // expect() and panic(). Better catch the error than having the app killed
+        // and I don't want to use panic handlers for this.
+        header_value
+            .to_str()
+            .map_err(|_| RequestError::InvalidHeaderValue(key.to_string()))?;
+
+        headers.insert(header_key, header_value);
+    }
+
+    // Add user agent if not added yet.
+    if !headers.contains_key("user-agent") {
+        headers.insert("user-agent", default_user_agent().try_into().unwrap());
+    }
+
+    let body = bound_request.body.unwrap_or_default();
+    builder.body(body).map_err(|_| RequestError::EncodingError)
+}
+
+fn isahc_request_method(cartero_method: &RequestMethod) -> isahc::http::Method {
+    match cartero_method {
+        RequestMethod::Head => isahc::http::Method::HEAD,
+        RequestMethod::Get => isahc::http::Method::GET,
+        RequestMethod::Post => isahc::http::Method::POST,
+        RequestMethod::Put => isahc::http::Method::PUT,
+        RequestMethod::Patch => isahc::http::Method::PATCH,
+        RequestMethod::Options => isahc::http::Method::OPTIONS,
+        RequestMethod::Delete => isahc::http::Method::DELETE,
+        RequestMethod::Trace => isahc::http::Method::TRACE,
+    }
+}

--- a/cartero-objects/Cargo.toml
+++ b/cartero-objects/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 glib.workspace = true
 gio.workspace = true
+srtemplate = "0.3.3"
 
 [dev-dependencies]
 ctor = "0.4.2"

--- a/cartero-objects/src/field_table.rs
+++ b/cartero-objects/src/field_table.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use gio::prelude::{ListModelExt, ListModelExtManual};
 use glib::subclass::prelude::*;
 use glib::{prelude::*, Object};
+use srtemplate::SrTemplate;
 
 use crate::field::Field;
 
@@ -138,6 +139,32 @@ impl FieldTable {
             }
             map
         })
+    }
+
+    pub fn render(&self, template: &SrTemplate) -> Result<Self, srtemplate::Error> {
+        self.iter::<Field>()
+            .filter_map(|r| r.ok())
+            .map(|field| {
+                let key = template.render(field.key())?;
+                let value = template.render(field.value())?;
+                Ok(Field::builder()
+                    .key(key)
+                    .value(value)
+                    .active(field.active())
+                    .masked(field.masked())
+                    .build())
+            })
+            .collect::<Result<Self, srtemplate::Error>>()
+    }
+
+    pub fn template_processor(&self) -> SrTemplate<'static> {
+        self.iter::<Field>()
+            .filter_map(|r| r.ok())
+            .filter(|field| field.active())
+            .fold(SrTemplate::default(), |acc, field| {
+                acc.add_variable(field.key(), field.value());
+                acc
+            })
     }
 }
 
@@ -354,5 +381,202 @@ mod tests {
         assert_eq!("Content-Type", table1.field(0).unwrap().key());
         assert_eq!("Host", table1.field(1).unwrap().key());
         assert_eq!("Server", table1.field(2).unwrap().key());
+    }
+
+    #[test]
+    fn test_template_processor() {
+        let table = FieldTable::from_iter(vec![
+            Field::builder()
+                .key("API_ROOT")
+                .value("http://localhost:8000")
+                .build(),
+            Field::builder().key("TOKEN").value("12341234").build(),
+        ]);
+
+        let processor = table.template_processor();
+        assert!(processor.contains_variable("API_ROOT"));
+        assert!(processor.contains_variable("TOKEN"));
+        assert_eq!(
+            processor.render("{{API_ROOT}}/api/v1").unwrap(),
+            "http://localhost:8000/api/v1"
+        );
+        assert!(processor.render("{{INVALID}}").is_err());
+    }
+
+    #[test]
+    fn test_template_processor_is_immutable() {
+        let field = Field::builder()
+            .key("API_ROOT")
+            .value("http://localhost:3000")
+            .build();
+        let table = FieldTable::from_iter(vec![field.clone()]);
+
+        // The processor renders the current state of the field table
+        let processor = table.template_processor();
+        assert_eq!(
+            processor.render("{{ API_ROOT }}/api/v1").unwrap(),
+            "http://localhost:3000/api/v1"
+        );
+
+        // Just because you update a value, it won't update the processor
+        field.set_value("http://api.example.com");
+        assert_eq!(
+            processor.render("{{ API_ROOT }}/api/v1").unwrap(),
+            "http://localhost:3000/api/v1"
+        );
+
+        // Of course if you create a new processor, the value is updated
+        let processor = table.template_processor();
+        assert_eq!(
+            processor.render("{{ API_ROOT }}/api/v1").unwrap(),
+            "http://api.example.com/api/v1"
+        );
+    }
+
+    #[test]
+    fn test_template_processor_can_survive_the_field_table() {
+        let processor = {
+            let field = Field::builder()
+                .key("API_ROOT")
+                .value("http://localhost:3000")
+                .build();
+            let table = FieldTable::from_iter(vec![field.clone()]);
+            table.template_processor()
+        };
+        assert!(processor.contains_variable("API_ROOT"));
+    }
+
+    #[test]
+    fn test_template_processor_deactivated_variable() {
+        let table = FieldTable::from_iter(vec![Field::builder()
+            .key("API_ROOT")
+            .value("http://localhost:8000")
+            .active(false)
+            .build()]);
+
+        let processor = table.template_processor();
+        assert!(!processor.contains_variable("API_ROOT"));
+    }
+
+    #[test]
+    fn test_template_processor_overriding_variable() {
+        let table = FieldTable::from_iter(vec![
+            Field::builder()
+                .key("API_ROOT")
+                .value("http://localhost:3000")
+                .build(),
+            Field::builder()
+                .key("API_ROOT")
+                .value("https://api.example.com")
+                .build(),
+        ]);
+
+        let processor = table.template_processor();
+        assert_eq!(
+            processor.render("{{ API_ROOT }}").unwrap(),
+            "https://api.example.com"
+        );
+    }
+
+    #[test]
+    fn test_template_processor_overriding_variable_is_disabled() {
+        let table = FieldTable::from_iter(vec![
+            Field::builder()
+                .key("API_ROOT")
+                .value("http://localhost:3000")
+                .build(),
+            Field::builder()
+                .key("API_ROOT")
+                .value("https://api.example.com")
+                .active(false)
+                .build(),
+        ]);
+
+        let processor = table.template_processor();
+        assert_eq!(
+            processor.render("{{ API_ROOT }}").unwrap(),
+            "http://localhost:3000"
+        );
+    }
+
+    #[test]
+    fn test_render_with_valid_variables() {
+        let template = SrTemplate::default();
+        template.add_variable("API_ROOT", "http://localhost:3000");
+        template.add_variable("API_KEY", "12341234");
+        template.add_variable("KEY", "category");
+
+        let table = FieldTable::from_iter(vec![
+            Field::builder()
+                .key("Location")
+                .value("{{ API_ROOT }}/v1/users")
+                .build(),
+            Field::builder()
+                .key("{{ KEY }}")
+                .value("10")
+                .active(false)
+                .build(),
+            Field::builder()
+                .key("Authorization")
+                .value("Bearer {{ API_KEY }}")
+                .masked(true)
+                .build(),
+            Field::builder()
+                .key("X-Api-Key")
+                .value("{{API_KEY}}")
+                .active(false)
+                .masked(true)
+                .build(),
+        ]);
+
+        let render_table = table.render(&template).unwrap();
+        assert_eq!(render_table.n_items(), 4);
+
+        let values = render_table.group_by_key();
+
+        assert_field(
+            &values["Location"][0],
+            "Location",
+            "http://localhost:3000/v1/users",
+            true,
+            false,
+        );
+        assert_field(
+            &values["Authorization"][0],
+            "Authorization",
+            "Bearer 12341234",
+            true,
+            true,
+        );
+        assert_field(
+            &values["X-Api-Key"][0],
+            "X-Api-Key",
+            "12341234",
+            false,
+            true,
+        );
+        assert_field(&values["category"][0], "category", "10", false, false);
+    }
+
+    #[test]
+    fn test_render_with_invalid_variables() {
+        let template = SrTemplate::default();
+
+        let table = FieldTable::from_iter(vec![Field::builder()
+            .key("Location")
+            .value("{{ API_ROOT }}/v1/users")
+            .build()]);
+        let render_table = table.render(&template);
+        let Err(srtemplate::Error::VariableNotFound(var)) = render_table else {
+            panic!("expected err");
+        };
+        assert_eq!(var, "API_ROOT");
+    }
+
+    fn assert_field(f: &Field, key: &str, value: &str, active: bool, masked: bool) {
+        assert_eq!(f.key(), key);
+        assert_eq!(f.value(), value);
+        assert_eq!(f.active(), active);
+        assert_eq!(f.masked(), masked);
     }
 }

--- a/cartero-objects/src/request.rs
+++ b/cartero-objects/src/request.rs
@@ -17,6 +17,7 @@
 
 use glib::subclass::prelude::*;
 use glib::{prelude::*, Object};
+use srtemplate::SrTemplate;
 
 use crate::RequestMethod;
 
@@ -71,6 +72,11 @@ impl Default for Request {
 impl Request {
     pub fn builder(url: &str, method: RequestMethod) -> builder::RequestBuilder {
         builder::RequestBuilder::new(url, method)
+    }
+
+    pub fn template_processor(&self) -> SrTemplate<'static> {
+        // Currently only delegates to variables(). In the future may be bound to an environment.
+        self.variables().template_processor()
     }
 }
 
@@ -349,5 +355,45 @@ mod tests {
             .headers(&headers)
             .build();
         assert_eq!(2, body.headers().group_by_key().len());
+    }
+
+    #[test]
+    fn test_template_processor() {
+        let request = Request::builder("https://www.example.com/api/users", RequestMethod::Get)
+            .variable(
+                &Field::builder()
+                    .key("API_ROOT")
+                    .value("http://localhost:3000")
+                    .build(),
+            )
+            .build();
+        let processor = request.template_processor();
+
+        assert!(processor.contains_variable("API_ROOT"));
+        assert_eq!(
+            processor.render("{{ API_ROOT }}/v1/users").unwrap(),
+            "http://localhost:3000/v1/users"
+        );
+    }
+
+    #[test]
+    fn test_template_processor_outlives_the_request() {
+        let processor = {
+            let request = Request::builder("https://www.example.com/api/users", RequestMethod::Get)
+                .variable(
+                    &Field::builder()
+                        .key("API_ROOT")
+                        .value("http://localhost:3000")
+                        .build(),
+                )
+                .build();
+            request.template_processor()
+        };
+
+        assert!(processor.contains_variable("API_ROOT"));
+        assert_eq!(
+            processor.render("{{ API_ROOT }}/v1/users").unwrap(),
+            "http://localhost:3000/v1/users"
+        );
     }
 }


### PR DESCRIPTION
Adds new crates that will allow to send an HTTP request using a cartero_objects::Request, and return a cartero_objects::Response as a result.

An additional crate called cartero_http has been created in order to make the conversion between a cartero_object::Request and a BoundRequest, which contains a normalized HTTP request without all the fluff (URL, verb, headers and payload). the isahc client will convert the Request into a BoundRequest and send the HTTP request. However, BoundRequest has public functions, and additional clients may be added:

* A client based on hyper-rs, in order to migrate Cartero to hyper.rs and stop using isahc.
* The cURL exporter could be rewritten to accept the new BoundRequest code provided by the cartero_http crate. Because the cartero_http crate has more tests, this would enable a safer implementation.

This work was going to be done in #222, but definitely doing it at the same time than the API swap is definitely a bad idea. It is probably better to first have the real HTTP client, and then replace the HTTP client at the same time.