### PR TITLE
Add changed signal to cartero_objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ version = "0.3.0"
 license = "GPL-3.0-or-later"
 
 [workspace.dependencies]
-glib = { version = "0.20.10", features = ["v2_72"] }
-gio = { version = "0.20.11", features = ["v2_72"] }
+glib = { version = "0.20.10", features = ["v2_74"] }
+gio = { version = "0.20.11", features = ["v2_74"] }
 serde = { version = "1.0.219", features = ["derive"] }
 toml = "0.8.23"
 

--- a/cartero-objects/src/field.rs
+++ b/cartero-objects/src/field.rs
@@ -90,10 +90,10 @@ impl Default for Field {
 }
 
 mod imp {
-    use std::cell::RefCell;
+    use std::{cell::RefCell, sync::OnceLock};
 
     use super::*;
-    use glib::Properties;
+    use glib::{subclass::Signal, Properties};
 
     #[derive(Properties)]
     #[properties(wrapper_type = super::Field)]
@@ -129,7 +129,33 @@ mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for Field {}
+    impl ObjectImpl for Field {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            self.obj().connect_key_notify(|field| {
+                field.emit_by_name::<()>("changed", &[&"key"]);
+            });
+            self.obj().connect_value_notify(|field| {
+                field.emit_by_name::<()>("changed", &[&"value"]);
+            });
+            self.obj().connect_active_notify(|field| {
+                field.emit_by_name::<()>("changed", &[&"active"]);
+            });
+            self.obj().connect_masked_notify(|field| {
+                field.emit_by_name::<()>("changed", &[&"masked"]);
+            });
+        }
+
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![Signal::builder("changed")
+                    .param_types([String::static_type()])
+                    .build()]
+            })
+        }
+    }
 }
 
 mod builder {
@@ -223,5 +249,14 @@ mod tests {
         assert_emits_signal(&field, "notify", || field.set_value("text/html"));
         assert_emits_signal(&field, "notify", || field.set_active(false));
         assert_emits_signal(&field, "notify", || field.set_masked(true));
+    }
+
+    #[test]
+    pub fn test_emits_changes_on_change() {
+        let field = Field::builder().build();
+        assert_emits_signal(&field, "changed", || field.set_key("Accept"));
+        assert_emits_signal(&field, "changed", || field.set_value("text/html"));
+        assert_emits_signal(&field, "changed", || field.set_active(false));
+        assert_emits_signal(&field, "changed", || field.set_masked(true));
     }
 }

