### PR TITLE
New application shell

### DIFF
--- a/data/cartero.gresource.xml
+++ b/data/cartero.gresource.xml
@@ -28,6 +28,7 @@
     <file alias="urlencoded_body_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/urlencoded_body_pane.ui</file>
     <file alias="multipart_body_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/multipart_body_pane.ui</file>
     <file alias="raw_body_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/raw_body_pane.ui</file>
+    <file alias="standalone/shell.ui" compressed="true" preprocess="xml-stripblanks">ui/standalone/shell.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">icons/scalable/actions/horizontal-arrows-symbolic.svg</file>
     <file compressed="true" preprocess="xml-stripblanks">icons/scalable/actions/tab-new-symbolic.svg</file>
     <file compressed="true" preprocess="xml-stripblanks">icons/scalable/actions/share-symbolic.svg</file>

--- a/data/meson.build
+++ b/data/meson.build
@@ -42,6 +42,7 @@ blueprint_files = [
     'ui/raw_body_pane.blp',
     'ui/multipart_body_pane.blp',
     'ui/urlencoded_body_pane.blp',
+    'ui/standalone/shell.blp',
 ]
 
 blueprint_targets = []

--- a/data/ui/standalone/shell.blp
+++ b/data/ui/standalone/shell.blp
@@ -1,0 +1,188 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+using Gtk 4.0;
+using Adw 1;
+
+template $CarteroStandaloneShell: Adw.BreakpointBin {
+  width-request: 100;
+  height-request: 100;
+
+  Adw.Breakpoint {
+    condition ("max-width: 500sp")
+
+    setters {
+      header_bar_start.visible: false;
+    }
+  }
+
+  Adw.ToolbarView {
+    top-bar-style: raised;
+
+    [top]
+    // An ID is assigned so that I can set the use-native-controls property
+    // dynamically when Adw is 1.8 or greater. This has to be done in code
+    // to keep the template compiling for Adw 1.5.
+    Adw.HeaderBar header_bar {
+      title-widget: window_title;
+
+      [start]
+      Gtk.Box header_bar_start {
+        spacing: 5;
+        orientation: horizontal;
+
+        Button {
+          action-name: "win.new-endpoint";
+          icon-name: "tab-new-symbolic";
+          tooltip-text: _("New");
+        }
+
+        Button {
+          action-name: "win.open-tab";
+          tooltip-text: _("Open");
+
+          Adw.ButtonContent {
+            icon-name: "document-open-symbolic";
+            label: _("Open");
+          }
+        }
+
+        Button {
+          action-name: "win.save-tab";
+          icon-name: "document-save-symbolic";
+          tooltip-text: _("Save");
+        }
+      }
+
+      [end]
+      Gtk.Box {
+        spacing: 5;
+        orientation: horizontal;
+
+        MenuButton export_request {
+          tooltip-text: _("Export request");
+          icon-name: "share-symbolic";
+          menu-model: export_request_menu;
+        }
+
+        MenuButton {
+          tooltip-text: _("Menu");
+          icon-name: "open-menu-symbolic";
+          primary: true;
+          menu-model: main_menu;
+        }
+      }
+    }
+
+    [top]
+    Adw.TabBar {
+      view: tabview;
+    }
+
+    Adw.TabView tabview {
+      notify::selected-page => $on_page_change() swapped;
+      create-window => $on_window_create_request();
+    }
+  }
+}
+
+// The title widget is detached so that it can be added or removed from the
+// HeaderBar when no tab is attached to the TabView, in order to let the
+// AdwHeaderBar present the default window title.
+Adw.WindowTitle window_title {}
+
+menu export_request_menu {
+  section {
+    item {
+      label: _("Export request as cURL…");
+      action: "win.export-request";
+      target: "curl";
+    }
+
+    item {
+      label: _("Export request as Jetbrains HTTP…");
+      action: "win.export-request";
+      target: "jetbrains-http";
+    }
+  }
+
+  section {
+    item {
+      label: _("Export response body…");
+      action: "win.export-response-body";
+    }
+  }
+}
+
+menu main_menu {
+  section {
+    item {
+      label: _("New endpoint");
+      action: "win.new-endpoint";
+    }
+
+    item {
+      label: _("New window");
+      action: "app.new-window";
+    }
+  }
+
+  section {
+    item {
+      label: _("Open request…");
+      action: "win.open-tab";
+    }
+
+    item {
+      label: _("Save request");
+      action: "win.save-tab";
+    }
+
+    item {
+      label: _("Save request as…");
+      action: "win.save-tab-as";
+    }
+
+    item {
+      label: _("Close tab");
+      action: "win.close-tab";
+    }
+  }
+
+  section {
+    item {
+      label: _("Settings");
+      action: "app.preferences";
+    }
+  }
+
+  section {
+    item {
+      label: _("Keyboard shortcuts");
+      action: "win.show-help-overlay";
+    }
+
+    item {
+      label: _("About Cartero");
+      action: "win.about";
+    }
+
+    item {
+      label: _("Quit");
+      action: "app.quit";
+    }
+  }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,12 +18,9 @@
 use adw::prelude::*;
 use glib::subclass::types::ObjectSubclassIsExt;
 use glib::Object;
-use gtk::gio::{self, ActionEntryBuilder, Settings};
-use gtk::prelude::ActionMapExtManual;
+use gtk::gio::{self, Settings};
 
 use crate::config::{APP_ID, BASE_ID, RESOURCE_PATH};
-use crate::win::CarteroWindow;
-use crate::windows::SettingsDialog;
 
 #[macro_export]
 macro_rules! accelerator {
@@ -65,27 +62,6 @@ mod imp {
     impl ApplicationImpl for CarteroApplication {
         fn activate(&self) {
             self.parent_activate();
-            let obj = self.obj();
-
-            let (window, is_new_window) = match obj.active_window() {
-                Some(window) => (window.downcast::<CarteroWindow>().unwrap(), false),
-                None => (CarteroWindow::new(&obj), true),
-            };
-
-            glib::spawn_future_local(glib::clone!(
-                #[weak]
-                obj,
-                async move {
-                    if is_new_window {
-                        let last_session = obj.last_session_tabs();
-                        let open_result = window.open_endpoints(&last_session).await;
-                        window.present();
-                        window.report_open_endpoints_errors(&open_result).await;
-                    } else {
-                        window.present();
-                    }
-                }
-            ));
         }
 
         fn startup(&self) {
@@ -112,32 +88,11 @@ mod imp {
             obj.set_accels_for_action("app.preferences", &[accelerator!("comma")]);
             obj.set_accels_for_action("app.quit", &[accelerator!("q")]);
             obj.set_accels_for_action("win.show-help-overlay", &[accelerator!("question")]);
-            obj.setup_app_actions();
             obj.setup_color_scheme();
         }
 
         fn open(&self, files: &[gio::File], hint: &str) {
             self.parent_open(files, hint);
-            let obj = self.obj();
-            let (window, is_new_window) = match self.obj().active_window() {
-                Some(window) => (window.downcast::<CarteroWindow>().unwrap(), false),
-                None => (CarteroWindow::new(&self.obj()), true),
-            };
-
-            /* If it's a new window, also open the files from the previous session. */
-            let files_to_open: Vec<gio::File> = if is_new_window {
-                let mut previous_files = obj.last_session_tabs();
-                previous_files.extend(files.to_vec());
-                previous_files
-            } else {
-                files.to_vec()
-            };
-
-            glib::spawn_future_local(async move {
-                let open_result = window.open_endpoints(&files_to_open).await;
-                window.present();
-                window.report_open_endpoints_errors(&open_result).await;
-            });
         }
     }
 
@@ -191,96 +146,5 @@ impl CarteroApplication {
                 Some(scheme.into())
             })
             .build();
-    }
-
-    fn setup_app_actions(&self) {
-        let settings = ActionEntryBuilder::new("preferences")
-            .activate(glib::clone!(
-                #[weak(rename_to = app)]
-                self,
-                move |_, _, _| {
-                    if let Some(window) = app.active_window() {
-                        SettingsDialog::present_for_window(&window);
-                    }
-                }
-            ))
-            .build();
-        let about = ActionEntryBuilder::new("about")
-            .activate(|app: &Self, _, _| {
-                if let Some(window) = app.active_window() {
-                    let _ = window.activate_action("win.about", None);
-                }
-            })
-            .build();
-        let quit = ActionEntryBuilder::new("quit")
-            .activate(glib::clone!(
-                #[weak(rename_to = app)]
-                self,
-                move |_, _, _| {
-                    for window in app.windows() {
-                        window.close();
-                    }
-
-                    if app.windows().is_empty() {
-                        app.quit();
-                    }
-                }
-            ))
-            .build();
-
-        self.add_action_entries([settings, about, quit]);
-
-        if cfg!(target_os = "macos") {
-            let links = vec![
-                ("menubar.user-manual", "https://cartero.danirod.es/docs/"),
-                (
-                    "menubar.report-issue",
-                    "https://github.com/danirod/cartero/issues",
-                ),
-                (
-                    "menubar.view-discussions",
-                    "https://github.com/danirod/cartero/discussions",
-                ),
-                (
-                    "menubar.translate",
-                    "https://hosted.weblate.org/projects/cartero/cartero",
-                ),
-            ];
-
-            let actions = links
-                .into_iter()
-                .map(|(id, url)| {
-                    ActionEntryBuilder::new(id)
-                        .activate(move |_, _, _| {
-                            glib::spawn_future_local(async move {
-                                let _ = gtk::UriLauncher::new(url)
-                                    .launch_future(gtk::Window::NONE)
-                                    .await;
-                            });
-                        })
-                        .build()
-                })
-                .collect::<Vec<_>>();
-            self.add_action_entries(actions);
-        }
-    }
-
-    pub fn last_session_tabs(&self) -> Vec<gio::File> {
-        let settings = self.settings();
-
-        settings
-            .get::<Vec<String>>("open-files")
-            .iter()
-            .filter_map(|path| {
-                // These paths are in the format file:///home/user/endpoint.cartero.
-                // TODO: Can't use the url crate to extract the path from the scheme?
-                if let Some((_type, path)) = path.split_once(':') {
-                    let file = gio::File::for_path(path);
-                    Some(file)
-                } else {
-                    None
-                }
-            })
-            .collect()
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -20,7 +20,10 @@ use glib::subclass::types::ObjectSubclassIsExt;
 use glib::Object;
 use gtk::gio::{self, Settings};
 
-use crate::config::{APP_ID, BASE_ID, RESOURCE_PATH};
+use crate::{
+    config::{APP_ID, BASE_ID, RESOURCE_PATH},
+    widgets::standalone::Shell,
+};
 
 #[macro_export]
 macro_rules! accelerator {
@@ -39,7 +42,7 @@ mod imp {
     use adw::prelude::*;
     use adw::subclass::application::AdwApplicationImpl;
     use glib::subclass::{object::ObjectImpl, types::ObjectSubclass};
-    use gtk::gio::Settings;
+    use gtk::gio::{ActionEntry, Settings};
     use gtk::subclass::prelude::*;
     use gtk::subclass::{application::GtkApplicationImpl, prelude::ApplicationImpl};
 
@@ -62,6 +65,7 @@ mod imp {
     impl ApplicationImpl for CarteroApplication {
         fn activate(&self) {
             self.parent_activate();
+            self.obj().new_window();
         }
 
         fn startup(&self) {
@@ -89,6 +93,8 @@ mod imp {
             obj.set_accels_for_action("app.quit", &[accelerator!("q")]);
             obj.set_accels_for_action("win.show-help-overlay", &[accelerator!("question")]);
             obj.setup_color_scheme();
+
+            self.init_actions();
         }
 
         fn open(&self, files: &[gio::File], hint: &str) {
@@ -99,6 +105,21 @@ mod imp {
     impl GtkApplicationImpl for CarteroApplication {}
 
     impl AdwApplicationImpl for CarteroApplication {}
+
+    impl CarteroApplication {
+        fn init_actions(&self) {
+            let new_window = ActionEntry::builder("new-window")
+                .activate(glib::clone!(
+                    #[weak(rename_to = imp)]
+                    self,
+                    move |_, _, _| {
+                        imp.obj().new_window();
+                    }
+                ))
+                .build();
+            self.obj().add_action_entries([new_window]);
+        }
+    }
 }
 
 glib::wrapper! {
@@ -146,5 +167,28 @@ impl CarteroApplication {
                 Some(scheme.into())
             })
             .build();
+    }
+
+    pub fn new_window(&self) -> Shell {
+        let shell = Shell::default();
+
+        let use_csd = true;
+        let window: gtk::ApplicationWindow = if use_csd {
+            let window = adw::ApplicationWindow::new(self);
+            window.set_content(Some(&shell));
+            window.upcast()
+        } else {
+            let window = gtk::ApplicationWindow::new(self);
+            window.set_child(Some(&shell));
+            window.upcast()
+        };
+
+        //let group = gtk::WindowGroup::new();
+        //group.add_window(&window);
+
+        window.set_default_size(800, 500);
+        window.present();
+
+        shell
     }
 }

--- a/src/widgets/shell/common_shell.rs
+++ b/src/widgets/shell/common_shell.rs
@@ -1,0 +1,41 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use glib::object::CastNone;
+use gtk::prelude::*;
+use gtk::subclass::prelude::*;
+
+/// A trait to be used by shell widgets.
+pub trait CommonShell: WidgetImpl
+where
+    <Self as ObjectSubclass>::Type: IsA<gtk::Widget>,
+{
+    /// Returns the root() object, already casted to gtk::ApplicationWindow.
+    fn get_application_window(&self) -> Option<gtk::ApplicationWindow> {
+        self.obj().root().and_downcast()
+    }
+
+    /// Checks if Cartero is running in client-side-decoration mode or not.
+    /// The difference is that in CSD, the root window is an
+    /// AdwApplicationWindow, because the compositor does not draw window
+    /// borders.
+    fn is_client_side(&self) -> bool {
+        self.get_application_window()
+            .and_downcast::<adw::ApplicationWindow>()
+            .is_some()
+    }
+}

--- a/src/widgets/shell/mod.rs
+++ b/src/widgets/shell/mod.rs
@@ -16,5 +16,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 mod base_pane;
+mod common_shell;
 
 pub use base_pane::*;
+pub use common_shell::*;

--- a/src/widgets/standalone/closures.rs
+++ b/src/widgets/standalone/closures.rs
@@ -1,0 +1,54 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use gettextrs::gettext;
+use gtk::gio;
+use gtk::prelude::*;
+use gtk::ClosureExpression;
+
+use crate::widgets::shell::BasePane;
+
+pub fn install_base_pane_page_closures(page: &adw::TabPage, child: &BasePane) {
+    // Define the bindings that act on the tab indicator.
+    let file = child.property_expression("file");
+    let dirty = child.property_expression("dirty");
+
+    // Bind title
+    ClosureExpression::with_callback([&file, &dirty], |args| {
+        let file = args[1].get::<Option<gio::File>>().unwrap();
+        let dirty = args[2].get::<bool>().unwrap();
+        let path = file
+            .and_then(|f| f.basename())
+            .map(|bn| bn.file_stem().unwrap().to_str().unwrap().to_string())
+            .unwrap_or(gettext("(untitled)"));
+        if dirty {
+            format!("• {}", &path)
+        } else {
+            path
+        }
+    })
+    .bind(page, "title", Some(child));
+
+    // Bind subtitle
+    ClosureExpression::with_callback([&file], |args| {
+        let file = args[1].get::<Option<gio::File>>().unwrap();
+        file.and_then(|f| f.path())
+            .map(|bn| bn.display().to_string())
+            .unwrap_or(gettext("Draft"))
+    })
+    .bind(page, "tooltip", Some(child));
+}

--- a/src/widgets/standalone/mod.rs
+++ b/src/widgets/standalone/mod.rs
@@ -15,23 +15,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-pub mod authentication;
-mod code_view;
-pub mod dialogs;
-pub mod endpoint;
-mod error_pane;
-mod export_dialog;
-pub mod field;
-mod file_dialogs;
-mod method_dropdown;
-pub mod req_body;
-mod search_box;
-pub mod shell;
-pub mod standalone;
+mod closures;
+mod shell;
 
-pub use code_view::CodeView;
-pub use error_pane::ErrorPane;
-pub use export_dialog::*;
-pub use file_dialogs::*;
-pub use method_dropdown::MethodDropdown;
-pub use search_box::SearchBox;
+pub use shell::*;

--- a/src/widgets/standalone/shell.rs
+++ b/src/widgets/standalone/shell.rs
@@ -1,0 +1,284 @@
+// Copyright 2024-2025 the Cartero authors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use adw::prelude::*;
+use adw::subclass::prelude::*;
+use gtk::gio;
+
+glib::wrapper! {
+    pub struct Shell(ObjectSubclass<imp::Shell>)
+        @extends gtk::Widget, adw::BreakpointBin,
+        @implements gio::ActionGroup, gio::ActionMap;
+}
+
+impl Default for Shell {
+    fn default() -> Self {
+        glib::Object::new()
+    }
+}
+
+mod imp {
+    use std::cell::OnceCell;
+
+    use crate::app::CarteroApplication;
+    use crate::widgets::endpoint::EndpointPane;
+    use crate::widgets::shell::{BasePane, CommonShell};
+    use crate::widgets::standalone::closures::install_base_pane_page_closures;
+
+    use super::*;
+    use glib::subclass::InitializingObject;
+    use gtk::gdk;
+    use gtk::{
+        gio::{ActionEntry, SimpleActionGroup},
+        CompositeTemplate,
+    };
+
+    #[derive(Default, CompositeTemplate)]
+    #[template(resource = "/es/danirod/Cartero/standalone/shell.ui")]
+    pub struct Shell {
+        #[template_child]
+        header_bar: TemplateChild<adw::HeaderBar>,
+
+        #[template_child]
+        tabview: TemplateChild<adw::TabView>,
+
+        #[template_child]
+        window_title: TemplateChild<adw::WindowTitle>,
+        window_title_binding_group: OnceCell<glib::BindingGroup>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for Shell {
+        const NAME: &'static str = "CarteroStandaloneShell";
+        type Type = super::Shell;
+        type ParentType = adw::BreakpointBin;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.bind_template();
+            klass.bind_template_callbacks();
+
+            let primary = if cfg!(target_os = "macos") {
+                gdk::ModifierType::META_MASK
+            } else {
+                gdk::ModifierType::CONTROL_MASK
+            };
+
+            // The new tab shortcut is kinda special
+            klass.add_binding_action(gdk::Key::T, primary, "win.new-endpoint");
+            klass.add_binding_action(gdk::Key::O, primary, "win.open-tab");
+            klass.add_binding_action(
+                gdk::Key::T,
+                primary | gdk::ModifierType::SHIFT_MASK,
+                "app.new-window",
+            );
+            klass.add_binding_action(gdk::Key::S, primary, "win.save-tab");
+            klass.add_binding_action(
+                gdk::Key::S,
+                primary | gdk::ModifierType::SHIFT_MASK,
+                "win.save-tab-as",
+            );
+            klass.add_binding_action(gdk::Key::W, primary, "win.close-tab");
+        }
+
+        fn instance_init(obj: &InitializingObject<Self>) {
+            obj.init_template();
+        }
+    }
+
+    impl ObjectImpl for Shell {
+        fn constructed(&self) {
+            self.parent_constructed();
+            self.init_actions();
+            self.connect_to_window();
+            self.init_window_title();
+            self.obj()
+                .connect_root_notify(|win| win.imp().connect_to_window());
+        }
+    }
+
+    impl WidgetImpl for Shell {}
+
+    impl BreakpointBinImpl for Shell {}
+
+    impl CommonShell for Shell {}
+
+    #[gtk::template_callbacks]
+    impl Shell {
+        #[template_callback]
+        fn on_page_change(&self) {
+            let selected_page = self.tabview.selected_page();
+            if let Some(bg) = self.window_title_binding_group.get() {
+                bg.set_source(selected_page.as_ref());
+            }
+
+            let window_title = match &selected_page {
+                Some(page) => page
+                    .property_expression("title")
+                    .chain_closure::<String>(glib::closure!(move |_: glib::Object, title: &str| {
+                        format!("{title} — Cartero")
+                    }))
+                    .upcast(),
+                None => gtk::ConstantExpression::new("Cartero").upcast(),
+            };
+            if let Some(window) = self.get_application_window() {
+                window_title.bind(&window, "title", selected_page.as_ref());
+
+                if selected_page.is_some() {
+                    self.header_bar.set_title_widget(Some(&*self.window_title));
+                } else {
+                    self.header_bar.set_title_widget(gtk::Widget::NONE);
+                }
+            }
+        }
+
+        #[template_callback]
+        fn on_window_create_request() -> Option<adw::TabView> {
+            let shell = CarteroApplication::get().new_window();
+            Some(shell.imp().tabview.clone())
+        }
+
+        /// Create a binding between the current tab title and tooltip and
+        /// the window title. The source will be the currently visible page,
+        /// if one is even visible at the moment.
+        fn init_window_title(&self) {
+            let binding_group = glib::BindingGroup::new();
+            binding_group
+                .bind("title", &*self.window_title, "title")
+                .sync_create()
+                .build();
+            binding_group
+                .bind("tooltip", &*self.window_title, "subtitle")
+                .sync_create()
+                .build();
+
+            // Persist it or it will be dropped and removed when this function ends.
+            binding_group.set_source(self.tabview.selected_page().as_ref());
+            self.window_title_binding_group
+                .set(binding_group)
+                .expect("Cannot assign window_title_binding_group");
+        }
+
+        /// Callback invoked whenever the shell gets connected to a window.
+        /// Supposedly, this should only be called at most twice, because you
+        /// don't usually swap the root for the shell in runtime.
+        fn connect_to_window(&self) {
+            /* Disable the header bar controls unless we are in CSD mode. */
+            let csd = self.is_client_side();
+            self.header_bar.set_show_end_title_buttons(csd);
+            self.header_bar.set_show_start_title_buttons(csd);
+            self.header_bar.set_show_title(csd);
+
+            /* Use native controls if the SDK 49 is supported. */
+            if adw::major_version() == 1 && adw::minor_version() >= 8 {
+                self.header_bar.set_property("use-native-controls", true);
+            }
+
+            /* Invoke tab-page <-> window related hooks. */
+            self.on_page_change();
+        }
+
+        fn init_actions(&self) {
+            let new = ActionEntry::builder("new-endpoint")
+                .activate(glib::clone!(
+                    #[weak(rename_to = imp)]
+                    self,
+                    move |_, _, _| imp.action_new_endpoint()
+                ))
+                .build();
+
+            let open = ActionEntry::builder("open-tab")
+                .activate(glib::clone!(
+                    #[weak(rename_to = imp)]
+                    self,
+                    move |_, _, _| imp.action_open_tab()
+                ))
+                .build();
+
+            let save = ActionEntry::builder("save-tab")
+                .activate(glib::clone!(
+                    #[weak(rename_to = imp)]
+                    self,
+                    move |_, _, _| imp.action_save_tab()
+                ))
+                .build();
+
+            let save_as = ActionEntry::builder("save-tab-as")
+                .activate(glib::clone!(
+                    #[weak(rename_to = imp)]
+                    self,
+                    move |_, _, _| imp.action_save_tab_as()
+                ))
+                .build();
+
+            let close = ActionEntry::builder("close-tab")
+                .activate(glib::clone!(
+                    #[weak(rename_to = imp)]
+                    self,
+                    move |_, _, _| imp.action_close_tab()
+                ))
+                .build();
+
+            let group = SimpleActionGroup::new();
+            group.add_action_entries([new, open, save, save_as, close]);
+            self.obj().insert_action_group("win", Some(&group));
+
+            // And then, bind the availability of some of these actions to the
+            // availability of a pane. You might be noticing I am using
+            // lookup_action() again instead of just reusing the variables
+            // from above... but for some reason ActionEntry objects are just
+            // structs that lack a "enabled" property, so I have to look them
+            // up again.
+            let has_page = self
+                .tabview
+                .property_expression("selected-page")
+                .chain_closure::<bool>(glib::closure!(
+                    move |_: glib::Object, page: Option<&adw::TabPage>| page.is_some()
+                ));
+            let tab_dependent_actions = ["save-tab", "save-tab-as", "close-tab"];
+            for tab in tab_dependent_actions {
+                if let Some(action) = group.lookup_action(tab) {
+                    has_page.bind(&action, "enabled", Some(&*self.tabview));
+                }
+            }
+        }
+
+        fn action_new_endpoint(&self) {
+            let endpoint_pane = EndpointPane::default();
+            let base_pane = endpoint_pane.upcast::<BasePane>();
+            let page = self.tabview.add_page(&base_pane, None);
+            install_base_pane_page_closures(&page, &base_pane);
+        }
+
+        fn action_open_tab(&self) {
+            println!("TODO: implement open");
+        }
+
+        fn action_save_tab(&self) {
+            println!("TODO: implement save");
+        }
+
+        fn action_save_tab_as(&self) {
+            println!("TODO: implement save as");
+        }
+
+        fn action_close_tab(&self) {
+            if let Some(current_page) = self.tabview.selected_page() {
+                self.tabview.close_page(&current_page);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This commit implements a new shell for Cartero. It will change the application windows and the content chrome (the toolbar). This is NOT an occasion to rewrite additional panels, as the new shell is going to continue using the EndpointPane that is just refactored.

The goals of this PR are:

* Move some actions where they make sense.
* Simplify some of the callback logic (currently there are too many things happening whenever the "open" or "save" actions are triggered).
* Add support for multiple windows (fixing #258 in the process).
* Remove the duplicate template definitions for the Windows / non-CSD version of Cartero.
* Make the shell more sustainable so that the sidebar required for collections (#11) can be added.