### PR TITLE
Win32: Use Microsoft Fluent for the window chrome

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,7 @@ dependencies = [
  "toml",
  "url 2.5.6",
  "winapi",
+ "windows-sys 0.60.2",
  "winresource",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,13 @@ url.workspace = true
 addr = "0.15.6"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["dwmapi"] }
+winapi = { version = "0.3.9", features = ["dwmapi", "winnt", "sysinfoapi"] }
+windows-sys = { version = "0.60.2", features = [
+    "Wdk",
+    "Wdk_System",
+    "Wdk_System_SystemServices",
+    "Win32_System_SystemInformation",
+]}
 gdk4-win32 = '0.10.0'
 
 [build-dependencies]

--- a/data/cartero.gresource.xml
+++ b/data/cartero.gresource.xml
@@ -34,6 +34,7 @@
     <file alias="settings/pill.ui" compressed="true" preprocess="xml-stripblanks">ui/settings/pill.ui</file>
     <file alias="settings/shell.ui" compressed="true" preprocess="xml-stripblanks">ui/settings/shell.ui</file>
     <file alias="style.css" compressed="true">style.css</file>
+    <file alias="style-dark.css" compressed="true">style-dark.css</file>
     <file alias="urlencoded_body_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/urlencoded_body_pane.ui</file>
     <file alias="welcome/welcome_pane.ui" compressed="true" preprocess="xml-stripblanks">ui/welcome/welcome_pane.ui</file>
     <file compressed="true" preprocess="xml-stripblanks">icons/scalable/actions/encode-symbolic.svg</file>

--- a/data/style-dark.css
+++ b/data/style-dark.css
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024-2025 the Cartero authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+window.mica .welcome-pane {
+  background-color: rgb(255 255 255 / 10%);
+}

--- a/data/style.css
+++ b/data/style.css
@@ -45,3 +45,16 @@
   background: var(--headerbar-bg-color);
   border-bottom-left-radius: 10px;
 }
+
+window.mica, window.mica .top-bar {
+  background-color: transparent;
+}
+
+window.mica .welcome-pane {
+  background-color: rgb(255 255 255 / 45%);
+}
+
+window.mica .sidebar-pane {
+  background-color: transparent;
+  --sidebar-border-color: transparent;
+}

--- a/data/ui/main_window_no_csd.blp
+++ b/data/ui/main_window_no_csd.blp
@@ -120,7 +120,13 @@ template $CarteroWindow: Gtk.ApplicationWindow {
         StackPage {
           name: "tabview";
 
-          child: Adw.TabView tabview {};
+          child: Adw.Bin {
+            styles [
+              "view",
+            ]
+
+            Adw.TabView tabview {}
+          };
         }
       }
     }

--- a/data/ui/welcome/welcome_pane.blp
+++ b/data/ui/welcome/welcome_pane.blp
@@ -21,6 +21,10 @@ template $CarteroWelcomePane: Adw.BreakpointBin {
   width-request: 1;
   height-request: 1;
 
+  styles [
+    "welcome-pane",
+  ]
+
   Adw.Breakpoint {
     condition ("max-width: 500sp")
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -213,6 +213,7 @@ impl CarteroApplication {
                 #[weak(rename_to = app)]
                 self,
                 move |_, _, _| {
+                    let current_window = app.active_window();
                     let window = app
                         .windows_by_type::<crate::windows::settings::Shell>()
                         .first()
@@ -224,8 +225,18 @@ impl CarteroApplication {
                             window.set_default_size(700, 500);
                             window.set_title(Some(&gettext("Settings")));
                             window.set_resizable(false);
+                            #[cfg(all(windows, not(feature = "csd")))]
+                            {
+                                // Prepare Windows L&F.
+                                let base_window = window.clone().upcast::<gtk::Window>();
+                                crate::platform::win32_init_window(
+                                    &base_window,
+                                    crate::platform::MicaLevel::MainWindow,
+                                );
+                            }
                             window.upcast()
                         });
+                    window.set_transient_for(current_window.as_ref());
                     window.present();
                 }
             ))

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -15,17 +15,80 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#[cfg(windows)]
-use gtk::prelude::*;
+#[cfg(all(windows, not(feature = "csd")))]
+#[derive(Copy, Clone)]
+pub enum MicaLevel {
+    MainWindow = 2,
+    Tabbed = 4,
+}
 
