### PR TITLE
Fix: Bearer token pane entry

### DIFF
--- a/data/ui/bearer_token_pane.blp
+++ b/data/ui/bearer_token_pane.blp
@@ -19,7 +19,7 @@ using Adw 1;
 
 template $CarteroBearerTokenPane: Adw.Bin {
   Adw.PreferencesGroup {
-    Adw.EntryRow token {
+    Adw.PasswordEntryRow token {
       title: _("Token");
       sensitive: true;
     }


### PR DESCRIPTION
It's me again, I did this PR to solve this issue: https://github.com/danirod/cartero/issues/298

I think when you rewrote the old file authorization_pane.blp and the authorization options were split in two files, the entry became a EntryRow instead of a PasswordEntryRow.  (https://github.com/danirod/cartero/commit/8b46e9bbe5cda86de0b42a610cc811f120b24731 on this [diff](https://github.com/danirod/cartero/commit/8b46e9bbe5cda86de0b42a610cc811f120b24731#diff-d50b951663d9aedeff411546a1be4d1030e4408d9dccbf0326845bbcaeb6bd32))

PD: Maybe it could be just an issue but I want to try to do this PR.
PD2: Let me know if you need something else, I know it's a single file, but let know.
PD3: Or maybe it was intentional.

Here are some screenshots (all are in arch but I installed cartero 2.4.0):
<img width="1322" height="882" alt="Screenshot_2025-10-06-22-59-30" src="https://github.com/user-attachments/assets/77770587-60b7-4e06-b86a-2686eab9abd3" />

cartero-git without the change:
<img width="1350" height="943" alt="Screenshot_2025-10-06-23-00-56" src="https://github.com/user-attachments/assets/25fa2f7d-8814-4757-8efa-2f42d1832aab" />

And with the change:
<img width="1285" height="912" alt="Screenshot_2025-10-06-23-01-53" src="https://github.com/user-attachments/assets/74ec093c-82d7-4e59-8d1b-98862bf5e379" />

