### PR TITLE
Suggest initial file name when exporting response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,9 +291,11 @@ name = "cartero_objects"
 version = "0.3.0"
 dependencies = [
  "base64 0.22.1",
+ "content_disposition",
  "ctor",
  "gio",
  "glib",
+ "http 1.3.1",
  "itertools",
  "srtemplate",
 ]
@@ -330,12 +332,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "charset"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1f927b07c74ba84c7e5fe4db2baeb3e996ab2688992e39ac68ce3220a677c7e"
+dependencies = [
+ "base64 0.22.1",
+ "encoding_rs",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "content_disposition"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc14a88e1463ddd193906285abe5c360c7e8564e05ccc5d501755f7fbc9ca9c"
+dependencies = [
+ "charset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ license = "GPL-3.0-or-later"
 [workspace.dependencies]
 askama = "0.14.0"
 base64 = "0.22.1"
+content_disposition = "0.4.0"
 glib = { version = "0.20.10", features = ["v2_74"] }
 gio = { version = "0.20.11", features = ["v2_74"] }
 http = "1.3.1"

--- a/cartero-objects/Cargo.toml
+++ b/cartero-objects/Cargo.toml
@@ -23,8 +23,10 @@ license.workspace = true
 
 [dependencies]
 base64.workspace = true
+content_disposition.workspace = true
 glib.workspace = true
 gio.workspace = true
+http.workspace = true
 itertools = "0.14.0"
 srtemplate.workspace = true
 

--- a/cartero-objects/src/response.rs
+++ b/cartero-objects/src/response.rs
@@ -15,8 +15,12 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use std::str::FromStr;
+
+use content_disposition::parse_content_disposition;
 use glib::prelude::*;
 use glib::subclass::prelude::*;
+use http::Uri;
 
 use crate::{FieldTable, Request};
 
@@ -52,6 +56,38 @@ impl Response {
             },
             None => false,
         }
+    }
+
+    pub fn file_name(&self) -> String {
+        let disposition = self
+            .headers()
+            .find_by_name_icase("content-disposition")
+            .and_then(|headers| {
+                if headers.len() == 1 {
+                    Some(headers[0].clone())
+                } else {
+                    None
+                }
+            })
+            .map(|header| parse_content_disposition(header.as_str()))
+            .and_then(|disposition| disposition.filename_full());
+
+        disposition.unwrap_or_else(|| {
+            let full_url = self.request().url();
+            let url = full_url
+                .split_once('?')
+                .map(|(start, _)| start)
+                .unwrap_or(&full_url);
+            match Uri::from_str(url) {
+                Ok(uri) => uri
+                    .path()
+                    .rsplit_once("/")
+                    .map(|(_, end)| end)
+                    .unwrap_or(url)
+                    .to_owned(),
+                Err(_) => url.to_owned(),
+            }
+        })
     }
 
     pub fn is_json(&self) -> bool {
@@ -200,6 +236,58 @@ mod tests {
 
     fn request() -> Request {
         Request::builder("https://www.example.com/api/users", RequestMethod::Get).build()
+    }
+
+    #[test]
+    fn file_name_reads_from_url() {
+        let response = Response::builder(&request()).build();
+        let file_name = response.file_name();
+        assert_eq!(file_name, "users");
+    }
+
+    #[test]
+    fn file_name_strips_query_params() {
+        let request = Request::builder(
+            "https://www.example.com/index.html?page=12341234",
+            RequestMethod::Get,
+        )
+        .build();
+        let response = Response::builder(&request).build();
+        let file_name = response.file_name();
+        assert_eq!(file_name, "index.html");
+    }
+
+    #[test]
+    fn file_name_includes_extension() {
+        let request =
+            Request::builder("https://www.example.com/attachment.jpg", RequestMethod::Get).build();
+        let response = Response::builder(&request).build();
+        let file_name = response.file_name();
+        assert_eq!(file_name, "attachment.jpg");
+    }
+
+    #[test]
+    fn file_name_deprioritizes_inline_content_disposition() {
+        let disposition = Field::builder()
+            .key("Content-Disposition")
+            .value("inline")
+            .build();
+        let headers = FieldTable::from_iter([disposition]);
+        let response = Response::builder(&request()).headers(&headers).build();
+        let file_name = response.file_name();
+        assert_eq!(file_name, "users");
+    }
+
+    #[test]
+    fn file_name_prioritizes_attachment_content_disposition() {
+        let disposition = Field::builder()
+            .key("Content-Disposition")
+            .value("attachment; filename=\"report.json\"")
+            .build();
+        let headers = FieldTable::from_iter([disposition]);
+        let response = Response::builder(&request()).headers(&headers).build();
+        let file_name = response.file_name();
+        assert_eq!(file_name, "report.json");
     }
 
     #[test]

--- a/src/widgets/endpoint/endpoint_pane.rs
+++ b/src/widgets/endpoint/endpoint_pane.rs
@@ -710,7 +710,12 @@ mod imp {
 
         async fn action_export_response(&self) {
             let root = self.obj().root().and_downcast::<gtk::Window>().unwrap();
-            let export_file = file_dialogs::export_file(&root).await;
+            let initial_file = self
+                .response_pane
+                .response()
+                .expect("No response to export?")
+                .file_name();
+            let export_file = file_dialogs::export_file(&root, Some(initial_file.as_str())).await;
             match export_file {
                 Err(e) => crate::widgets::dialogs::glib_file_dialog_error(&root, &e).await,
                 Ok(file) => {

--- a/src/widgets/export_dialog.rs
+++ b/src/widgets/export_dialog.rs
@@ -123,7 +123,7 @@ mod imp {
                 async move {
                     let obj = &*dialog.obj();
                     let root = obj.root().and_downcast::<gtk::Window>().unwrap();
-                    let file = match crate::widgets::export_file(&root).await {
+                    let file = match crate::widgets::export_file(&root, None).await {
                         Ok(maybe_file) => maybe_file,
                         Err(e) => {
                             glib_file_dialog_error(&root, &e).await;

--- a/src/widgets/file_dialogs.rs
+++ b/src/widgets/file_dialogs.rs
@@ -217,12 +217,16 @@ where
 /// Opens a generic export dialog that can be used to pick a save location.
 /// This dialog will accept other file types that are not the application
 /// type.
-pub async fn export_file<T>(parent: &T) -> Result<Option<gio::File>, glib::Error>
+pub async fn export_file<T>(
+    parent: &T,
+    initial_name: Option<&str>,
+) -> Result<Option<gio::File>, glib::Error>
 where
     T: IsA<gtk::Window> + Clone + 'static,
 {
     let dialog = FileDialog::builder().modal(true).build();
     dialog.set_accept_label(Some(&gettext("Save")));
+    dialog.set_initial_name(initial_name);
     dialog.set_title(&gettext("Export to file"));
 
     let file = match dialog.save_future(Some(parent)).await {


### PR DESCRIPTION
In this change, the save dialog for responses (like, the one you see when you download a binary response or when you want to export your response data in general) will suggest the file name as the initial name. The priority rules are:

* Use the Content-Disposition if it's attachment and has a valid file name.
* If not present, infer the file name from the request URL.