### PR TITLE
Fixes for macOS (0.3 series)

### DIFF
--- a/data/ui/endpoint_pane.blp
+++ b/data/ui/endpoint_pane.blp
@@ -33,13 +33,8 @@ template $CarteroEndpointPane: $CarteroBasePane {
     }
   }
 
-  ShortcutController {
+  ShortcutController shortcuts {
     scope: managed;
-
-    Shortcut {
-      trigger: '<Primary>l';
-      action: 'action(endpoint.focus-url)';
-    }
   }
 
   Box {

--- a/src/widgets/endpoint/endpoint_pane.rs
+++ b/src/widgets/endpoint/endpoint_pane.rs
@@ -55,6 +55,8 @@ mod imp {
     #[template(resource = "/es/danirod/Cartero/endpoint_pane.ui")]
     #[properties(wrapper_type = super::EndpointPane)]
     pub struct EndpointPane {
+        #[template_child]
+        shortcuts: TemplateChild<gtk::ShortcutController>,
         #[template_child(id = "cancel")]
         cancel_button: TemplateChild<gtk::Button>,
         #[template_child]
@@ -128,6 +130,7 @@ mod imp {
     impl ObjectImpl for EndpointPane {
         fn constructed(&self) {
             self.parent_constructed();
+            self.init_shortcuts();
 
             self.init_request_binding_group();
 
@@ -239,6 +242,19 @@ mod imp {
 
     #[gtk::template_callbacks]
     impl EndpointPane {
+        fn init_shortcuts(&self) {
+            let focus_url_trigger = if cfg!(target_os = "macos") {
+                "<Meta>l"
+            } else {
+                "<Primary>l"
+            };
+            let focus_url = gtk::Shortcut::builder()
+                .trigger(&gtk::ShortcutTrigger::parse_string(focus_url_trigger).unwrap())
+                .action(&gtk::ShortcutAction::parse_string("action(endpoint.focus-url)").unwrap())
+                .build();
+            self.shortcuts.add_shortcut(focus_url);
+        }
+
         fn init_pregenerated_rows(&self) {
             self.update_pregenerated_headers();
             self.obj().connect_request_notify(glib::clone!(

--- a/src/widgets/export_dialog.rs
+++ b/src/widgets/export_dialog.rs
@@ -103,7 +103,10 @@ mod imp {
             let obj = &*self.obj();
             let content = {
                 let blob = obj.blob().unwrap_or(glib::Bytes::from(&[]));
-                ContentProvider::for_bytes("text/plain", &blob)
+                ContentProvider::new_union(&[
+                    ContentProvider::for_bytes("text/plain", &blob),
+                    ContentProvider::for_bytes("text/plain;charset=utf-8", &blob),
+                ])
             };
             if let Some(display) = Display::default() {
                 let clipboard = display.clipboard();


### PR DESCRIPTION
Some bugs that I've reproduced recently on macOS:

- The URL bar required Ctrl+L rather than Cmd+L to be focused. Now it will require Cmd+L.
- The export dialog did not actually export to the system clipboard when the copy button was pressed due to how clipboards work on macOS.