### PR TITLE
Change datatype of CarteroRequestBodyRaw:payload from glib::Bytes to String

### DIFF
--- a/cartero-file-format/src/payload_value.rs
+++ b/cartero-file-format/src/payload_value.rs
@@ -93,10 +93,9 @@ impl From<RequestBody> for PayloadValue {
             }
             RequestBodyType::Raw => {
                 let raw = value.raw().unwrap();
-                let payload = String::from_utf8_lossy(&raw.bytes()).to_string();
                 Self::Raw {
                     format: Some(raw.payload_type().into()),
-                    body: payload,
+                    body: raw.payload(),
                 }
             }
         }
@@ -109,8 +108,7 @@ impl From<PayloadValue> for RequestBody {
             PayloadValue::Raw { format, body } => {
                 let parsed_format: RequestBodyRawType =
                     format.unwrap_or(PayloadRawFormat::OctetStream).into();
-                let parsed_content = glib::Bytes::from(body.as_bytes());
-                let parsed_body = RequestBodyRaw::new(parsed_format, &parsed_content);
+                let parsed_body = RequestBodyRaw::new(parsed_format, &body);
                 RequestBody::new(RequestBodyType::Raw, Some(parsed_body))
             }
             PayloadValue::Multipart { variables } => {
@@ -374,7 +372,7 @@ mod tests {
         assert_eq!(parsed.body_type(), RequestBodyType::Raw);
         let body = parsed.raw().unwrap();
         assert_eq!(body.payload_type(), RequestBodyRawType::OctetStream);
-        assert_eq!(body.bytes(), b"this is the content");
+        assert_eq!(body.payload(), "this is the content");
     }
 
     #[test]
@@ -387,7 +385,7 @@ mod tests {
         assert_eq!(parsed.body_type(), RequestBodyType::Raw);
         let body = parsed.raw().unwrap();
         assert_eq!(body.payload_type(), RequestBodyRawType::OctetStream);
-        assert_eq!(body.bytes(), b"this is the content");
+        assert_eq!(body.payload(), "this is the content");
     }
 
     #[test]
@@ -396,7 +394,7 @@ mod tests {
             RequestBodyType::Raw,
             Some(RequestBodyRaw::new(
                 RequestBodyRawType::OctetStream,
-                b"this is the content",
+                "this is the content",
             )),
         );
 
@@ -418,7 +416,7 @@ mod tests {
         assert_eq!(parsed.body_type(), RequestBodyType::Raw);
         let body = parsed.raw().unwrap();
         assert_eq!(body.payload_type(), RequestBodyRawType::Json);
-        assert_eq!(body.bytes(), b"{\"result\": \"hello world\"}");
+        assert_eq!(body.payload(), "{\"result\": \"hello world\"}");
     }
 
     #[test]
@@ -427,7 +425,7 @@ mod tests {
             RequestBodyType::Raw,
             Some(RequestBodyRaw::new(
                 RequestBodyRawType::Json,
-                br#"{"user_id": "200"}"#,
+                r#"{"user_id": "200"}"#,
             )),
         );
 
@@ -449,7 +447,7 @@ mod tests {
         assert_eq!(parsed.body_type(), RequestBodyType::Raw);
         let body = parsed.raw().unwrap();
         assert_eq!(body.payload_type(), RequestBodyRawType::Xml);
-        assert_eq!(body.bytes(), b"<result>hello world</result>");
+        assert_eq!(body.payload(), "<result>hello world</result>");
     }
 
     #[test]
@@ -458,7 +456,7 @@ mod tests {
             RequestBodyType::Raw,
             Some(RequestBodyRaw::new(
                 RequestBodyRawType::Xml,
-                b"<message>hello world</message>",
+                "<message>hello world</message>",
             )),
         );
 

--- a/cartero-file-format/src/request_value.rs
+++ b/cartero-file-format/src/request_value.rs
@@ -286,7 +286,7 @@ mod tests {
         request.body().set_body_type(RequestBodyType::Raw);
         request.body().set_body_data(Some(RequestBodyRaw::new(
             cartero_objects::RequestBodyRawType::OctetStream,
-            "hello world".as_bytes(),
+            "hello world",
         )));
         let value = RequestValue::from(request);
         assert_eq!(value.version, 1);

--- a/cartero-file-format/tests/test_read_body.rs
+++ b/cartero-file-format/tests/test_read_body.rs
@@ -49,7 +49,7 @@ pub fn legacy_format() {
     assert_eq!(request.body().body_type(), RequestBodyType::Raw);
     let raw = request.body().raw().unwrap();
     assert_eq!(raw.payload_type(), RequestBodyRawType::OctetStream);
-    assert_eq!(raw.bytes(), b"request contents");
+    assert_eq!(raw.payload(), "request contents");
 }
 
 #[test]
@@ -221,7 +221,7 @@ pub fn raw() {
     assert_eq!(request.body().body_type(), RequestBodyType::Raw);
     let raw = request.body().raw().unwrap();
     assert_eq!(raw.payload_type(), RequestBodyRawType::OctetStream);
-    assert_eq!(raw.bytes(), b"this is raw content");
+    assert_eq!(raw.payload(), "this is raw content");
 }
 
 #[test]
@@ -235,7 +235,7 @@ pub fn octet_stream() {
     assert_eq!(request.body().body_type(), RequestBodyType::Raw);
     let raw = request.body().raw().unwrap();
     assert_eq!(raw.payload_type(), RequestBodyRawType::OctetStream);
-    assert_eq!(raw.bytes(), b"this is raw content");
+    assert_eq!(raw.payload(), "this is raw content");
 }
 
 #[test]
@@ -250,8 +250,8 @@ pub fn xml() {
     let raw = request.body().raw().unwrap();
     assert_eq!(raw.payload_type(), RequestBodyRawType::Xml);
     assert_eq!(
-        raw.bytes(),
-        b"<?xml version=\"1.0\" ?><payload value=\"Hello world\" />"
+        raw.payload(),
+        "<?xml version=\"1.0\" ?><payload value=\"Hello world\" />"
     );
 }
 
@@ -266,7 +266,7 @@ pub fn json() {
     assert_eq!(request.body().body_type(), RequestBodyType::Raw);
     let raw = request.body().raw().unwrap();
     assert_eq!(raw.payload_type(), RequestBodyRawType::Json);
-    assert_eq!(raw.bytes(), b"{\"message\": \"hello world\"}");
+    assert_eq!(raw.payload(), "{\"message\": \"hello world\"}");
 }
 
 #[test]
@@ -281,8 +281,8 @@ pub fn multiline_json() {
     let raw = request.body().raw().unwrap();
     assert_eq!(raw.payload_type(), RequestBodyRawType::Json);
     assert_eq!(
-        raw.bytes(),
-        br#"{
+        raw.payload(),
+        r#"{
   "message": {
     "code": "HELLO_WORLD",
     "text": "Hello world!"

--- a/cartero-file-format/tests/test_write_body.rs
+++ b/cartero-file-format/tests/test_write_body.rs
@@ -29,8 +29,7 @@ pub fn json() {
         .build();
 
     let text = "{\"message\": \"hello world\"}";
-    let payload = text.as_bytes();
-    let json_body = RequestBodyRaw::new(cartero_objects::RequestBodyRawType::Json, payload);
+    let json_body = RequestBodyRaw::new(cartero_objects::RequestBodyRawType::Json, text);
     req.body().set_body_type(RequestBodyType::Raw);
     req.body().set_body_data(Some(json_body.as_ref()));
 
@@ -52,8 +51,7 @@ pub fn multiline_json() {
     "text": "Hello world!"
   }
 }"#;
-    let payload = text.as_bytes();
-    let json_body = RequestBodyRaw::new(cartero_objects::RequestBodyRawType::Json, payload);
+    let json_body = RequestBodyRaw::new(cartero_objects::RequestBodyRawType::Json, text);
     req.body().set_body_type(RequestBodyType::Raw);
     req.body().set_body_data(Some(json_body.as_ref()));
 
@@ -176,7 +174,7 @@ fn octet_stream() {
             RequestBody::builder()
                 .raw(
                     &RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
-                        .payload(&glib::Bytes::from_static("this is raw content".as_bytes()))
+                        .payload("this is raw content")
                         .build(),
                 )
                 .build(),
@@ -301,9 +299,7 @@ fn xml() {
             RequestBody::builder()
                 .raw(
                     &RequestBodyRaw::builder(RequestBodyRawType::Xml)
-                        .payload(&glib::Bytes::from_static(
-                            "<?xml version=\"1.0\" ?><payload value=\"Hello world\" />".as_bytes(),
-                        ))
+                        .payload("<?xml version=\"1.0\" ?><payload value=\"Hello world\" />")
                         .build(),
                 )
                 .build(),

--- a/cartero-http/src/body.rs
+++ b/cartero-http/src/body.rs
@@ -110,8 +110,7 @@ impl BoundBody {
         let encoding = raw.payload_type();
 
         let processor = value.template_processor();
-        let body = String::from_utf8_lossy(&content);
-        let interpolated = processor.render(&body)?;
+        let interpolated = processor.render(&content)?;
 
         let content_type = match encoding {
             RequestBodyRawType::OctetStream => "application/octet-stream",
@@ -310,7 +309,7 @@ mod tests {
     #[test]
     fn test_octet_stream() {
         let raw = RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
-            .payload(&glib::Bytes::from(b"the payload"))
+            .payload("the payload")
             .build();
         let req = Request::builder("https://www.example.com", RequestMethod::Get)
             .with_body(RequestBody::builder().raw(&raw).build())
@@ -329,7 +328,7 @@ mod tests {
     #[test]
     fn test_octet_stream_with_variables() {
         let raw = RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
-            .payload(&glib::Bytes::from(b"Hello {{NAME}}!"))
+            .payload("Hello {{NAME}}!")
             .build();
         let req = Request::builder("https://www.example.com", RequestMethod::Get)
             .with_body(RequestBody::builder().raw(&raw).build())
@@ -349,9 +348,7 @@ mod tests {
     #[test]
     fn test_xml() {
         let raw = RequestBodyRaw::builder(RequestBodyRawType::Xml)
-            .payload(&glib::Bytes::from(
-                b"<?xml version=\"1.0\" ?><hello who=\"world\" />",
-            ))
+            .payload("<?xml version=\"1.0\" ?><hello who=\"world\" />")
             .build();
         let req = Request::builder("https://www.example.com", RequestMethod::Get)
             .with_body(RequestBody::builder().raw(&raw).build())
@@ -373,9 +370,7 @@ mod tests {
     #[test]
     fn test_xml_with_variables() {
         let raw = RequestBodyRaw::builder(RequestBodyRawType::Xml)
-            .payload(&glib::Bytes::from(
-                b"<?xml version=\"1.0\" ?><hello who=\"{{USER}}\" />",
-            ))
+            .payload("<?xml version=\"1.0\" ?><hello who=\"{{USER}}\" />")
             .build();
         let req = Request::builder("https://www.example.com", RequestMethod::Get)
             .with_body(RequestBody::builder().raw(&raw).build())
@@ -398,7 +393,7 @@ mod tests {
     #[test]
     fn test_json() {
         let raw = RequestBodyRaw::builder(RequestBodyRawType::Json)
-            .payload(&glib::Bytes::from(b"{\"hello\": \"world\"}"))
+            .payload("{\"hello\": \"world\"}")
             .build();
         let req = Request::builder("https://www.example.com", RequestMethod::Get)
             .with_body(RequestBody::builder().raw(&raw).build())
@@ -420,7 +415,7 @@ mod tests {
     #[test]
     fn test_json_with_variables() {
         let raw = RequestBodyRaw::builder(RequestBodyRawType::Json)
-            .payload(&glib::Bytes::from(b"{\"hello\": \"{{USER}}\"}"))
+            .payload("{\"hello\": \"{{USER}}\"}")
             .build();
         let req = Request::builder("https://www.example.com", RequestMethod::Get)
             .with_body(RequestBody::builder().raw(&raw).build())

--- a/cartero-objects/src/request.rs
+++ b/cartero-objects/src/request.rs
@@ -261,7 +261,7 @@ mod tests {
     #[test]
     pub fn test_builder_can_change_body() {
         let body = RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
-            .payload(&glib::Bytes::from(b"hello world"))
+            .payload("hello world")
             .build();
         let request = Request::builder("https://www.example.com/api/users", RequestMethod::Get)
             .with_body(RequestBody::builder().raw(&body).build())
@@ -269,9 +269,9 @@ mod tests {
         assert_eq!(request.url(), "https://www.example.com/api/users");
         assert_eq!(request.method(), RequestMethod::Get);
         assert_eq!(request.body().body_type(), RequestBodyType::Raw);
-        let bearer = request.body().raw().unwrap();
-        assert_eq!(bearer.payload_type(), RequestBodyRawType::OctetStream);
-        assert_eq!(bearer.payload().into_data().as_ref(), b"hello world");
+        let raw = request.body().raw().unwrap();
+        assert_eq!(raw.payload_type(), RequestBodyRawType::OctetStream);
+        assert_eq!(raw.payload(), "hello world");
     }
 
     #[test]

--- a/cartero-objects/src/request_body.rs
+++ b/cartero-objects/src/request_body.rs
@@ -93,7 +93,7 @@ glib::wrapper! {
     /// assert!(urlencoded.body_data().is_some_and(|d| d.body_type() == RequestBodyType::UrlEncoded));
     ///
     /// let data = r#"{"error": true, "detail": "User not found"}"#;
-    /// let raw = RequestBodyRaw::new(RequestBodyRawType::Json, data.as_bytes());
+    /// let raw = RequestBodyRaw::new(RequestBodyRawType::Json, data);
     /// let body = RequestBody::new(RequestBodyType::Raw, Some(raw));
     /// assert_eq!(body.body_type(), RequestBodyType::Raw);
     /// assert!(body.body_data().is_some_and(|d| d.body_type() == RequestBodyType::Raw));
@@ -452,7 +452,7 @@ mod tests {
 
     #[test]
     pub fn new_for_raw_with_initial() {
-        let payload = RequestBodyRaw::new(RequestBodyRawType::Json, "[1, 2, 4]".as_bytes());
+        let payload = RequestBodyRaw::new(RequestBodyRawType::Json, "[1, 2, 4]");
         let body = RequestBody::new(RequestBodyType::Raw, Some(payload));
         assert_eq!(RequestBodyType::Raw, body.body_type());
         let body_data = body.body_data().and_downcast::<RequestBodyRaw>().unwrap();
@@ -524,13 +524,12 @@ mod tests {
     #[test]
     pub fn test_raw() {
         let raw = RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
-            .payload(&glib::Bytes::from(b"hello world"))
+            .payload("hello world")
             .build();
         let body = RequestBody::builder().raw(&raw).build();
         assert_eq!(body.body_type(), RequestBodyType::Raw);
         let data = body.raw().unwrap();
         assert_eq!(data.payload_type(), RequestBodyRawType::OctetStream);
-        let bytes = data.payload().into_data();
-        assert_eq!(bytes.as_ref(), b"hello world");
+        assert_eq!(data.payload(), "hello world");
     }
 }

--- a/cartero-objects/src/request_body_raw.rs
+++ b/cartero-objects/src/request_body_raw.rs
@@ -61,17 +61,11 @@ impl RequestBodyRaw {
     ///
     /// The payload will be initialised to the type `raw_type`, and the given
     /// byte slice will be the initial contents of the payload data.
-    pub fn new(raw_type: RequestBodyRawType, initial: &[u8]) -> Self {
-        let bytes = glib::Bytes::from(initial);
+    pub fn new(raw_type: RequestBodyRawType, initial: impl AsRef<str>) -> Self {
         Object::builder()
             .property("payload-type", raw_type)
-            .property("payload", bytes)
+            .property("payload", initial.as_ref().to_owned())
             .build()
-    }
-
-    /// Returns an owned vector of the bytes contained in the payload.
-    pub fn bytes(&self) -> Vec<u8> {
-        self.payload().into_data().into()
     }
 
     pub fn builder(payload_type: RequestBodyRawType) -> builder::RequestBodyRawBuilder {
@@ -115,7 +109,7 @@ mod imp {
 
     use super::RequestBodyRawType;
 
-    #[derive(Properties)]
+    #[derive(Default, Properties)]
     #[properties(wrapper_type = super::RequestBodyRaw)]
     pub struct RequestBodyRaw {
         #[property(
@@ -127,16 +121,7 @@ mod imp {
         payload_type: RefCell<RequestBodyRawType>,
 
         #[property(get, set)]
-        payload: RefCell<glib::Bytes>,
-    }
-
-    impl Default for RequestBodyRaw {
-        fn default() -> Self {
-            Self {
-                payload_type: Default::default(),
-                payload: glib::Bytes::from_static(&[]).into(),
-            }
-        }
+        payload: RefCell<String>,
     }
 
     #[glib::object_subclass]
@@ -176,8 +161,8 @@ mod builder {
             self.builder.build()
         }
 
-        pub fn payload(mut self, payload: &glib::Bytes) -> Self {
-            self.builder = self.builder.property("payload", payload);
+        pub fn payload(mut self, payload: impl AsRef<str>) -> Self {
+            self.builder = self.builder.property("payload", payload.as_ref());
             self
         }
     }
@@ -194,13 +179,10 @@ mod tests {
     #[test]
     fn test_builder() {
         let raw = RequestBodyRaw::builder(RequestBodyRawType::Xml)
-            .payload(&glib::Bytes::from(br#"<?xml version="1.0" ?><document />"#))
+            .payload(r#"<?xml version="1.0" ?><document />"#)
             .build();
         assert_eq!(raw.payload_type(), RequestBodyRawType::Xml);
-        assert_eq!(
-            String::from_utf8_lossy(&raw.payload().into_data()),
-            r#"<?xml version="1.0" ?><document />"#
-        );
+        assert_eq!(raw.payload(), r#"<?xml version="1.0" ?><document />"#);
     }
 
     #[test]
@@ -212,22 +194,9 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let raw = RequestBodyRaw::new(RequestBodyRawType::Xml, "<?xml?>".as_bytes());
+        let raw = RequestBodyRaw::new(RequestBodyRawType::Xml, "<?xml?>");
         assert_eq!(raw.payload_type(), RequestBodyRawType::Xml);
-        assert_eq!(raw.payload().len(), 7);
-        let payload = raw.payload();
-        let contents = String::from_utf8_lossy(payload.as_ref());
-        assert_eq!(contents, "<?xml?>");
-    }
-
-    #[test]
-    pub fn test_bytes() {
-        let raw = RequestBodyRaw::new(RequestBodyRawType::Xml, "<?xml?>".as_bytes());
-        assert_eq!(raw.payload_type(), RequestBodyRawType::Xml);
-        assert_eq!(raw.payload().len(), 7);
-        let value = raw.bytes();
-        assert_eq!(value.len(), 7);
-        assert_eq!(value, b"<?xml?>");
+        assert_eq!(raw.payload(), "<?xml?>");
     }
 
     #[test]
@@ -243,8 +212,7 @@ mod tests {
     pub fn test_change_payload() {
         let raw = RequestBodyRaw::default();
         assert_emits_signal(&raw, "notify::payload", || {
-            let new_body = "hello world".as_bytes();
-            raw.set_payload(glib::Bytes::from(new_body));
+            raw.set_payload("hello world");
         });
         assert_eq!(11, raw.payload().len());
     }


### PR DESCRIPTION
Previously, the `payload` property of the raw body in a request was of type glib::Bytes.

My original intention was to have a opaque byte array so that you could type whatever you wanted inside, even binary strings coming from files.

However, it turns out that making all these conversions from glib::Bytes to String in order to present them in the reactive user interface are not cheap, and they have some quirks and sometimes it crashes.

Therefore, considering that if support for uploading payloads from a file is added in the future, it will be a different RequestData sub-type, I think it can be a String, because a different object will be used whenever raw files are used.

If your code break after applying this commit, check your types. If you previously assumed that raw.payload() is of type glib::Bytes, it is now a String. Therefore, you should not be doing `.as_bytes()` or `.bytes()` or `glib::Bytes::from_*()` or `String::from_utf8_lossy()` anymore.