--- a/cartero-objects/src/field_table.rs
+++ b/cartero-objects/src/field_table.rs
@@ -79,6 +79,38 @@ impl Default for FieldTable {
 }
 
 impl FieldTable {
+    /// Register the change signal for this field, so that whenever the inner
+    /// Field changes because it emits a "change" signal, this table broadcasts
+    /// the same event upwards.
+    fn connect_signal(&self, field: &Field, n_item: usize) {
+        let mut signals = self.imp().signals.borrow_mut();
+        let signal = field.connect_closure(
+            "changed",
+            false,
+            glib::closure_local!(
+                #[weak(rename_to = field_table)]
+                self,
+                move |_field: Field, param: &str| {
+                    let parameter = format!("[{}].{}", n_item, param);
+                    field_table.emit_by_name::<()>("changed", &[&parameter]);
+                }
+            ),
+        );
+        signals.insert(field.clone(), Some(signal));
+    }
+
+    /// Disconnects the previously added signal handler for this field, so
+    /// that future "change" events triggered in the field are not broadcasted
+    /// upwards from this table.
+    fn disconnect_signal(&self, field: &Field) {
+        let mut signals = self.imp().signals.borrow_mut();
+        if let Some(handler) = signals.remove(field) {
+            if let Some(signal) = handler {
+                field.disconnect(signal);
+            }
+        }
+    }
+
     /// Add a new field to the table.
     ///
     /// The given `field` is inserted at the bottom of the table, and
@@ -90,7 +122,9 @@ impl FieldTable {
             fields.push(field.clone());
         }
         let len = { self.imp().fields.borrow().len() };
+        self.connect_signal(field, len - 1);
         self.items_changed(len as u32, 0, 1);
+        self.emit_by_name::<()>("changed", &[&""]);
     }
 
     pub fn field(&self, pos: u32) -> Option<Field> {
@@ -104,11 +138,21 @@ impl FieldTable {
         {
             let mut fields = self.imp().fields.borrow_mut();
             let mut new_fields = { table.imp().fields.borrow().clone() };
+
+            fields
+                .iter()
+                .for_each(|field| self.disconnect_signal(field));
+
             fields.clear();
             fields.append(&mut new_fields);
+
+            new_fields.iter().enumerate().for_each(|(pos, field)| {
+                self.connect_signal(field, pos);
+            });
         }
 
         self.items_changed(0, old_len, new_len);
+        self.emit_by_name::<()>("changed", &[&""]);
     }
 
     /// Remove a field from the table.
@@ -118,6 +162,10 @@ impl FieldTable {
     /// given index is out of bounds**. Emits an `items-changed` signal when
     /// done.
     pub fn remove(&self, pos: u32) {
+        if let Some(field) = self.field(pos) {
+            self.disconnect_signal(&field);
+        }
+
         {
             let mut fields = self.imp().fields.borrow_mut();
             // Panics in case of out of bounds.
@@ -125,6 +173,7 @@ impl FieldTable {
         }
         // If we reach here, we survived delete.
         self.items_changed(pos, 1, 0);
+        self.emit_by_name::<()>("changed", &[&""]);
     }
 
     /// Groups by key every field contained in this table, accepting duplicates.
@@ -229,19 +278,31 @@ impl FromIterator<Field> for FieldTable {
             .imp()
             .fields
             .replace(iter.into_iter().collect::<Vec<Field>>());
+
+        // Manually initialize the events.
+        {
+            let fields = table.imp().fields.borrow();
+            fields.iter().enumerate().for_each(|(pos, field)| {
+                table.connect_signal(field, pos);
+            });
+        }
+
         table
     }
 }
 
 mod imp {
     use gio::subclass::prelude::ListModelImpl;
+    use glib::{subclass::Signal, SignalHandlerId};
 
     use super::*;
-    use std::cell::RefCell;
+    use std::{cell::RefCell, sync::OnceLock};
 
     #[derive(Default)]
     pub struct FieldTable {
         pub(super) fields: RefCell<Vec<Field>>,
+
+        pub(super) signals: RefCell<HashMap<Field, Option<SignalHandlerId>>>,
     }
 
     #[glib::object_subclass]
@@ -251,7 +312,16 @@ mod imp {
         type Interfaces = (gio::ListModel,);
     }
 
-    impl ObjectImpl for FieldTable {}
+    impl ObjectImpl for FieldTable {
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![Signal::builder("changed")
+                    .param_types([String::static_type()])
+                    .build()]
+            })
+        }
+    }
 
     impl ListModelImpl for FieldTable {
         fn item_type(&self) -> glib::Type {
@@ -275,6 +345,8 @@ mod tests {
         collections::HashSet,
         sync::{Arc, Mutex},
     };
+
+    use crate::utils::test::{assert_emits_signal, assert_not_emits_signal};
 
     use super::*;
 
@@ -680,6 +752,44 @@ mod tests {
         table.reconcile(&update);
         assert_field(&table.field(0).unwrap(), "cat_id", "15", true, false);
         assert_field(&table.field(1).unwrap(), "limit", "20", false, false);
+    }
+
+    #[test]
+    fn test_emits_items_changed_when_item_is_added() {
+        let table = FieldTable::default();
+        assert_emits_signal(&table, "items-changed", || {
+            table.insert(
+                &Field::builder()
+                    .key("user-agent")
+                    .value("mozilla/5.0")
+                    .build(),
+            );
+        });
+        assert_not_emits_signal(&table, "items-changed", || {
+            if let Some(field) = table.field(0) {
+                field.set_value("internet explorer");
+            }
+        });
+        assert_emits_signal(&table, "items-changed", || table.remove(0));
+    }
+
+    #[test]
+    fn test_emits_changed_when_a_field_changes() {
+        let table = FieldTable::default();
+        assert_emits_signal(&table, "changed", || {
+            table.insert(
+                &Field::builder()
+                    .key("user-agent")
+                    .value("mozilla/5.0")
+                    .build(),
+            );
+        });
+        assert_emits_signal(&table, "changed", || {
+            if let Some(field) = table.field(0) {
+                field.set_value("internet explorer");
+            }
+        });
+        assert_emits_signal(&table, "changed", || table.remove(0));
     }
 
     fn assert_field(f: &Field, key: &str, value: &str, active: bool, masked: bool) {

--- a/cartero-objects/src/request.rs
+++ b/cartero-objects/src/request.rs
@@ -81,9 +81,12 @@ impl Request {
 }
 
 mod imp {
-    use std::cell::RefCell;
+    use std::{
+        cell::{OnceCell, RefCell},
+        sync::OnceLock,
+    };
 
-    use glib::Properties;
+    use glib::{subclass::Signal, Properties, SignalGroup};
 
     use crate::{field_table::FieldTable, RequestAuthentication, RequestBody, RequestMethod};
 
@@ -100,18 +103,23 @@ mod imp {
 
         #[property(get, set)]
         params: RefCell<FieldTable>,
+        params_group: OnceCell<SignalGroup>,
 
         #[property(get, set)]
         headers: RefCell<FieldTable>,
+        headers_group: OnceCell<SignalGroup>,
 
         #[property(get, set)]
         variables: RefCell<FieldTable>,
+        variables_group: OnceCell<SignalGroup>,
 
         #[property(get)]
         authentication: RefCell<RequestAuthentication>,
+        authentication_group: OnceCell<SignalGroup>,
 
         #[property(get)]
         body: RefCell<RequestBody>,
+        body_group: OnceCell<SignalGroup>,
     }
 
     #[glib::object_subclass]
@@ -121,7 +129,191 @@ mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for Request {}
+    impl ObjectImpl for Request {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.init_signal_group();
+
+            let obj = self.obj();
+
+            self.obj().connect_url_notify(|request| {
+                request.emit_by_name::<()>("changed", &[&"url"]);
+            });
+            self.obj().connect_method_notify(|request| {
+                request.emit_by_name::<()>("changed", &[&"method"]);
+            });
+
+            self.params_group
+                .get()
+                .unwrap()
+                .set_target(Some(&obj.params()));
+            self.obj().connect_params_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |request| {
+                    imp.params_group
+                        .get()
+                        .unwrap()
+                        .set_target(Some(&request.params()));
+                    request.emit_by_name::<()>("changed", &[&"params"]);
+                }
+            ));
+
+            self.headers_group
+                .get()
+                .unwrap()
+                .set_target(Some(&obj.headers()));
+            self.obj().connect_headers_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |request| {
+                    imp.headers_group
+                        .get()
+                        .unwrap()
+                        .set_target(Some(&request.headers()));
+                    request.emit_by_name::<()>("changed", &[&"headers"]);
+                }
+            ));
+
+            self.variables_group
+                .get()
+                .unwrap()
+                .set_target(Some(&obj.variables()));
+            self.obj().connect_variables_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |request| {
+                    imp.variables_group
+                        .get()
+                        .unwrap()
+                        .set_target(Some(&request.variables()));
+                    request.emit_by_name::<()>("changed", &[&"variables"]);
+                }
+            ));
+
+            self.authentication_group
+                .get()
+                .expect("No authentication_group?")
+                .set_target(Some(&obj.authentication()));
+            obj.connect_authentication_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |request| {
+                    imp.authentication_group
+                        .get()
+                        .unwrap()
+                        .set_target(Some(&request.authentication()));
+                    request.emit_by_name::<()>("changed", &[&"authentication"]);
+                }
+            ));
+
+            self.body_group
+                .get()
+                .expect("No body_group?")
+                .set_target(Some(&obj.body()));
+            self.obj().connect_body_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |request| {
+                    imp.body_group
+                        .get()
+                        .unwrap()
+                        .set_target(Some(&request.body()));
+                    request.emit_by_name::<()>("changed", &[&"body"]);
+                }
+            ));
+        }
+
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![Signal::builder("changed")
+                    .param_types([String::static_type()])
+                    .build()]
+            })
+        }
+    }
+
+    impl Request {
+        fn init_signal_group(&self) {
+            let obj = self.obj();
+
+            let params_group = SignalGroup::new::<FieldTable>();
+            params_group.connect_closure(
+                "changed",
+                false,
+                glib::closure_local!(
+                    #[weak]
+                    obj,
+                    move |_: &FieldTable, param: &str| {
+                        let param = format!("params.{param}");
+                        obj.emit_by_name::<()>("changed", &[&param]);
+                    }
+                ),
+            );
+            self.params_group.set(params_group).unwrap();
+
+            let headers_group = SignalGroup::new::<FieldTable>();
+            headers_group.connect_closure(
+                "changed",
+                false,
+                glib::closure_local!(
+                    #[weak]
+                    obj,
+                    move |_: &FieldTable, param: &str| {
+                        let param = format!("headers.{param}");
+                        obj.emit_by_name::<()>("changed", &[&param]);
+                    }
+                ),
+            );
+            self.headers_group.set(headers_group).unwrap();
+
+            let variables_group = SignalGroup::new::<FieldTable>();
+            variables_group.connect_closure(
+                "changed",
+                false,
+                glib::closure_local!(
+                    #[weak]
+                    obj,
+                    move |_: &FieldTable, param: &str| {
+                        let param = format!("variables.{param}");
+                        obj.emit_by_name::<()>("changed", &[&param]);
+                    }
+                ),
+            );
+            self.variables_group.set(variables_group).unwrap();
+
+            let authentication_group = SignalGroup::new::<RequestAuthentication>();
+            authentication_group.connect_closure(
+                "changed",
+                false,
+                glib::closure_local!(
+                    #[weak]
+                    obj,
+                    move |_: &RequestAuthentication, param: &str| {
+                        let param = format!("authentication.{param}");
+                        obj.emit_by_name::<()>("changed", &[&param]);
+                    }
+                ),
+            );
+            self.authentication_group.set(authentication_group).unwrap();
+
+            let body_group: SignalGroup = SignalGroup::new::<RequestBody>();
+            body_group.connect_closure(
+                "changed",
+                false,
+                glib::closure_local!(
+                    #[weak]
+                    obj,
+                    move |_: &RequestBody, param: &str| {
+                        let param = format!("body.{param}");
+                        obj.emit_by_name::<()>("changed", &[&param]);
+                    }
+                ),
+            );
+            self.body_group.set(body_group).unwrap();
+        }
+    }
 }
 
 mod builder {
@@ -218,9 +410,9 @@ mod builder {
 #[cfg(test)]
 mod tests {
     use crate::{
-        Field, FieldTable, RequestAuthentication, RequestAuthenticationBearer,
-        RequestAuthenticationType, RequestBody, RequestBodyRaw, RequestBodyRawType,
-        RequestBodyType,
+        utils::test::assert_emits_signal, Field, FieldTable, RequestAuthentication,
+        RequestAuthenticationBearer, RequestAuthenticationType, RequestBody, RequestBodyRaw,
+        RequestBodyRawType, RequestBodyType,
     };
 
     use super::*;
@@ -236,6 +428,14 @@ mod tests {
             RequestAuthenticationType::None
         );
         assert!(request.authentication().auth_data().is_none());
+
+        request
+            .authentication()
+            .set_auth_type(RequestAuthenticationType::BearerToken);
+        assert_eq!(
+            request.authentication().auth_type(),
+            RequestAuthenticationType::BearerToken
+        );
     }
 
     #[test]
@@ -395,5 +595,91 @@ mod tests {
             processor.render("{{ API_ROOT }}/v1/users").unwrap(),
             "http://localhost:3000/v1/users"
         );
+    }
+
+    #[test]
+    fn test_emits_signals() {
+        let request = Request::builder("", RequestMethod::Get).build();
+
+        assert_emits_signal(&request, "changed", || {
+            request.set_url("https://www.example.com")
+        });
+        assert_emits_signal(&request, "changed", || {
+            request.set_method(RequestMethod::Put)
+        });
+
+        assert_emits_signal(&request, "changed", || {
+            let param = Field::builder().key("a").value("1").build();
+            request.params().insert(&param);
+        });
+        assert_emits_signal(&request, "changed", || {
+            request.set_params(FieldTable::default());
+        });
+        assert_emits_signal(&request, "changed", || {
+            let param = Field::builder().key("a").value("1").build();
+            request.params().insert(&param);
+        });
+
+        assert_emits_signal(&request, "changed", || {
+            let header = Field::builder()
+                .key("User-Agent")
+                .value("Mozilla/5.0")
+                .build();
+            request.headers().insert(&header);
+        });
+        assert_emits_signal(&request, "changed", || {
+            request.set_headers(FieldTable::default());
+        });
+        assert_emits_signal(&request, "changed", || {
+            let header = Field::builder()
+                .key("User-Agent")
+                .value("Mozilla/5.0")
+                .build();
+            request.headers().insert(&header);
+        });
+
+        assert_emits_signal(&request, "changed", || {
+            let variable = Field::builder()
+                .key("API_ROOT")
+                .value("http://localhost:3000")
+                .build();
+            request.variables().insert(&variable);
+        });
+        assert_emits_signal(&request, "changed", || {
+            request.set_variables(FieldTable::default());
+        });
+        assert_emits_signal(&request, "changed", || {
+            let variable = Field::builder()
+                .key("API_ROOT")
+                .value("http://localhost:3000")
+                .build();
+            request.variables().insert(&variable);
+        });
+
+        assert_emits_signal(&request, "changed", || {
+            request
+                .authentication()
+                .set_auth_type(RequestAuthenticationType::BearerToken);
+        });
+        assert_emits_signal(&request, "changed", || {
+            request
+                .authentication()
+                .bearer_token()
+                .expect("This is not my bearer token!")
+                .set_token("12341234");
+        });
+
+        assert_emits_signal(&request, "changed", || {
+            request.body().set_body_type(RequestBodyType::Multipart);
+        });
+        assert_emits_signal(&request, "changed", || {
+            let field = Field::builder().key("user_id").value("10").build();
+            request
+                .body()
+                .multipart()
+                .expect("This is not my multipart!")
+                .params()
+                .insert(&field);
+        });
     }
 }

