### PR TITLE
Refactor cURL exporter

### DIFF
--- a/src/export/curl.rs
+++ b/src/export/curl.rs
@@ -18,88 +18,413 @@
 use cartero_objects::{Request, RequestBodyRawType};
 use serde_json::{Error, Value};
 
-pub struct CodeExportService {
-    request: Request,
-}
+pub fn export_as_curl(request: &Request) -> Result<String, cartero_http::RequestError> {
+    let bound_request = cartero_http::BoundRequest::try_from(request.clone())?;
+    let mut command = "curl".to_string();
 
-impl CodeExportService {
-    pub fn new(request: Request) -> Self {
-        Self { request }
+    command.push_str(&{
+        let method_str: String = bound_request.method.to_string();
+        format!(" -X {} '{}'", method_str, bound_request.url)
+    });
+
+    if !bound_request.headers.is_empty() {
+        let size = bound_request.headers.len();
+        let mut keys: Vec<&String> = bound_request.headers.keys().collect();
+        keys.sort();
+
+        command.push_str(" \\\n");
+
+        for (i, key) in keys.iter().enumerate() {
+            let val = bound_request.headers.get(*key).unwrap();
+
+            command.push_str(&{
+                let mut initial = format!("  -H '{key}: {val}'");
+
+                if i < size - 1 {
+                    initial.push_str(" \\\n");
+                }
+
+                initial
+            });
+        }
     }
 
-    pub fn generate(&self) -> Result<String, cartero_http::RequestError> {
-        let bound_request = cartero_http::BoundRequest::try_from(self.request.clone())?;
-        let mut command = "curl".to_string();
+    if let Some(_) = request.body().urlencoded() {
+        if let Some(bd) = bound_request.body.clone() {
+            let str = String::from_utf8_lossy(&bd).to_string();
+            command.push_str(&format!(" \\\n  -d '{str}'"));
+        }
+    }
 
-        command.push_str(&{
-            let method_str: String = bound_request.method.to_string();
-            format!(" -X {} '{}'", method_str, bound_request.url)
-        });
+    if let Some(raw) = request.body().raw() {
+        let content = bound_request.body.clone().unwrap_or_default();
+        let encoding = raw.payload_type();
+        match encoding {
+            RequestBodyRawType::Json => {
+                command.push_str(&'fmt: {
+                    let body = String::from_utf8_lossy(&content).to_string();
+                    let value: Result<Value, Error> = serde_json::from_str(body.as_ref());
 
-        if !bound_request.headers.is_empty() {
-            let size = bound_request.headers.len();
-            let mut keys: Vec<&String> = bound_request.headers.keys().collect();
-            keys.sort();
-
-            command.push_str(" \\\n");
-
-            for (i, key) in keys.iter().enumerate() {
-                let val = bound_request.headers.get(*key).unwrap();
-
-                command.push_str(&{
-                    let mut initial = format!("  -H '{key}: {val}'");
-
-                    if i < size - 1 {
-                        initial.push_str(" \\\n");
+                    if value.is_err() {
+                        break 'fmt String::new();
                     }
 
-                    initial
+                    let value = value.unwrap();
+                    let trimmed_json_str = serde_json::to_string(&value);
+
+                    if trimmed_json_str.is_err() {
+                        break 'fmt String::new();
+                    }
+
+                    let trimmed_json_str = trimmed_json_str.unwrap();
+                    let trimmed_json_str = trimmed_json_str.replace("'", "\\\\'");
+
+                    format!(" \\\n  -d '{}'", trimmed_json_str)
+                });
+            }
+            _ => {
+                command.push_str(&{
+                    let string = String::from_utf8_lossy(&content).to_string();
+                    format!(" \\\n  -d '{}'", string)
                 });
             }
         }
+    }
 
-        if let Some(_) = self.request.body().urlencoded() {
-            if let Some(bd) = bound_request.body.clone() {
-                let str = String::from_utf8_lossy(&bd).to_string();
-                command.push_str(&format!(" \\\n  -d '{str}'"));
-            }
+    Ok(command)
+}
+
+#[cfg(test)]
+mod tests {
+    use cartero_objects::{
+        Field, RequestAuthentication, RequestAuthenticationBasic, RequestAuthenticationBearer,
+        RequestBody, RequestBodyRaw, RequestBodyUrlencoded, RequestMethod,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_export_simple_as_curl() {
+        let request =
+            Request::builder("https://www.example.com/foobar", RequestMethod::Get).build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains("curl -X GET 'https://www.example.com/foobar'"),
+            "Expected {} to be valid",
+            output
+        );
+    }
+
+    #[test]
+    fn test_export_uses_http_method() {
+        let cases = [
+            (
+                RequestMethod::Get,
+                "curl -X GET 'https://www.example.com/foobar'",
+            ),
+            (
+                RequestMethod::Post,
+                "curl -X POST 'https://www.example.com/foobar'",
+            ),
+            (
+                RequestMethod::Put,
+                "curl -X PUT 'https://www.example.com/foobar'",
+            ),
+            (
+                RequestMethod::Delete,
+                "curl -X DELETE 'https://www.example.com/foobar'",
+            ),
+        ];
+        for (verb, expected) in cases {
+            let request = Request::builder("https://www.example.com/foobar", verb).build();
+            let output = super::export_as_curl(&request).expect("Should have been OK");
+            assert!(
+                output.contains(expected),
+                "Expected {} to contain {}",
+                output,
+                expected
+            );
         }
+    }
 
-        if let Some(raw) = self.request.body().raw() {
-            let content = bound_request.body.clone().unwrap_or_default();
-            let encoding = raw.payload_type();
-            match encoding {
-                RequestBodyRawType::Json => {
-                    command.push_str(&'fmt: {
-                        let body = String::from_utf8_lossy(&content).to_string();
-                        let value: Result<Value, Error> = serde_json::from_str(body.as_ref());
+    #[test]
+    fn test_includes_headers() {
+        let request = Request::builder("https://www.example.com/foobar", RequestMethod::Get)
+            .header(
+                &Field::builder()
+                    .key("User-Agent")
+                    .value("Mozilla/5.0")
+                    .build(),
+            )
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains("-H 'User-Agent: Mozilla/5.0'"),
+            "Expected {} to contain the header",
+            output
+        );
+    }
 
-                        if value.is_err() {
-                            break 'fmt String::new();
-                        }
+    #[test]
+    fn test_renders_variables() {
+        let request = Request::builder("{{API_ROOT}}/foobar", RequestMethod::Get)
+            .header(
+                &Field::builder()
+                    .key("X-Api-Key")
+                    .value("{{API_TOKEN}}")
+                    .build(),
+            )
+            .variable(
+                &Field::builder()
+                    .key("API_ROOT")
+                    .value("https://api.example.com")
+                    .build(),
+            )
+            .variable(
+                &Field::builder()
+                    .key("API_TOKEN")
+                    .value("123412341234")
+                    .build(),
+            )
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains("curl -X GET 'https://api.example.com/foobar'"),
+            "Expected {} to contain the rendered URL",
+            output
+        );
+        assert!(
+            output.contains("-H 'X-Api-Key: 123412341234'"),
+            "Expected {} to contain the header",
+            output
+        );
+    }
 
-                        let value = value.unwrap();
-                        let trimmed_json_str = serde_json::to_string(&value);
+    #[test]
+    fn test_renders_basic_auth() {
+        let basic_auth = RequestAuthenticationBasic::builder()
+            .username("admin")
+            .password("{{PASSWORD}}")
+            .build();
+        let auth = RequestAuthentication::builder()
+            .basic_auth(&basic_auth)
+            .build();
+        let request = Request::builder("http://localhost:3000/foobar", RequestMethod::Get)
+            .variable(
+                &Field::builder()
+                    .key("PASSWORD")
+                    .value("12341234")
+                    .masked(true)
+                    .build(),
+            )
+            .with_auth(auth)
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains("-H 'Authorization: Basic YWRtaW46MTIzNDEyMzQ="),
+            "Expected {} to contain the encoded credentials",
+            output
+        );
+    }
 
-                        if trimmed_json_str.is_err() {
-                            break 'fmt String::new();
-                        }
+    #[test]
+    fn test_renders_bearer_tokens() {
+        let bearer_token = RequestAuthenticationBearer::builder()
+            .token("secret_token")
+            .build();
+        let auth = RequestAuthentication::builder()
+            .bearer_token(&bearer_token)
+            .build();
+        let request = Request::builder("http://localhost:3000/foobar", RequestMethod::Get)
+            .with_auth(auth)
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains("-H 'Authorization: Bearer secret_token"),
+            "Expected {} to contain the encoded credentials",
+            output
+        );
+    }
 
-                        let trimmed_json_str = trimmed_json_str.unwrap();
-                        let trimmed_json_str = trimmed_json_str.replace("'", "\\\\'");
+    #[test]
+    fn test_renders_urlencoded() {
+        let urlencoded = RequestBodyUrlencoded::builder()
+            .field(&Field::builder().key("user_id").value("100").build())
+            .field(
+                &Field::builder()
+                    .key("category")
+                    .value("home office")
+                    .build(),
+            )
+            .field(
+                &Field::builder()
+                    .key("ignore_me")
+                    .value("please")
+                    .active(false)
+                    .build(),
+            )
+            .field(&Field::builder().key("is_admin").value("{{ADMIN}}").build())
+            .build();
+        let body = RequestBody::builder().urlencoded(&urlencoded).build();
+        let request = Request::builder("https://localhost:3000/foobar", RequestMethod::Post)
+            .variable(&Field::builder().key("ADMIN").value("true").build())
+            .with_body(body)
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains("-d 'user_id=100&category=home+office&is_admin=true'"),
+            "Expected {} to contain the encoded body",
+            output
+        );
+    }
 
-                        format!(" \\\n  -d '{}'", trimmed_json_str)
-                    });
-                }
-                _ => {
-                    command.push_str(&{
-                        let string = String::from_utf8_lossy(&content).to_string();
-                        format!(" \\\n  -d '{}'", string)
-                    });
-                }
-            }
-        }
+    #[test]
+    fn test_renders_json() {
+        let json = RequestBodyRaw::builder(RequestBodyRawType::Json)
+            .payload(r#"{"hello": "world"}"#)
+            .build();
+        let body = RequestBody::builder().raw(&json).build();
+        let request = Request::builder("https://localhost:3000/foobar", RequestMethod::Post)
+            .with_body(body)
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains(r#"-d '{"hello":"world"}'"#),
+            "Expected {} to contain the encoded body",
+            output
+        );
+        assert!(
+            output.contains("-H 'Content-Type: application/json'"),
+            "Expected {} to contain the default header",
+            output
+        );
+    }
 
-        Ok(command)
+    #[test]
+    fn test_renders_json_with_custom_content_type() {
+        let json = RequestBodyRaw::builder(RequestBodyRawType::Json)
+            .payload(r#"{"hello": "world"}"#)
+            .build();
+        let body = RequestBody::builder().raw(&json).build();
+        let request = Request::builder("https://localhost:3000/foobar", RequestMethod::Post)
+            .header(
+                &Field::builder()
+                    .key("Content-Type")
+                    .value("application/activity+json")
+                    .build(),
+            )
+            .with_body(body)
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains(r#"-d '{"hello":"world"}'"#),
+            "Expected {} to contain the encoded body",
+            output
+        );
+        assert!(
+            output.contains("-H 'Content-Type: application/activity+json'"),
+            "Expected {} to contain the custom header",
+            output
+        );
+    }
+
+    #[test]
+    fn test_renders_xml() {
+        let xml = RequestBodyRaw::builder(RequestBodyRawType::Xml)
+            .payload(r#"<?xml version="1.0" ?><envelope />"#)
+            .build();
+        let body = RequestBody::builder().raw(&xml).build();
+        let request = Request::builder("https://localhost:3000/foobar", RequestMethod::Post)
+            .with_body(body)
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains(r#"-d '<?xml version="1.0" ?><envelope />'"#),
+            "Expected {} to contain the encoded body",
+            output
+        );
+        assert!(
+            output.contains("-H 'Content-Type: application/xml'"),
+            "Expected {} to contain the default header",
+            output
+        );
+    }
+
+    #[test]
+    fn test_renders_xml_with_custom_content_type() {
+        let xml = RequestBodyRaw::builder(RequestBodyRawType::Xml)
+            .payload(r#"<?xml version="1.0" ?><envelope />"#)
+            .build();
+        let body = RequestBody::builder().raw(&xml).build();
+        let request = Request::builder("https://localhost:3000/foobar", RequestMethod::Post)
+            .header(
+                &Field::builder()
+                    .key("Content-Type")
+                    .value("application/atom+xml")
+                    .build(),
+            )
+            .with_body(body)
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains(r#"-d '<?xml version="1.0" ?><envelope />'"#),
+            "Expected {} to contain the encoded body",
+            output
+        );
+        assert!(
+            output.contains("-H 'Content-Type: application/atom+xml'"),
+            "Expected {} to contain the custom header",
+            output
+        );
+    }
+
+    #[test]
+    fn test_renders_octet_stream() {
+        let os = RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
+            .payload("ID,Date,Description,Ready")
+            .build();
+        let body = RequestBody::builder().raw(&os).build();
+        let request = Request::builder("https://localhost:3000/foobar", RequestMethod::Post)
+            .with_body(body)
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains("-d 'ID,Date,Description,Ready'"),
+            "Expected {} to contain the encoded body",
+            output
+        );
+        assert!(
+            output.contains("-H 'Content-Type: application/octet-stream'"),
+            "Expected {} to contain the default header",
+            output
+        );
+    }
+
+    #[test]
+    fn test_renders_octet_stream_with_custom_content_type() {
+        let os = RequestBodyRaw::builder(RequestBodyRawType::OctetStream)
+            .payload("ID,Date,Description,Ready")
+            .build();
+        let body = RequestBody::builder().raw(&os).build();
+        let request = Request::builder("https://localhost:3000/foobar", RequestMethod::Post)
+            .header(
+                &Field::builder()
+                    .key("Content-Type")
+                    .value("text/csv")
+                    .build(),
+            )
+            .with_body(body)
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains("-d 'ID,Date,Description,Ready'"),
+            "Expected {} to contain the encoded body",
+            output
+        );
+        assert!(
+            output.contains("-H 'Content-Type: text/csv'"),
+            "Expected {} to contain the custom header",
+            output
+        );
     }
 }

--- a/src/export/curl.rs
+++ b/src/export/curl.rs
@@ -15,12 +15,34 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use cartero_objects::{Request, RequestBodyRawType};
+use cartero_objects::{Field, FieldTable, Request, RequestBodyRawType, RequestBodyType};
+use gtk::gio::prelude::ListModelExtManual;
 use serde_json::{Error, Value};
+
+fn escape_single_string(str: impl AsRef<str>) -> String {
+    str.as_ref().replace("'", "'\\''")
+}
+
+fn encode_multipart(params: &FieldTable) -> String {
+    params
+        .iter::<Field>()
+        .filter_map(|f| f.ok())
+        .filter(|f| f.active())
+        .map(|f| {
+            format!(
+                "-F '{}={}'",
+                escape_single_string(f.key()),
+                escape_single_string(f.value())
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" \\\n  ")
+}
 
 pub fn export_as_curl(request: &Request) -> Result<String, cartero_http::RequestError> {
     let bound_request = cartero_http::BoundRequest::try_from(request.clone())?;
     let mut command = "curl".to_string();
+    let template = request.variables().template_processor();
 
     command.push_str(&{
         let method_str: String = bound_request.method.to_string();
@@ -29,13 +51,19 @@ pub fn export_as_curl(request: &Request) -> Result<String, cartero_http::Request
 
     if !bound_request.headers.is_empty() {
         let size = bound_request.headers.len();
-        let mut keys: Vec<&String> = bound_request.headers.keys().collect();
+        let mut keys: Vec<String> = bound_request.headers.keys().cloned().collect();
         keys.sort();
+
+        // Skip the Content-Type in multipart requests because it is ugly anyway
+        // and cURL will add its own boundary anyway.
+        if request.body().body_type() == RequestBodyType::Multipart {
+            keys.retain(|k| !k.eq("Content-Type"));
+        }
 
         command.push_str(" \\\n");
 
         for (i, key) in keys.iter().enumerate() {
-            let val = bound_request.headers.get(*key).unwrap();
+            let val = bound_request.headers.get(key).unwrap();
 
             command.push_str(&{
                 let mut initial = format!("  -H '{key}: {val}'");
@@ -54,6 +82,12 @@ pub fn export_as_curl(request: &Request) -> Result<String, cartero_http::Request
             let str = String::from_utf8_lossy(&bd).to_string();
             command.push_str(&format!(" \\\n  -d '{str}'"));
         }
+    }
+
+    if let Some(multipart) = request.body().multipart() {
+        let table = multipart.params().render(&template)?;
+        let params = encode_multipart(&table);
+        command.push_str(&format!(" \\\n  {params}"));
     }
 
     if let Some(raw) = request.body().raw() {
@@ -98,7 +132,7 @@ pub fn export_as_curl(request: &Request) -> Result<String, cartero_http::Request
 mod tests {
     use cartero_objects::{
         Field, RequestAuthentication, RequestAuthenticationBasic, RequestAuthenticationBearer,
-        RequestBody, RequestBodyRaw, RequestBodyUrlencoded, RequestMethod,
+        RequestBody, RequestBodyMultipart, RequestBodyRaw, RequestBodyUrlencoded, RequestMethod,
     };
 
     use super::*;
@@ -274,6 +308,53 @@ mod tests {
         assert!(
             output.contains("-d 'user_id=100&category=home+office&is_admin=true'"),
             "Expected {} to contain the encoded body",
+            output
+        );
+    }
+
+    #[test]
+    fn test_renders_multipart() {
+        let multipart = RequestBodyMultipart::builder()
+            .field(&Field::builder().key("user_id").value("100").build())
+            .field(
+                &Field::builder()
+                    .key("category")
+                    .value("home office")
+                    .build(),
+            )
+            .field(
+                &Field::builder()
+                    .key("ignore_me")
+                    .value("please")
+                    .active(false)
+                    .build(),
+            )
+            .field(&Field::builder().key("is_admin").value("{{ADMIN}}").build())
+            .build();
+        let body = RequestBody::builder().multipart(&multipart).build();
+        let request = Request::builder("https://localhost:3000/foobar", RequestMethod::Post)
+            .variable(&Field::builder().key("ADMIN").value("true").build())
+            .with_body(body)
+            .build();
+        let output = super::export_as_curl(&request).expect("Should have been OK");
+        assert!(
+            output.contains("-F 'user_id=100'"),
+            "Expected {} to contain the encoded body for user_id",
+            output
+        );
+        assert!(
+            output.contains("-F 'category=home office'"),
+            "Expected {} to contain the encoded body for category",
+            output
+        );
+        assert!(
+            output.contains("-F 'is_admin=true'"),
+            "Expected {} to contain the encoded body for is_admin",
+            output
+        );
+        assert!(
+            !output.contains("-H 'Content-Type: multipart/form-data; boundary="),
+            "Expected {} not to contain a multipart header",
             output
         );
     }

--- a/src/widgets/endpoint/endpoint_pane.rs
+++ b/src/widgets/endpoint/endpoint_pane.rs
@@ -26,7 +26,7 @@ use url::form_urlencoded;
 
 use crate::{
     app::CarteroApplication,
-    export::curl::CodeExportService,
+    export::curl::export_as_curl,
     interop::{InnerError, LoadResult, ObjectPane, SaveResult},
     widgets::ExportDialog,
 };
@@ -568,9 +568,7 @@ impl EndpointPane {
     }
 
     pub fn export_request(&self, format: &str) {
-        let curl = CodeExportService::new(self.request());
-
-        if let Ok(command) = curl.generate() {
+        if let Ok(command) = export_as_curl(&self.request()) {
             let buffer = glib::Bytes::from(command.as_bytes());
             let file_format = sourceview5::LanguageManager::default().language("sh");
             let dialog = glib::Object::builder::<ExportDialog>()


### PR DESCRIPTION
## Fixes the missing export type for RequestBodyMultipart

As reported in #236, if you try to export a request whose body is set to multipart, it will not include currently the form fields assigned to the request. I'm using the `-F` parameter of the cURL parameter list, because it looks better than trying to encapsulate the whole request body including the boundaries.

## Rename CodeService to just `export_as_curl`

Because this function is stateless now and doesn't need automatic updates, I've replaced the CodeService struct with just a function that receives the current state of the Request as a parameter.

If I move this to a different crate such as `cartero_curl_format` (which I bet is going to happen), then the new name makes a lot of sense.

## Add more tests

This code is currently not tested and it would be nice to have some automatic tests to check that the different request components are exported correctly, in case I make some refactors.

