### PR TITLE
Don't use power hungry gpu's on macs with dual GPU's

### DIFF
--- a/packaging/macos/Info.plist.in
+++ b/packaging/macos/Info.plist.in
@@ -43,6 +43,8 @@
     <string>Copyright © 2024-2025 The Cartero authors</string>
     <key>CFBundleSignature</key>
     <string>Cartero</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
     <key>LSMinimumSystemVersion</key>
     <string>11.0</string>
     <key>LSArchitecturePriority</key>


### PR DESCRIPTION
on a macbook pro 15inch with both an intel gpu and an amd gpu, the intel gpu should be used for most apps, and the amd gpu should only be turned on when the higher performance is needed. using the amd gpu requires twice the battery in my testing.

the default gl renderer in gtk switches to the amd gpu (filed a bug report), and switching to the cairo renderer isnt a good option

[NSSupportsAutomaticGraphicsSwitching](https://developer.apple.com/documentation/bundleresources/information-property-list/nssupportsautomaticgraphicsswitching)