--- a/cartero-objects/src/request_authentication.rs
+++ b/cartero-objects/src/request_authentication.rs
@@ -301,9 +301,12 @@ pub enum RequestAuthenticationType {
 }
 
 mod imp {
-    use std::cell::RefCell;
+    use std::{
+        cell::{OnceCell, RefCell},
+        sync::OnceLock,
+    };
 
-    use glib::Properties;
+    use glib::{subclass::Signal, Properties, SignalGroup};
 
     use crate::RequestAuthenticationData;
 
@@ -317,18 +320,67 @@ mod imp {
 
         #[property(get, set = Self::set_auth_data, explicit_notify, name = "auth-data", nullable)]
         auth_data: RefCell<Option<RequestAuthenticationData>>,
+        auth_data_group: OnceCell<SignalGroup>,
     }
 
     #[glib::object_subclass]
     impl ObjectSubclass for RequestAuthentication {
-        const NAME: &'static str = "CarteroRequestAuthorization";
+        const NAME: &'static str = "CarteroRequestAuthentication";
         type Type = super::RequestAuthentication;
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for RequestAuthentication {}
+    impl ObjectImpl for RequestAuthentication {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.init_signal_group();
+
+            self.obj().connect_auth_type_notify(|auth| {
+                auth.emit_by_name::<()>("changed", &[&"type"]);
+            });
+            self.obj().connect_auth_data_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |auth| {
+                    imp.auth_data_group
+                        .get()
+                        .unwrap()
+                        .set_target(auth.auth_data().as_ref());
+                    auth.emit_by_name::<()>("changed", &[&"data"]);
+                }
+            ));
+        }
+
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![Signal::builder("changed")
+                    .param_types([String::static_type()])
+                    .build()]
+            })
+        }
+    }
 
     impl RequestAuthentication {
+        fn init_signal_group(&self) {
+            let obj = self.obj();
+
+            let auth_data_group = SignalGroup::new::<RequestAuthenticationData>();
+            auth_data_group.connect_closure(
+                "changed",
+                false,
+                glib::closure_local!(
+                    #[weak]
+                    obj,
+                    move |_: &RequestAuthenticationData, param: &str| {
+                        let param = format!("data.{param}");
+                        obj.emit_by_name::<()>("changed", &[&param]);
+                    }
+                ),
+            );
+            self.auth_data_group.set(auth_data_group).unwrap();
+        }
+
         // This is the inner setter for the auth-type property. It also changes the auth-data
         // to a new object of the appropiate type. The old contents of the auth-data are erased
         // in the process.
@@ -640,5 +692,46 @@ mod tests {
             RequestAuthenticationData::NONE,
         );
         assert!(auth.bearer_token().is_none());
+    }
+
+    #[test]
+    pub fn test_emits_signal_on_change() {
+        let auth = RequestAuthentication::new(
+            RequestAuthenticationType::None,
+            RequestAuthenticationData::NONE,
+        );
+        assert_emits_signal(&auth, "changed", || {
+            auth.set_auth_type(RequestAuthenticationType::Inherit);
+        });
+        assert_eq!(auth.auth_type(), RequestAuthenticationType::Inherit);
+        assert_emits_signal(&auth, "changed", || {
+            auth.set_auth_type(RequestAuthenticationType::BearerToken);
+        });
+        assert_eq!(auth.auth_type(), RequestAuthenticationType::BearerToken);
+    }
+
+    #[test]
+    pub fn test_emits_signal_on_basic_change() {
+        let auth = RequestAuthentication::new(
+            RequestAuthenticationType::BasicAuth,
+            RequestAuthenticationData::NONE,
+        );
+        assert_emits_signal(&auth, "changed", || {
+            auth.basic_auth().unwrap().set_username("foo");
+        });
+        assert_emits_signal(&auth, "changed", || {
+            auth.basic_auth().unwrap().set_password("bar");
+        });
+    }
+
+    #[test]
+    pub fn test_emits_signal_on_bearer_change() {
+        let auth = RequestAuthentication::new(
+            RequestAuthenticationType::BearerToken,
+            RequestAuthenticationData::NONE,
+        );
+        assert_emits_signal(&auth, "changed", || {
+            auth.bearer_token().unwrap().set_token("12341234");
+        });
     }
 }