-#[cfg(windows)]
-use crate::win::CarteroWindow;
+#[cfg(all(windows, not(feature = "csd")))]
+fn win32_get_build_number() -> u32 {
+    // You use the RtlGetVersion. There was a GetVersion, but it is currently deprecated.
+    // I know it will never stop working, but just in case let's not use it.
+    // https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlgetversion
+    use std::sync::OnceLock;
+    use windows_sys::Wdk::System::SystemServices::RtlGetVersion;
+    use windows_sys::Win32::System::SystemInformation::OSVERSIONINFOW;
 
-#[cfg(windows)]
-pub fn win32_set_dark_mode(win: &CarteroWindow, dark: bool) {
+    static BUILD_NUMBER: OnceLock<u32> = OnceLock::new();
+    *BUILD_NUMBER.get_or_init(|| {
+        // The C version of RtlGetVersion literally receives a pointer so that it can dump
+        // OS information. Standard behaviour for C, but since we are crossing the FFI
+        // frontier here, it has to be done exactly like that too. Spooky.
+        let version_info = OSVERSIONINFOW {
+            ..Default::default()
+        };
+        unsafe {
+            if RtlGetVersion(&version_info as *const _ as _) == 0 {
+                version_info.dwBuildNumber
+            } else {
+                0
+            }
+        }
+    })
+}
+
+#[cfg(all(windows, not(feature = "csd")))]
+fn win32_supports_mica() -> bool {
+    // Mica is only supported on Windows 11 Build 22621 or greater:
+    // https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
+    win32_get_build_number() >= 22621
+}
+
+#[cfg(all(windows, not(feature = "csd")))]
+pub fn win32_set_mica(win: &gtk::Window, mica: MicaLevel) {
     use gdk4_win32::Win32Surface;
+    use gtk::prelude::*;
 
-    // Get HWND from the CarteroWindow. This only works if the window is already
+    // Get HWND from the window. This only works if the window is already
+    // visible, otherwise Windows will not have assigned an HWND to the window yet.
+    let maybe_hwnd = win
+        .surface()
+        .and_downcast::<Win32Surface>()
+        .map(|surface| surface.handle().0);
+
+    if let Some(hwnd) = maybe_hwnd {
+        use winapi::{shared::windef::HWND, um::dwmapi::DwmSetWindowAttribute};
+
+        let winapi_backdrop = mica as i32;
+        unsafe {
+            DwmSetWindowAttribute(
+                hwnd as HWND,
+                38,
+                &winapi_backdrop as *const _ as _,
+                std::mem::size_of_val(&winapi_backdrop) as u32,
+            );
+        }
+    }
+}
+
+#[cfg(all(windows, not(feature = "csd")))]
+pub fn win32_set_dark_mode(win: &gtk::Window, dark: bool) {
+    use gdk4_win32::Win32Surface;
+    use gtk::prelude::*;
+
+    // Get HWND from the window. This only works if the window is already
     // visible, otherwise Windows will not have assigned an HWND to the window yet.
     let maybe_hwnd = win
         .surface()
@@ -61,4 +124,59 @@ pub fn win32_set_dark_mode(win: &CarteroWindow, dark: bool) {
             );
         }
     }
+}
+
+#[cfg(all(windows, not(feature = "csd")))]
+pub fn win32_init_window(window: &gtk::Window, mica: MicaLevel) {
+    use gtk::prelude::*;
+
+    let style_manager = adw::StyleManager::default();
+    win32_set_dark_mode(window, style_manager.is_dark());
+    if win32_supports_mica() {
+        win32_set_mica(window, mica.clone());
+        if !style_manager.is_high_contrast() {
+            window.add_css_class("mica");
+        }
+    }
+
+    style_manager.connect_color_scheme_notify(glib::clone!(
+        #[weak]
+        window,
+        move |scheme: &adw::StyleManager| {
+            let dark = scheme.is_dark();
+            win32_set_dark_mode(&window, dark);
+        }
+    ));
+    style_manager.connect_dark_notify(glib::clone!(
+        #[weak]
+        window,
+        move |scheme: &adw::StyleManager| {
+            let dark = scheme.is_dark();
+            win32_set_dark_mode(&window, dark);
+        }
+    ));
+    style_manager.connect_high_contrast_notify(glib::clone!(
+        #[weak]
+        window,
+        move |scheme: &adw::StyleManager| {
+            let dark = scheme.is_dark();
+            win32_set_dark_mode(&window, dark);
+            if scheme.is_high_contrast() {
+                window.remove_css_class("mica");
+            } else {
+                window.add_css_class("mica");
+            }
+        }
+    ));
+
+    let mica_clone = mica.clone();
+    window.connect_realize(glib::clone!(
+        #[weak]
+        style_manager,
+        move |window| {
+            let dark = style_manager.is_dark();
+            win32_set_mica(&window, mica_clone);
+            win32_set_dark_mode(&window, dark);
+        }
+    ));
 }

