### PR TITLE
Export response body

### DIFF
--- a/data/ui/main_window.blp
+++ b/data/ui/main_window.blp
@@ -165,10 +165,19 @@ template $CarteroWindow: Adw.ApplicationWindow {
 }
 
 menu share_menu {
-  item {
-    label: _("Export request as cURL…");
-    action: "win.export-request";
-    target: "curl";
+  section {
+    item {
+      label: _("Export request as cURL…");
+      action: "win.export-request";
+      target: "curl";
+    }
+  }
+
+  section {
+    item {
+      label: _("Export response body…");
+      action: "win.export-response-body";
+    }
   }
 }
 

--- a/data/ui/main_window_no_csd.blp
+++ b/data/ui/main_window_no_csd.blp
@@ -167,10 +167,19 @@ template $CarteroWindow: Gtk.ApplicationWindow {
 }
 
 menu share_menu {
-  item {
-    label: _("Export request as cURL…");
-    action: "win.export-request";
-    target: "curl";
+  section {
+    item {
+      label: _("Export request as cURL…");
+      action: "win.export-request";
+      target: "curl";
+    }
+  }
+
+  section {
+    item {
+      label: _("Export response body…");
+      action: "win.export-response-body";
+    }
   }
 }
 

--- a/po/ca.po
+++ b/po/ca.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-05-22 15:06+0000\n"
 "Last-Translator: alesdevux <aleswebgit@gmail.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -362,29 +362,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Nova pestanya"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Obrir petició…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Guardar petició"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Guardar petició com…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Tancar pestanya"
 
@@ -440,53 +440,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Aparença del cos"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Adaptar contingut"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Mostrar números de línia"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Indentar automàticament"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Indentar amb espais"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Indentar amb tabuladors"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Espais per tabulador"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -511,7 +511,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr "Manual d’usuari"
 
@@ -525,7 +525,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr "Ajuda’ns a traduir"
 
@@ -564,25 +564,30 @@ msgstr "Benvolgut a Cartero"
 msgid "Create or open a request and start testing APIs now."
 msgstr "Crea o obre una petició i comença a provar APIs ara."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 #, fuzzy
 msgid "Export request as cURL…"
 msgstr "Exportar petició"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Exportar petició"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "Configuració"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Dreceres de teclat"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "Quant a Cartero"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Sortir"
 
@@ -919,7 +924,7 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Guardar"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "Exportar petició"
@@ -1038,24 +1043,24 @@ msgid_plural "{} results"
 msgstr[0] "{} resultat"
 msgstr[1] "{} resultats"
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(sense títol)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Esborrany"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Els autors de Cartero"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "Ivan Garcia, Àlex Serra (alesdevux)"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 Els autors de Cartero"
 

--- a/po/cartero.pot
+++ b/po/cartero.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -348,29 +348,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr ""
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr ""
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr ""
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr ""
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr ""
 
@@ -424,53 +424,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr ""
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr ""
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr ""
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr ""
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr ""
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr ""
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr ""
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr ""
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr ""
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr ""
 
@@ -548,24 +548,28 @@ msgstr ""
 msgid "Create or open a request and start testing APIs now."
 msgstr ""
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 msgid "Export request as cURL…"
 msgstr ""
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+msgid "Export response body…"
+msgstr ""
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr ""
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr ""
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr ""
 
@@ -883,7 +887,7 @@ msgstr ""
 msgid "_Save"
 msgstr ""
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 msgid "Export request as cURL"
 msgstr ""
 
@@ -1000,23 +1004,23 @@ msgid_plural "{} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr ""
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr ""
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr ""
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr ""
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-04-16 11:02+0000\n"
 "Last-Translator: vesp <vesp@post.cz>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/cartero/cartero/cs/"
@@ -363,29 +363,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Nový panel"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Otevřít požadavek…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Uložit požadavek"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Uložit požadavek jako…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Zavřít panel"
 
@@ -441,53 +441,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Vzhled těla"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Zalomit obsah"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Zobrazit čísla řádků"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Automatické odsazení"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Odsadit mezerami"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Odsadit tabulátory"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Délka tabulátoru v mezerách"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -512,7 +512,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr "Uživatelská příručka"
 
@@ -526,7 +526,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr "Pomozte nám s překladem"
 
@@ -565,25 +565,30 @@ msgstr "Vítá vás aplikace Cartero"
 msgid "Create or open a request and start testing APIs now."
 msgstr "Vytvořte nebo otevřete požadavek a začněte testovat API."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 #, fuzzy
 msgid "Export request as cURL…"
 msgstr "Exportovat požadavek"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Exportovat požadavek"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "Nastavení"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Klávesové zkratky"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "O aplikaci Cartero"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Ukončit"
 
@@ -919,7 +924,7 @@ msgstr "Zahodi_t změny"
 msgid "_Save"
 msgstr "_Uložit"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "Exportovat požadavek"
@@ -1039,24 +1044,24 @@ msgstr[0] "{} požadavek"
 msgstr[1] "{} požadavky"
 msgstr[2] "{} požadavků"
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(bez názvu)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Koncept"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Autoři aplikace Cartero"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "vesp"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 autoři aplikace Cartero"
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-05-17 00:02+0000\n"
 "Last-Translator: Juan Manuel Nani <jn4625070@gmail.com>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -367,29 +367,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Neuer Tab"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Anfrage öffnen…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Anfrage speichern"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Anfrage speichern unter…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Tab schließen"
 
@@ -445,53 +445,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Aussehen des Körpers"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Inhalte umbrechen"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Zeilennummern anzeigen"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Automatische Einrückung"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Einrücken mit Leerzeichen"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Einrücken mit Tabs"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Leerzeichen pro Tab"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -516,7 +516,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr "Benutzerhandbuch"
 
@@ -530,7 +530,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr "Bei der Übersetzung helfen"
 
@@ -571,25 +571,30 @@ msgstr ""
 "Erstellen oder öffnen Sie eine Anfrage und beginnen Sie jetzt mit dem Testen "
 "von APIs."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 #, fuzzy
 msgid "Export request as cURL…"
 msgstr "Anfrage exportieren"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Anfrage exportieren"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "Einstellungen"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Tastenkürzel"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "Über Cartero"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Beenden"
 
@@ -933,7 +938,7 @@ msgstr "_Verwerfen"
 msgid "_Save"
 msgstr "_Speichern"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "Anfrage exportieren"
@@ -1054,24 +1059,24 @@ msgid_plural "{} results"
 msgstr[0] "{} Ergebnis"
 msgstr[1] "{} Ergebnisse"
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(unbenannt)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Entwurf"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Die Autoren von Cartero"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "mstffn"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 die Cartero Autoren"
 

--- a/po/eo.po
+++ b/po/eo.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2024-11-04 17:46+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/cartero/"
@@ -348,29 +348,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr ""
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr ""
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr ""
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr ""
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr ""
 
@@ -426,53 +426,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr ""
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr ""
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr ""
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr ""
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr ""
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr ""
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr ""
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -497,7 +497,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr ""
 
@@ -511,7 +511,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr ""
 
@@ -550,24 +550,28 @@ msgstr ""
 msgid "Create or open a request and start testing APIs now."
 msgstr ""
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 msgid "Export request as cURL…"
 msgstr ""
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+msgid "Export response body…"
+msgstr ""
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr ""
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "Pri Cartero"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr ""
 
@@ -888,7 +892,7 @@ msgstr ""
 msgid "_Save"
 msgstr ""
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "URL"
@@ -1007,24 +1011,24 @@ msgid_plural "{} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr ""
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr ""
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr ""
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "Dani Rodríguez"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-08-01 22:56+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -364,29 +364,29 @@ msgid "File"
 msgstr "Archivo"
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Nueva pestaña"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Abrir petición…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Guardar petición"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Guardar petición como…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Cerrar pestaña"
 
@@ -440,53 +440,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr "Editar URL"
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Apariencia del cuerpo"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Adaptar contenido"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Mostrar números de línea"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Indentar automáticamente"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Indentar con espacios"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Indentar con tabuladores"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Espacios por tabulador"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -511,7 +511,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr "Ayuda"
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr "Manual de usuario"
 
@@ -525,7 +525,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr "Ver discusiones"
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr "Ayúdanos a traducir"
 
@@ -564,24 +564,29 @@ msgstr "Bienvenido a Cartero"
 msgid "Create or open a request and start testing APIs now."
 msgstr "Crea o abre una petición y empieza a probar APIs ahora."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 msgid "Export request as cURL…"
 msgstr "Exportar petición como cURL…"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Exportar petición como cURL…"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "Preferencias"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Atajos de teclado"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "Acerca de Cartero"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Salir"
 
@@ -919,7 +924,7 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Guardar"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 msgid "Export request as cURL"
 msgstr "Exportar petición como cURL"
 
@@ -1038,24 +1043,24 @@ msgid_plural "{} results"
 msgstr[0] "{} resultado"
 msgstr[1] "{} resultados"
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(sin título)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Borrador"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Los autores de Cartero"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "Dani Rodríguez"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 los autores de Cartero"
 

--- a/po/eu.po
+++ b/po/eu.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-05-01 14:01+0000\n"
 "Last-Translator: Ibai Oihanguren Sala <ibaios@disroot.org>\n"
 "Language-Team: Basque <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -366,29 +366,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Fitxa berria"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Ireki eskaera…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Gorde eskaera"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Gorde eskaera honela…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Itxi fitxa"
 
@@ -444,53 +444,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Gorputzaren itxura"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Itzulbiratu edukia"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Erakutsi lerro-zenbakiak"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Koska automatikoa"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Erabili zuriuneak koskarako"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Erabili tabulazioak koskarako"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Tabulazio bakoitzeko zuriuneak"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -515,7 +515,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr "Erabiltzailearen eskuliburua"
 
@@ -529,7 +529,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr "Lagun gaitzazu itzultzen"
 
@@ -568,25 +568,30 @@ msgstr "Ongi etorri Carterora"
 msgid "Create or open a request and start testing APIs now."
 msgstr "Sortu edo ireki eskaera bat eta hasi APIak probatzen orain."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 #, fuzzy
 msgid "Export request as cURL…"
 msgstr "Esportatu eskaera"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Esportatu eskaera"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "Ezarpenak"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Laster-teklak"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "Carterori buruz"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Irten"
 
@@ -925,7 +930,7 @@ msgstr "_Baztertu"
 msgid "_Save"
 msgstr "_Gorde"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "Esportatu eskaera"
@@ -1044,24 +1049,24 @@ msgid_plural "{} results"
 msgstr[0] "Emaitza {}"
 msgstr[1] "{} emaitza"
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(izengabea)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Zirriborroa"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Carteroren egileak"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "Ibai Oihanguren Sala"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 Carteroren egileak"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-08-01 22:56+0000\n"
 "Last-Translator: Dani Rodríguez <dani@danirod.es>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -366,29 +366,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Nouvel onglet"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Ouvrir une requête…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Enregistrer la requête"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Enregistrer la requête sous…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Fermer l'onglet"
 
@@ -444,53 +444,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Apparence du corps"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Adapter le contenu"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Afficher les numéros de ligne"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Indentation automatique"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Indenter avec des espaces"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Indenter avec des tabulations"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Espaces par tabulation"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -515,7 +515,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr ""
 
@@ -569,25 +569,30 @@ msgid "Create or open a request and start testing APIs now."
 msgstr ""
 "Créez ou ouvrez une requête et commencez dès maintenant à tester des API."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 #, fuzzy
 msgid "Export request as cURL…"
 msgstr "Exporter la requête"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Exporter la requête"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "Préférences"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Raccourcis clavier"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "À propos de Cartero"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Quitter"
 
@@ -919,7 +924,7 @@ msgstr "_Abandonner"
 msgid "_Save"
 msgstr "_Enregistrer"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "Exporter la requête"
@@ -1038,24 +1043,24 @@ msgid_plural "{} results"
 msgstr[0] "{} résultat"
 msgstr[1] "{} résultats"
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(sans titre)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Brouillon"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Les auteurs de Cartero"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "Altero"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 les auteurs de Cartero"
 

--- a/po/gl.po
+++ b/po/gl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-08-05 14:02+0000\n"
 "Last-Translator: Eric Pernas <ericpg76@gmail.com>\n"
 "Language-Team: Galician <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -364,29 +364,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Nova lapela"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Abrir petición…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Gardar petición"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Gardar petición coma…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Pechar lapela"
 
@@ -442,53 +442,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Apariencia do corpo"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Adaptar contido"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Mostrar números de liña"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Indentar automáticamente"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Indentar con espazos"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Indentar con tabuladores"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Espazos por tabulador"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -513,7 +513,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr "Manual de usuario"
 
@@ -527,7 +527,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr "Axúdanos a traducir"
 
@@ -566,24 +566,29 @@ msgstr "Benvido a Cartero"
 msgid "Create or open a request and start testing APIs now."
 msgstr "Crea ou abre unha petición e comeza a probar APIs agora."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 msgid "Export request as cURL…"
 msgstr "Exportar petición como cURL…"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Exportar petición como cURL…"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "Axustes"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Atallos de teclado"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "Sobre Cartero"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Saír"
 
@@ -920,7 +925,7 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Gardar"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "Exportar petición"
@@ -1039,24 +1044,24 @@ msgid_plural "{} results"
 msgstr[0] "{} resultado"
 msgstr[1] "{} resultados"
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(sen título)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Borrador"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Os autores de Cartero"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "Eric Pernas"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 os autores de Cartero"
 

--- a/po/pt.po
+++ b/po/pt.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-04-10 15:58+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: Portuguese <https://hosted.weblate.org/projects/cartero/"
@@ -364,29 +364,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Nova guia"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Pedido aberto…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Gravar solicitação"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Gravar solicitação como…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Beche a guia"
 
@@ -442,53 +442,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Aparência corporal"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Enrole o conteúdo"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Mostrar números de linha"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Recuo automático"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Recuo com espaços"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Recuo com guias"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Espaços por guia"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -513,7 +513,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr "Manual do utilizador"
 
@@ -527,7 +527,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr "Ajude-nos a traduzir"
 
@@ -566,25 +566,30 @@ msgstr "Bem -vindo a um Mailman"
 msgid "Create or open a request and start testing APIs now."
 msgstr "Crie ou abra uma solicitação e comece a testar as APIs agora."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 #, fuzzy
 msgid "Export request as cURL…"
 msgstr "Solicitação de exportação"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Solicitação de exportação"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "Configurações"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Atalhos de teclado"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "Sobre Cartero"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Desistir"
 
@@ -923,7 +928,7 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Salvar"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "Solicitação de exportação"
@@ -1043,24 +1048,24 @@ msgid_plural "{} results"
 msgstr[0] "{} resultado"
 msgstr[1] "{} resultados"
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(sem título)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Rascunho"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Os autores de Cartero"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "john peter"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 Os autores Cartero"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-05-12 14:02+0000\n"
 "Last-Translator: John Peter Sa <johnppetersa@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -364,29 +364,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Nova guia"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Pedido aberto…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Salvar solicitação"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Salvar solicitação como…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Beche a guia"
 
@@ -442,53 +442,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Aparência corporal"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Enrole o conteúdo"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Mostrar números de linha"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Recuo automático"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Recuo com espaços"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Recuo com guias"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Espaços por guia"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -513,7 +513,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr "Manual do usuário"
 
@@ -527,7 +527,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr "Ajude-nos a traduzir"
 
@@ -566,25 +566,30 @@ msgstr "Bem -vindo a um Mailman"
 msgid "Create or open a request and start testing APIs now."
 msgstr "Crie ou abra uma solicitação e comece a testar as APIs agora."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 #, fuzzy
 msgid "Export request as cURL…"
 msgstr "Solicitação de exportação"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Solicitação de exportação"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "Configurações"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Atalhos de teclado"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "Sobre Cartero"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Desistir"
 
@@ -925,7 +930,7 @@ msgstr "_Descartar"
 msgid "_Save"
 msgstr "_Salvar"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "Solicitação de exportação"
@@ -1045,24 +1050,24 @@ msgid_plural "{} results"
 msgstr[0] "{} resultado"
 msgstr[1] "{} resultados"
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(sem título)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Rascunho"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Os autores de Cartero"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "john peter"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 Os autores Cartero"
 

--- a/po/ro.po
+++ b/po/ro.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2024-07-30 15:00+0200\n"
 "Last-Translator:  <>\n"
 "Language-Team: Romanian\n"
@@ -348,29 +348,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Tab nou"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Deschideți cererea…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Salvați cererea"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Salvați cererea ca…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Închideți tab-ul"
 
@@ -425,53 +425,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Aspectul corpului"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Înveliți conținutul"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Afișați numerele de linie"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Indentarea automată"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Indentăm cu spații"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Indentăm cu taburi"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Spații pe tab"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -496,7 +496,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr ""
 
@@ -510,7 +510,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr ""
 
@@ -549,25 +549,30 @@ msgstr "Bun venit în Cartero"
 msgid "Create or open a request and start testing APIs now."
 msgstr "Creați sau deschideți o cerere și începeți testarea API-urilor acum."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 #, fuzzy
 msgid "Export request as cURL…"
 msgstr "Salvați cererea ca…"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Salvați cererea ca…"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr ""
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Scurtături de tastatură"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "Despre Cartero"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Ieșiți"
 
@@ -894,7 +899,7 @@ msgstr "_Renunțați"
 msgid "_Save"
 msgstr "_Salvați"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "Salvați cererea ca…"
@@ -1013,24 +1018,24 @@ msgid_plural "{} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(fără titlu)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Proiect"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Autorii Cartero"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "Richardo G.C."
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 autorii Cartero"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-05-06 12:01+0000\n"
 "Last-Translator: Yurt Page <yurtpage@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/cartero/cartero/"
@@ -363,29 +363,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "Новая вкладка"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "Открыть запрос…"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "Сохранить запрос"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "Сохранить запрос как…"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "Закрыть вкладку"
 
@@ -441,53 +441,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "Внешний вид тела запроса"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "Переносить содержимое"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "Показывать номера строк"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "Автоматический отступ"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "Пробелы"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "Табуляция"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "Пробелов на табуляцию"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -512,7 +512,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr ""
 
@@ -526,7 +526,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr "Помогите нам перевести"
 
@@ -565,25 +565,30 @@ msgstr "Добро пожаловать в Cartero"
 msgid "Create or open a request and start testing APIs now."
 msgstr "Создайте или откройте запрос и начните тестировать API прямо сейчас."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 #, fuzzy
 msgid "Export request as cURL…"
 msgstr "Экспортировать запрос"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "Экспортировать запрос"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "Настройки"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "Комбинации клавиш"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "О приложении"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "Выход"
 
@@ -907,7 +912,7 @@ msgstr "_Отменить"
 msgid "_Save"
 msgstr "_Сохранить"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "Экспортировать запрос"
@@ -1026,24 +1031,24 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(без названия)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "Черновик"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "Авторы Cartero"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "Vladimir Kosolapov"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 Авторы Cartero"
 

--- a/po/ta.po
+++ b/po/ta.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: 2025-04-27 13:08+0000\n"
 "Last-Translator: தமிழ்நேரம் <anishprabu.t@gmail.com>\n"
 "Language-Team: Tamil <https://hosted.weblate.org/projects/cartero/cartero/ta/"
@@ -362,29 +362,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr "புதிய தாவல்"
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr "திறந்த கோரிக்கை …"
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr "கோரிக்கையைச் சேமிக்கவும்"
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr "கோரிக்கையை சேமிக்கவும் …"
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr "தாவலை மூடு"
 
@@ -440,53 +440,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr "உடல் தோற்றம்"
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr "உள்ளடக்கத்தை மடக்கு"
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr "வரி எண்களைக் காட்டு"
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr "தானியங்கி உள்தள்ளல்"
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr "இடைவெளிகளுடன் உள்தள்ளுங்கள்"
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr "தாவல்களுடன் உள்தள்ளுங்கள்"
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr "ஒரு தாவலுக்கு இடங்கள்"
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr "2"
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr "4"
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr "8"
 
@@ -511,7 +511,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr "பயனர் கையேடு"
 
@@ -525,7 +525,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr "உதவி us மொழிபெயர்த்திடு"
 
@@ -564,25 +564,30 @@ msgstr "கார்டெரோவுக்கு வருக"
 msgid "Create or open a request and start testing APIs now."
 msgstr "ஒரு கோரிக்கையை உருவாக்கி அல்லது திறந்து இப்போது பநிஇ களை சோதிக்கத் தொடங்குங்கள்."
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 #, fuzzy
 msgid "Export request as cURL…"
 msgstr "ஏற்றுமதி கோரிக்கை"
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+#, fuzzy
+msgid "Export response body…"
+msgstr "ஏற்றுமதி கோரிக்கை"
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr "அமைப்புகள்"
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr "விசைப்பலகை குறுக்குவழிகள்"
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr "கார்டெரோ பற்றி"
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr "வெளியேறு"
 
@@ -917,7 +922,7 @@ msgstr "_ டிச்கார்ட்"
 msgid "_Save"
 msgstr "_சேவ்"
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 #, fuzzy
 msgid "Export request as cURL"
 msgstr "ஏற்றுமதி கோரிக்கை"
@@ -1036,24 +1041,24 @@ msgid_plural "{} results"
 msgstr[0] "{} முடிவு"
 msgstr[1] "{} முடிவுகள்"
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr "(பெயரிடப்படாதது)"
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr "வரைவு"
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr "கார்டெரோ ஆசிரியர்கள்"
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr "தமிழ்நேரம்"
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr "© 2024-2025 கார்டெரோ ஆசிரியர்கள்"
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: cartero\n"
 "Report-Msgid-Bugs-To: https://github.com/danirod/cartero/issues\n"
-"POT-Creation-Date: 2025-08-07 18:10+0200\n"
+"POT-Creation-Date: 2025-08-08 18:50+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -347,29 +347,29 @@ msgid "File"
 msgstr ""
 
 #: data/ui/mac_menu.blp:25 data/ui/main_window.blp:137
-#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:138
-#: data/ui/main_window_no_csd.blp:180
+#: data/ui/main_window.blp:187 data/ui/main_window_no_csd.blp:138
+#: data/ui/main_window_no_csd.blp:189
 msgid "New tab"
 msgstr ""
 
 #: data/ui/mac_menu.blp:30 data/ui/main_window.blp:150
-#: data/ui/main_window.blp:183 data/ui/main_window_no_csd.blp:151
-#: data/ui/main_window_no_csd.blp:185
+#: data/ui/main_window.blp:192 data/ui/main_window_no_csd.blp:151
+#: data/ui/main_window_no_csd.blp:194
 msgid "Open request…"
 msgstr ""
 
-#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:188
-#: data/ui/main_window_no_csd.blp:190 src/widgets/file_dialogs.rs:146
+#: data/ui/mac_menu.blp:35 data/ui/main_window.blp:197
+#: data/ui/main_window_no_csd.blp:199 src/widgets/file_dialogs.rs:146
 msgid "Save request"
 msgstr ""
 
-#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:193
-#: data/ui/main_window_no_csd.blp:195
+#: data/ui/mac_menu.blp:40 data/ui/main_window.blp:202
+#: data/ui/main_window_no_csd.blp:204
 msgid "Save request as…"
 msgstr ""
 
-#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:198
-#: data/ui/main_window_no_csd.blp:200
+#: data/ui/mac_menu.blp:47 data/ui/main_window.blp:207
+#: data/ui/main_window_no_csd.blp:209
 msgid "Close tab"
 msgstr ""
 
@@ -423,53 +423,53 @@ msgctxt "menubar"
 msgid "Edit URL"
 msgstr ""
 
-#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:210
-#: data/ui/main_window_no_csd.blp:212
+#: data/ui/mac_menu.blp:120 data/ui/main_window.blp:219
+#: data/ui/main_window_no_csd.blp:221
 msgid "Body appearance"
 msgstr ""
 
-#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:214
-#: data/ui/main_window_no_csd.blp:216
+#: data/ui/mac_menu.blp:124 data/ui/main_window.blp:223
+#: data/ui/main_window_no_csd.blp:225
 msgid "Wrap content"
 msgstr ""
 
-#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:219
-#: data/ui/main_window_no_csd.blp:221
+#: data/ui/mac_menu.blp:129 data/ui/main_window.blp:228
+#: data/ui/main_window_no_csd.blp:230
 msgid "Show line numbers"
 msgstr ""
 
-#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:226
-#: data/ui/main_window_no_csd.blp:228
+#: data/ui/mac_menu.blp:136 data/ui/main_window.blp:235
+#: data/ui/main_window_no_csd.blp:237
 msgid "Automatic indentation"
 msgstr ""
 
-#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:231
-#: data/ui/main_window_no_csd.blp:233
+#: data/ui/mac_menu.blp:141 data/ui/main_window.blp:240
+#: data/ui/main_window_no_csd.blp:242
 msgid "Indent with spaces"
 msgstr ""
 
-#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:237
-#: data/ui/main_window_no_csd.blp:239
+#: data/ui/mac_menu.blp:147 data/ui/main_window.blp:246
+#: data/ui/main_window_no_csd.blp:248
 msgid "Indent with tabs"
 msgstr ""
 
-#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:243
-#: data/ui/main_window_no_csd.blp:245
+#: data/ui/mac_menu.blp:153 data/ui/main_window.blp:252
+#: data/ui/main_window_no_csd.blp:254
 msgid "Spaces per tab"
 msgstr ""
 
-#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:246
-#: data/ui/main_window_no_csd.blp:248
+#: data/ui/mac_menu.blp:156 data/ui/main_window.blp:255
+#: data/ui/main_window_no_csd.blp:257
 msgid "2"
 msgstr ""
 
-#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:252
-#: data/ui/main_window_no_csd.blp:254
+#: data/ui/mac_menu.blp:162 data/ui/main_window.blp:261
+#: data/ui/main_window_no_csd.blp:263
 msgid "4"
 msgstr ""
 
-#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:258
-#: data/ui/main_window_no_csd.blp:260
+#: data/ui/mac_menu.blp:168 data/ui/main_window.blp:267
+#: data/ui/main_window_no_csd.blp:269
 msgid "8"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgctxt "menubar"
 msgid "Help"
 msgstr ""
 
-#: data/ui/mac_menu.blp:200 src/win.rs:634
+#: data/ui/mac_menu.blp:200 src/win.rs:669
 msgid "User manual"
 msgstr ""
 
@@ -508,7 +508,7 @@ msgctxt "menubar"
 msgid "View discussions"
 msgstr ""
 
-#: data/ui/mac_menu.blp:217 src/win.rs:636
+#: data/ui/mac_menu.blp:217 src/win.rs:671
 msgid "Help us translate"
 msgstr ""
 
@@ -547,24 +547,28 @@ msgstr ""
 msgid "Create or open a request and start testing APIs now."
 msgstr ""
 
-#: data/ui/main_window.blp:169 data/ui/main_window_no_csd.blp:171
+#: data/ui/main_window.blp:170 data/ui/main_window_no_csd.blp:172
 msgid "Export request as cURL…"
 msgstr ""
 
-#: data/ui/main_window.blp:205 data/ui/main_window_no_csd.blp:207
+#: data/ui/main_window.blp:178 data/ui/main_window_no_csd.blp:180
+msgid "Export response body…"
+msgstr ""
+
+#: data/ui/main_window.blp:214 data/ui/main_window_no_csd.blp:216
 #: data/ui/settings_dialog.blp:21
 msgid "Settings"
 msgstr ""
 
-#: data/ui/main_window.blp:269 data/ui/main_window_no_csd.blp:271
+#: data/ui/main_window.blp:278 data/ui/main_window_no_csd.blp:280
 msgid "Keyboard shortcuts"
 msgstr ""
 
-#: data/ui/main_window.blp:274 data/ui/main_window_no_csd.blp:276
+#: data/ui/main_window.blp:283 data/ui/main_window_no_csd.blp:285
 msgid "About Cartero"
 msgstr ""
 
-#: data/ui/main_window.blp:279 data/ui/main_window_no_csd.blp:281
+#: data/ui/main_window.blp:288 data/ui/main_window_no_csd.blp:290
 msgid "Quit"
 msgstr ""
 
@@ -882,7 +886,7 @@ msgstr ""
 msgid "_Save"
 msgstr ""
 
-#: src/widgets/endpoint/endpoint_pane.rs:585
+#: src/widgets/endpoint/endpoint_pane.rs:618
 msgid "Export request as cURL"
 msgstr ""
 
@@ -999,23 +1003,23 @@ msgid_plural "{} results"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/win.rs:256
+#: src/win.rs:285
 msgid "(untitled)"
 msgstr ""
 
-#: src/win.rs:270
+#: src/win.rs:299
 msgid "Draft"
 msgstr ""
 
-#: src/win.rs:578
+#: src/win.rs:613
 msgid "The Cartero authors"
 msgstr ""
 
 #. Translators: Replace "translator-credits" with your names. Put a comma between.
-#: src/win.rs:601
+#: src/win.rs:636
 msgid "translator-credits"
 msgstr ""
 
-#: src/win.rs:602
+#: src/win.rs:637
 msgid "© 2024-2025 the Cartero authors"
 msgstr ""

--- a/src/widgets/endpoint/endpoint_pane.rs
+++ b/src/widgets/endpoint/endpoint_pane.rs
@@ -18,9 +18,12 @@
 use adw::prelude::AdwDialogExt;
 use cartero_objects::Request;
 use gettextrs::gettext;
+use glib::object::CastNone;
+use glib::subclass::types::ObjectSubclassIsExt;
 use glib::Object;
-use gtk::gio::prelude::SettingsExtManual;
+use gtk::gio::FileCreateFlags;
 use gtk::glib;
+use gtk::{gio::prelude::SettingsExtManual, prelude::WidgetExt};
 use sourceview5::prelude::FileExtManual;
 use url::form_urlencoded;
 
@@ -28,7 +31,7 @@ use crate::{
     app::CarteroApplication,
     export::curl::CodeExportService,
     interop::{InnerError, LoadResult, ObjectPane, SaveResult},
-    widgets::ExportDialog,
+    widgets::{file_dialogs, ExportDialog},
 };
 
 mod imp {
@@ -36,7 +39,7 @@ mod imp {
     use std::sync::{Arc, Mutex};
 
     use adw::subclass::breakpoint_bin::BreakpointBinImpl;
-    use cartero_objects::{Field, Request};
+    use cartero_objects::{Field, Request, Response};
     use glib::subclass::InitializingObject;
     use glib::{JoinHandle, Properties};
     use gtk::gio::{self, SimpleAction, SimpleActionGroup};
@@ -217,6 +220,10 @@ mod imp {
                     binding_group_2.set_source(Some(&ep.request()));
                 }
             ));
+        }
+
+        pub(super) fn get_response_object(&self) -> Option<Response> {
+            self.response.response()
         }
 
         fn has_response_impl(&self) -> bool {
@@ -568,6 +575,32 @@ impl EndpointPane {
     pub fn new() -> Self {
         // TODO: Accept additional initial state maybe?
         Object::builder().build()
+    }
+
+    pub async fn export_response(&self) {
+        let root = self.root().and_downcast::<gtk::Window>().unwrap();
+        let export_file = file_dialogs::export_file(&root).await;
+        match export_file {
+            Err(e) => crate::widgets::dialogs::glib_file_dialog_error(&root, &e).await,
+            Ok(file) => {
+                if let Some(file) = file {
+                    // get the current response payload
+                    let resp = self.imp().get_response_object().unwrap();
+                    let payload = resp.body().unwrap_or(glib::Bytes::from_static(&[]));
+                    if let Err((_, e)) = file
+                        .replace_contents_future(
+                            payload.to_vec(),
+                            None,
+                            false,
+                            FileCreateFlags::NONE,
+                        )
+                        .await
+                    {
+                        crate::widgets::dialogs::glib_file_dialog_error(&root, &e).await;
+                    }
+                }
+            }
+        }
     }
 
     pub async fn export_request(&self, format: &str) {

--- a/src/win.rs
+++ b/src/win.rs
@@ -25,7 +25,7 @@ mod imp {
     use std::collections::HashSet;
 
     use adw::prelude::WidgetExt;
-    use std::cell::OnceCell;
+    use std::cell::{OnceCell, RefCell};
 
     use adw::AboutDialog;
     use adw::{prelude::*, subclass::prelude::*, TabPage};
@@ -69,10 +69,47 @@ mod imp {
         stack: TemplateChild<gtk::Stack>,
 
         current_tab_binding_group: OnceCell<glib::BindingGroup>,
+        export_menu_tab_responses: RefCell<Vec<gtk::ExpressionWatch>>,
     }
 
     #[gtk::template_callbacks]
     impl CarteroWindow {
+        /// Updates the binds for the "Export response" actions, so that
+        /// they use the has-response property of the current pane, or
+        /// false if there is no current pane at all. This function should
+        /// be called whenever the current page changes.
+        fn evaluate_export_menu_tab_responses(&self) {
+            {
+                let watches = self.export_menu_tab_responses.borrow_mut();
+                for watch in &*watches {
+                    watch.unwatch();
+                }
+            }
+
+            let action_binding = if let Some(page) = self.tabview.selected_page() {
+                page.property_expression("child")
+                    .chain_property::<EndpointPane>("has-response")
+                    .upcast()
+            } else {
+                gtk::ConstantExpression::new(false).upcast()
+            };
+            let obj = self.obj();
+
+            /* Enable these actions only if there is an open page and the page has a valid response. */
+            let tab_and_response_actions = ["export-response-body", "export-har"];
+            let new_tab_bindings = tab_and_response_actions
+                .iter()
+                .filter_map(|tab| {
+                    if let Some(action) = obj.lookup_action(&tab) {
+                        Some(action_binding.bind(&action, "enabled", Some(&*self.tabview)))
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>();
+            self.export_menu_tab_responses.replace(new_tab_bindings);
+        }
+
         fn init_tab_bindings(&self) {
             let obj = &*self.obj();
 
@@ -118,18 +155,7 @@ mod imp {
                 }
             }
 
-            /* Enable these actions only if there is an open page and the page has a valid response. */
-            let has_response = self
-                .tabview
-                .property_expression("selected-page")
-                .chain_property::<adw::TabPage>("child")
-                .chain_property::<EndpointPane>("has-response");
-            let tab_and_response_actions = ["export-response-body", "export-har"];
-            for tab in tab_and_response_actions {
-                if let Some(action) = obj.lookup_action(&tab) {
-                    has_response.bind(&action, "enabled", Some(&*self.tabview));
-                }
-            }
+            self.evaluate_export_menu_tab_responses();
 
             self.tabview.connect_notify_local(
                 Some("selected-page"),
@@ -137,6 +163,9 @@ mod imp {
                     #[weak(rename_to = imp)]
                     self,
                     move |tv: &adw::TabView, _| {
+                        // Re-evalute the export bindings.
+                        imp.evaluate_export_menu_tab_responses();
+
                         let page = tv.selected_page();
                         let binding_group = imp.current_tab_binding_group.get().unwrap();
                         binding_group.set_source(page.as_ref());

--- a/src/win.rs
+++ b/src/win.rs
@@ -567,6 +567,12 @@ mod imp {
             }
         }
 
+        async fn action_export_response(&self) {
+            if let Some(pane) = self.current_pane() {
+                pane.export_response().await;
+            }
+        }
+
         async fn close_tab_requested(&self, tabpage: &TabPage) {
             let obj = self.obj();
             let endpoint_pane = tabpage.child().downcast::<EndpointPane>().unwrap();
@@ -906,13 +912,15 @@ mod imp {
                 .build();
 
             let action_export_response_body = ActionEntry::builder("export-response-body")
-                .activate(glib::clone!(
-                    #[weak(rename_to = window)]
-                    self,
-                    move |_, _, _| {
-                        println!("Exporting response body");
-                    }
-                ))
+                .activate(move |window: &super::CarteroWindow, _, _| {
+                    glib::spawn_future_local(glib::clone!(
+                        #[weak]
+                        window,
+                        async move {
+                            window.imp().action_export_response().await;
+                        }
+                    ));
+                })
                 .build();
 
             let action_export_har = ActionEntry::builder("export-har")


### PR DESCRIPTION
This PR will add a menu item in the Export dropdown menu that will allow saving the response body in a file. The main use case is exporting responses into files, as previously discussed in #187, #188 and probably #124.

<img width="270" height="194" alt="image" src="https://github.com/user-attachments/assets/3ae2f5e8-48f5-4306-b5b1-9516e3957f46" />