--- a/cartero-objects/src/request_authentication_basic.rs
+++ b/cartero-objects/src/request_authentication_basic.rs
@@ -89,7 +89,18 @@ mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for RequestAuthenticationBasic {}
+    impl ObjectImpl for RequestAuthenticationBasic {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            self.obj().connect_username_notify(|auth| {
+                auth.emit_by_name::<()>("changed", &[&"username"]);
+            });
+            self.obj().connect_password_notify(|auth| {
+                auth.emit_by_name::<()>("changed", &[&"password"]);
+            });
+        }
+    }
 
     impl RequestAuthenticationDataImpl for RequestAuthenticationBasic {
         fn auth_type(&self) -> crate::RequestAuthenticationType {
@@ -139,7 +150,9 @@ mod builder {
 
 #[cfg(test)]
 mod tests {
-    use crate::{RequestAuthenticationDataExt, RequestAuthenticationType};
+    use crate::{
+        utils::test::assert_emits_signal, RequestAuthenticationDataExt, RequestAuthenticationType,
+    };
 
     use super::*;
 
@@ -180,5 +193,12 @@ mod tests {
         assert_eq!(basic.username(), "admin");
         assert_eq!(basic.password(), "1234");
         assert_eq!(basic.auth_type(), RequestAuthenticationType::BasicAuth);
+    }
+
+    #[test]
+    pub fn test_emits_signals() {
+        let basic = RequestAuthenticationBasic::default();
+        assert_emits_signal(&basic, "changed", || basic.set_username("foo"));
+        assert_emits_signal(&basic, "changed", || basic.set_password("bar"));
     }
 }

--- a/cartero-objects/src/request_authentication_bearer.rs
+++ b/cartero-objects/src/request_authentication_bearer.rs
@@ -83,7 +83,15 @@ mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for RequestAuthenticationBearer {}
+    impl ObjectImpl for RequestAuthenticationBearer {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            self.obj().connect_token_notify(|auth| {
+                auth.emit_by_name::<()>("changed", &[&"token"]);
+            });
+        }
+    }
 
     impl RequestAuthenticationDataImpl for RequestAuthenticationBearer {
         fn auth_type(&self) -> crate::RequestAuthenticationType {
@@ -125,7 +133,9 @@ mod builder {
 
 #[cfg(test)]
 mod tests {
-    use crate::{RequestAuthenticationDataExt, RequestAuthenticationType};
+    use crate::{
+        utils::test::assert_emits_signal, RequestAuthenticationDataExt, RequestAuthenticationType,
+    };
 
     use super::*;
 
@@ -161,5 +171,11 @@ mod tests {
             .build();
         assert_eq!(bearer.token(), "aabbccdd");
         assert_eq!(bearer.auth_type(), RequestAuthenticationType::BearerToken);
+    }
+
+    #[test]
+    pub fn test_emits_signals() {
+        let bearer = RequestAuthenticationBearer::default();
+        assert_emits_signal(&bearer, "changed", || bearer.set_token("1234"));
     }
 }

--- a/cartero-objects/src/request_authentication_data.rs
+++ b/cartero-objects/src/request_authentication_data.rs
@@ -64,6 +64,10 @@ mod ffi {
 }
 
 mod imp {
+    use std::sync::OnceLock;
+
+    use glib::{subclass::Signal, types::StaticType};
+
     use crate::RequestAuthenticationType;
 
     use super::*;
@@ -83,7 +87,16 @@ mod imp {
         }
     }
 
-    impl ObjectImpl for RequestAuthenticationData {}
+    impl ObjectImpl for RequestAuthenticationData {
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![Signal::builder("changed")
+                    .param_types([String::static_type()])
+                    .build()]
+            })
+        }
+    }
 
     impl RequestAuthenticationData {
         fn auth_type_default(&self) -> RequestAuthenticationType {

--- a/cartero-objects/src/request_body.rs
+++ b/cartero-objects/src/request_body.rs
@@ -314,9 +314,12 @@ mod builder {
 }
 
 mod imp {
-    use std::cell::RefCell;
+    use std::{
+        cell::{OnceCell, RefCell},
+        sync::OnceLock,
+    };
 
-    use glib::Properties;
+    use glib::{subclass::Signal, Properties, SignalGroup};
 
     use crate::{RequestBodyData, RequestBodyDataExt};
 
@@ -330,6 +333,7 @@ mod imp {
 
         #[property(get, set = Self::set_body_data, explicit_notify, name = "body-data", nullable)]
         body_data: RefCell<Option<RequestBodyData>>,
+        body_data_group: OnceCell<SignalGroup>,
     }
 
     #[glib::object_subclass]
@@ -339,9 +343,57 @@ mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for RequestBody {}
+    impl ObjectImpl for RequestBody {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.init_signal_group();
+
+            self.obj().connect_body_type_notify(|auth| {
+                auth.emit_by_name::<()>("changed", &[&"type"]);
+            });
+            self.obj().connect_body_data_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |body| {
+                    imp.body_data_group
+                        .get()
+                        .unwrap()
+                        .set_target(body.body_data().as_ref());
+                    body.emit_by_name::<()>("changed", &[&"data"]);
+                }
+            ));
+        }
+
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![Signal::builder("changed")
+                    .param_types([String::static_type()])
+                    .build()]
+            })
+        }
+    }
 
     impl RequestBody {
+        fn init_signal_group(&self) {
+            let obj = self.obj();
+
+            let body_data_group = SignalGroup::new::<RequestBodyData>();
+            body_data_group.connect_closure(
+                "changed",
+                false,
+                glib::closure_local!(
+                    #[weak]
+                    obj,
+                    move |_: &RequestBodyData, param: &str| {
+                        let param = format!("data.{param}");
+                        obj.emit_by_name::<()>("changed", &[&param]);
+                    }
+                ),
+            );
+            self.body_data_group.set(body_data_group).unwrap();
+        }
+
         fn set_body_type(&self, body_type: RequestBodyType) {
             if *self.body_type.borrow() == body_type {
                 return;
@@ -531,5 +583,79 @@ mod tests {
         let data = body.raw().unwrap();
         assert_eq!(data.payload_type(), RequestBodyRawType::OctetStream);
         assert_eq!(data.payload(), "hello world");
+    }
+
+    #[test]
+    pub fn test_emits_signal_on_change_none() {
+        let body = RequestBody::new(RequestBodyType::None, RequestBodyData::NONE);
+        assert_emits_signal(&body, "changed", || {
+            body.set_body_type(RequestBodyType::Multipart);
+        });
+    }
+
+    #[test]
+    pub fn test_emits_signal_on_multipart_change() {
+        let multipart = RequestBodyMultipart::builder()
+            .field(&Field::builder().key("user_id").value("1").build())
+            .build();
+        let body = RequestBody::builder().multipart(&multipart).build();
+
+        assert_emits_signal(&body, "changed", || {
+            body.multipart()
+                .expect("This is not a multipart")
+                .params()
+                .insert(&Field::builder().build());
+        });
+        assert_emits_signal(&body, "changed", || {
+            body.multipart()
+                .expect("This is not a multipart")
+                .set_params(FieldTable::default());
+        });
+        assert_emits_signal(&body, "changed", || {
+            body.multipart()
+                .expect("This is not a multipart")
+                .params()
+                .insert(&Field::builder().build());
+        });
+    }
+
+    #[test]
+    pub fn test_emits_signal_on_urlencoded_change() {
+        let urlencoded = RequestBodyUrlencoded::builder()
+            .field(&Field::builder().key("user_id").value("1").build())
+            .build();
+        let body = RequestBody::builder().urlencoded(&urlencoded).build();
+
+        assert_emits_signal(&body, "changed", || {
+            body.urlencoded()
+                .expect("This is not a urlencoded")
+                .params()
+                .insert(&Field::builder().build());
+        });
+        assert_emits_signal(&body, "changed", || {
+            body.urlencoded()
+                .expect("This is not a urlencoded")
+                .set_params(FieldTable::default());
+        });
+        assert_emits_signal(&body, "changed", || {
+            body.urlencoded()
+                .expect("This is not a urlencoded")
+                .params()
+                .insert(&Field::builder().build());
+        });
+    }
+
+    #[test]
+    pub fn test_emits_signal_on_raw_change() {
+        let body = RequestBody::new(RequestBodyType::Raw, RequestBodyData::NONE);
+
+        assert_emits_signal(&body, "changed", || {
+            body.raw().expect("This is not raw").set_payload("hello");
+        });
+        assert_emits_signal(&body, "changed", || {
+            body.raw()
+                .expect("This is not raw")
+                .set_payload_type(RequestBodyRawType::Xml);
+        });
     }
 }

--- a/cartero-objects/src/request_body_data.rs
+++ b/cartero-objects/src/request_body_data.rs
@@ -65,6 +65,10 @@ mod ffi {
 }
 
 mod imp {
+    use std::sync::OnceLock;
+
+    use glib::{subclass::Signal, types::StaticType};
+
     use crate::RequestBodyType;
 
     use super::*;
@@ -84,7 +88,16 @@ mod imp {
         }
     }
 
-    impl ObjectImpl for RequestBodyData {}
+    impl ObjectImpl for RequestBodyData {
+        fn signals() -> &'static [Signal] {
+            static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
+            SIGNALS.get_or_init(|| {
+                vec![Signal::builder("changed")
+                    .param_types([String::static_type()])
+                    .build()]
+            })
+        }
+    }
 
     impl RequestBodyData {
         fn body_type_default(&self) -> RequestBodyType {

--- a/cartero-objects/src/request_body_multipart.rs
+++ b/cartero-objects/src/request_body_multipart.rs
@@ -71,11 +71,11 @@ impl RequestBodyMultipart {
 }
 
 mod imp {
-    use glib::Properties;
+    use glib::{Properties, SignalGroup};
 
     use super::*;
 
-    use std::cell::RefCell;
+    use std::cell::{OnceCell, RefCell};
 
     use crate::{FieldTable, RequestBodyDataImpl};
 
@@ -84,6 +84,8 @@ mod imp {
     pub struct RequestBodyMultipart {
         #[property(get, set)]
         params: RefCell<FieldTable>,
+
+        params_changed: OnceCell<SignalGroup>,
     }
 
     #[glib::object_subclass]
@@ -94,11 +96,54 @@ mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for RequestBodyMultipart {}
+    impl ObjectImpl for RequestBodyMultipart {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.init_signal_group();
+
+            let obj = self.obj();
+            self.params_changed
+                .get()
+                .unwrap()
+                .set_target(Some(&obj.params()));
+            obj.connect_params_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |body| {
+                    imp.params_changed
+                        .get()
+                        .unwrap()
+                        .set_target(Some(&body.params()));
+                    body.emit_by_name::<()>("changed", &[&"params"]);
+                }
+            ));
+        }
+    }
 
     impl RequestBodyDataImpl for RequestBodyMultipart {
         fn body_type(&self) -> crate::RequestBodyType {
             crate::RequestBodyType::Multipart
+        }
+    }
+
+    impl RequestBodyMultipart {
+        fn init_signal_group(&self) {
+            let obj = self.obj();
+
+            let params_group = SignalGroup::new::<FieldTable>();
+            params_group.connect_closure(
+                "changed",
+                false,
+                glib::closure_local!(
+                    #[weak]
+                    obj,
+                    move |_: &FieldTable, param: &str| {
+                        let param = format!("params.{param}");
+                        obj.emit_by_name::<()>("changed", &[&param]);
+                    }
+                ),
+            );
+            self.params_changed.set(params_group).unwrap();
         }
     }
 }
@@ -149,7 +194,9 @@ mod tests {
     use gio::prelude::ListModelExt;
     use glib::object::CastNone;
 
-    use crate::{Field, FieldTable, RequestBodyDataExt, RequestBodyType};
+    use crate::{
+        utils::test::assert_emits_signal, Field, FieldTable, RequestBodyDataExt, RequestBodyType,
+    };
 
     use super::RequestBodyMultipart;
 
@@ -215,5 +262,27 @@ mod tests {
     pub fn test_body_type() {
         let body = RequestBodyMultipart::default();
         assert_eq!(body.body_type(), RequestBodyType::Multipart);
+    }
+
+    #[test]
+    pub fn test_emits_change() {
+        let body = RequestBodyMultipart::default();
+        assert_emits_signal(&body, "changed", || {
+            let field = Field::builder().key("user-agent").value("mozilla").build();
+            body.params().insert(&field);
+        });
+        assert_emits_signal(&body, "changed", || {
+            body.params()
+                .field(0)
+                .unwrap()
+                .set_value("internet explorer");
+        });
+        assert_emits_signal(&body, "changed", || {
+            body.set_params(FieldTable::default());
+        });
+        assert_emits_signal(&body, "changed", || {
+            let field = Field::builder().key("user-agent").value("mozilla").build();
+            body.params().insert(&field);
+        });
     }
 }

--- a/cartero-objects/src/request_body_raw.rs
+++ b/cartero-objects/src/request_body_raw.rs
@@ -132,7 +132,18 @@ mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for RequestBodyRaw {}
+    impl ObjectImpl for RequestBodyRaw {
+        fn constructed(&self) {
+            self.parent_constructed();
+
+            self.obj().connect_payload_notify(|raw| {
+                raw.emit_by_name::<()>("changed", &[&"payload"]);
+            });
+            self.obj().connect_payload_type_notify(|raw| {
+                raw.emit_by_name::<()>("changed", &[&"payload-type"]);
+            });
+        }
+    }
 
     impl RequestBodyDataImpl for RequestBodyRaw {
         fn body_type(&self) -> crate::RequestBodyType {
@@ -221,5 +232,14 @@ mod tests {
     pub fn test_body_type() {
         let body: RequestBodyRaw = RequestBodyRaw::default();
         assert_eq!(body.body_type(), RequestBodyType::Raw);
+    }
+
+    #[test]
+    pub fn test_emits_signals() {
+        let body = RequestBodyRaw::builder(RequestBodyRawType::Json).build();
+        assert_emits_signal(&body, "changed", || body.set_payload("hello"));
+        assert_emits_signal(&body, "changed", || {
+            body.set_payload_type(RequestBodyRawType::Xml)
+        });
     }
 }

--- a/cartero-objects/src/request_body_urlencoded.rs
+++ b/cartero-objects/src/request_body_urlencoded.rs
@@ -66,11 +66,11 @@ impl RequestBodyUrlencoded {
 }
 
 mod imp {
-    use glib::Properties;
+    use glib::{Properties, SignalGroup};
 
     use super::*;
 
-    use std::cell::RefCell;
+    use std::cell::{OnceCell, RefCell};
 
     use crate::{FieldTable, RequestBodyDataImpl};
 
@@ -79,6 +79,8 @@ mod imp {
     pub struct RequestBodyUrlencoded {
         #[property(get, set)]
         params: RefCell<FieldTable>,
+
+        params_changed: OnceCell<SignalGroup>,
     }
 
     #[glib::object_subclass]
@@ -89,11 +91,54 @@ mod imp {
     }
 
     #[glib::derived_properties]
-    impl ObjectImpl for RequestBodyUrlencoded {}
+    impl ObjectImpl for RequestBodyUrlencoded {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.init_signal_group();
+
+            let obj = self.obj();
+            self.params_changed
+                .get()
+                .unwrap()
+                .set_target(Some(&obj.params()));
+            obj.connect_params_notify(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |body| {
+                    imp.params_changed
+                        .get()
+                        .unwrap()
+                        .set_target(Some(&body.params()));
+                    body.emit_by_name::<()>("changed", &[&"params"]);
+                }
+            ));
+        }
+    }
 
     impl RequestBodyDataImpl for RequestBodyUrlencoded {
         fn body_type(&self) -> crate::RequestBodyType {
             crate::RequestBodyType::UrlEncoded
+        }
+    }
+
+    impl RequestBodyUrlencoded {
+        fn init_signal_group(&self) {
+            let obj = self.obj();
+
+            let params_group = SignalGroup::new::<FieldTable>();
+            params_group.connect_closure(
+                "changed",
+                false,
+                glib::closure_local!(
+                    #[weak]
+                    obj,
+                    move |_: &FieldTable, param: &str| {
+                        let param = format!("params.{param}");
+                        obj.emit_by_name::<()>("changed", &[&param]);
+                    }
+                ),
+            );
+            self.params_changed.set(params_group).unwrap();
         }
     }
 }
@@ -144,7 +189,9 @@ mod tests {
     use gio::prelude::ListModelExt;
     use glib::object::CastNone;
 
-    use crate::{Field, FieldTable, RequestBodyDataExt, RequestBodyType};
+    use crate::{
+        utils::test::assert_emits_signal, Field, FieldTable, RequestBodyDataExt, RequestBodyType,
+    };
 
     use super::RequestBodyUrlencoded;
 
@@ -200,5 +247,27 @@ mod tests {
     pub fn test_body_type() {
         let body: RequestBodyUrlencoded = RequestBodyUrlencoded::default();
         assert_eq!(body.body_type(), RequestBodyType::UrlEncoded);
+    }
+
+    #[test]
+    pub fn test_emits_change() {
+        let body = RequestBodyUrlencoded::default();
+        assert_emits_signal(&body, "changed", || {
+            let field = Field::builder().key("user-agent").value("mozilla").build();
+            body.params().insert(&field);
+        });
+        assert_emits_signal(&body, "changed", || {
+            body.params()
+                .field(0)
+                .unwrap()
+                .set_value("internet explorer");
+        });
+        assert_emits_signal(&body, "changed", || {
+            body.set_params(FieldTable::default());
+        });
+        assert_emits_signal(&body, "changed", || {
+            let field = Field::builder().key("user-agent").value("mozilla").build();
+            body.params().insert(&field);
+        });
     }
 }

--- a/meson.build
+++ b/meson.build
@@ -28,7 +28,7 @@ gnome = import('gnome')
 
 base_id = 'es.danirod.Cartero'
 
-dependency('glib-2.0', version: '>= 2.72')
+dependency('glib-2.0', version: '>= 2.74')
 dependency('gtk4', version: '>= 4.14')
 dependency('gtksourceview-5', version: '>= 5.4')
 dependency('libadwaita-1', version: '>= 1.5')


### PR DESCRIPTION
GObject types in the cartero_objects crate will now emit different `changed` signals as the value of their properties change.

The signals are composed. This means that an object that contains another object (such as a `RequestBodyMultipart` containing a `FieldTable` as a property) will bubble a received `changed` signal whenever their properties emit their own `changed` signal.

Also, this PR bumps the required GLib version to GLib 2.74. I need this because gtk-rs does not support SignalGroup when using the `2_72` feature, since it has dependencies that explictly require glib-rs with the `2_74` feature.