--- a/src/win.rs
+++ b/src/win.rs
@@ -692,34 +692,11 @@ mod imp {
                 }
             }
 
-            // Dark title bar on Windows
             #[cfg(all(windows, not(feature = "csd")))]
             {
-                let obj = self.obj();
-                let style_manager = adw::StyleManager::default();
-                style_manager.connect_color_scheme_notify(glib::clone!(
-                    #[weak]
-                    obj,
-                    move |scheme: &adw::StyleManager| {
-                        let dark = scheme.is_dark();
-                        crate::platform::win32_set_dark_mode(&obj, dark);
-                    }
-                ));
-                style_manager.connect_dark_notify(glib::clone!(
-                    #[weak]
-                    obj,
-                    move |scheme: &adw::StyleManager| {
-                        let dark = scheme.is_dark();
-                        crate::platform::win32_set_dark_mode(&obj, dark);
-                    }
-                ));
-                obj.connect_show(glib::clone!(
-                    #[weak]
-                    style_manager,
-                    move |obj: &super::CarteroWindow| {
-                        crate::platform::win32_set_dark_mode(&*obj, style_manager.is_dark());
-                    }
-                ));
+                // Init Fluent style.
+                let gtk_window = self.obj().clone().upcast::<gtk::Window>();
+                crate::platform::win32_init_window(&gtk_window, crate::platform::MicaLevel::Tabbed);
             }
 
             self.init_settings();


### PR DESCRIPTION
This PR will ask the Microsoft Windows compositor to enable a system backdrop when running Cartero on Windows 11. This is known as acrylic mode, Microsoft Fluent 2 or just Mica.

Any Win32 application running on Windows 11 Build 22621 or greater can [request a DwmAttribute](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute) called `DWMWA_SYSTEMBACKDROP_TYPE` to set [one of the four supported Mica values](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type).

The way this seems to work is that the backdrop is handled by the compositor. In other words, the application will paint on top of the backdrop. If the application supports alpha channels (which GTK does) and decides to render the background transparent or partially transparent, it can blend with the backdrop.

And this is what I'm doing right now. If I detect that the system supports Mica, I request the backdrop from the compositor, and add a CSS class called `mica` to the window. The style.css file has new rules that mark some elements such as the top bar or the NavigationSplit sidebar as transparent when the window has the `mica` class. The backdrop will render because the header bar does not have a solid background color:

<img width="897" height="243" alt="imagen" src="https://github.com/user-attachments/assets/d7bbf023-873f-417c-a285-2dc21585f93b" />

For the welcome pane I'm setting a background with alpha channel. Therefore, the backdrop appears lighter:

<img width="897" height="756" alt="imagen" src="https://github.com/user-attachments/assets/1b9f662d-c968-4d78-a175-734d4de297bb" />

Dark mode is supported too, for that matter.

<img width="851" height="697" alt="imagen" src="https://github.com/user-attachments/assets/014ba136-baaf-4d29-90cb-36149b8b11cd" />

Indirectally, this commit also fixes the following two side bugs:

* Cartero was not reacting to the "high contrast mode has changed" event in order to update the dark mode style. There is an edge case where this can cause the application text to become unreadable then the high contrast mode is enabled or disabled, as the Adwaita theme switches to High Contrast (borders everywhere) but the text color is kept white over light or black over dark.

* The new settings page added in #267 did not request the title bar color to switch on Windows.