### PR TITLE
Show the response URL in the response pane

### DIFF
--- a/crates/cartero-isahc-client/src/lib.rs
+++ b/crates/cartero-isahc-client/src/lib.rs
@@ -25,7 +25,7 @@ use cartero_objects::{Field, FieldTable, Request, RequestMethod, Response};
 use isahc::{
     config::{Configurable, RedirectPolicy, SslOption},
     http::{HeaderName, HeaderValue, Uri},
-    AsyncBody, RequestExt,
+    AsyncBody, RequestExt, ResponseExt,
 };
 
 pub fn default_user_agent() -> String {
@@ -85,6 +85,12 @@ async fn build_response(
     let duration = start.elapsed();
 
     let response = Response::builder(request)
+        .effective_url(
+            isahc_request
+                .effective_uri()
+                .map(|uri| uri.to_string())
+                .unwrap_or_default(),
+        )
         .status_code(status_code as u32)
         .headers(&headers)
         .size(body.len() as u64)

--- a/crates/cartero-objects/src/response.rs
+++ b/crates/cartero-objects/src/response.rs
@@ -157,6 +157,8 @@ mod imp {
         #[property(get, set)]
         request: RefCell<Request>,
         #[property(get, set)]
+        effective_url: RefCell<String>,
+        #[property(get, set)]
         status_code: RefCell<u32>,
         #[property(get, set)]
         duration: RefCell<u64>,
@@ -196,6 +198,11 @@ mod builder {
 
         pub fn build(self) -> Response {
             self.builder.build()
+        }
+
+        pub fn effective_url(mut self, url: String) -> Self {
+            self.builder = self.builder.property("effective-url", url);
+            self
         }
 
         pub fn status_code(mut self, code: u32) -> Self {

--- a/data/ui/response_panel.blp
+++ b/data/ui/response_panel.blp
@@ -41,174 +41,176 @@ template $CarteroResponsePanel: Adw.Bin {
     StackPage {
       name: "response";
 
-      child: Box {
-        hexpand: true;
-        vexpand: true;
-        orientation: vertical;
-
+      child: Adw.ToastOverlay toaster {
         Box {
-          orientation: horizontal;
           hexpand: true;
-          spacing: 6;
-          margin-top: 4;
-          margin-start: 12;
-          margin-end: 12;
-          margin-bottom: 4;
+          vexpand: true;
+          orientation: vertical;
 
           Box {
-            spacing: 8;
             orientation: horizontal;
-            halign: start;
             hexpand: true;
+            spacing: 6;
+            margin-top: 4;
+            margin-start: 12;
+            margin-end: 12;
+            margin-bottom: 4;
 
-            Entry response_url {
-              styles [
-                "flat",
-              ]
-
-              halign: fill;
-              max-width-chars: 30;
-              editable: false;
-            }
-
-            Button {
-              styles [
-                "circular",
-              ]
-
-              action-name: "response.copy-response-url";
-              icon-name: "edit-copy-symbolic";
-              tooltip-text: _("Copy to clipboard");
-            }
-          }
-
-          Box response_meta {
-            spacing: 8;
-            hexpand: false;
-            valign: center;
-            halign: end;
-
-            Label status_code {
-              visible: false;
-            }
-
-            Label duration {
-              visible: false;
-            }
-
-            Label response_size {
-              visible: false;
-            }
-          }
-        }
-
-        Separator {}
-
-        Notebook {
-          show-border: false;
-          scrollable: true;
-
-          NotebookPage {
-            tab: Label {
-              label: _("Body");
-            };
-
-            child: Gtk.Overlay {
-              Gtk.Stack response_body_stack {
-                Gtk.StackPage {
-                  name: 'text';
-
-                  child: ScrolledWindow {
-                    hexpand: true;
-                    vexpand: true;
-
-                    $CarteroCodeView response_body {
-                      tooltip-text: _("Response body");
-                      top-margin: 10;
-                      bottom-margin: 10;
-                      left-margin: 10;
-                      right-margin: 10;
-                      smart-backspace: true;
-                      monospace: true;
-                      editable: false;
-                      buffer: buffer;
-                      search-requested => $on_search_requested() swapped;
-                    }
-                  };
-                }
-
-                Gtk.StackPage {
-                  name: 'binary';
-
-                  child: Adw.StatusPage {
-                    icon-name: "encode-symbolic";
-                    title: _("Binary response received");
-                    description: _("The response of this request should not be rendered in a text view.");
-
-                    Gtk.Box {
-                      orientation: vertical;
-                      spacing: 12;
-                      hexpand: false;
-                      halign: center;
-
-                      Gtk.Button {
-                        styles [
-                          "suggested-action",
-                        ]
-
-                        hexpand: false;
-                        halign: center;
-                        label: _("Export to file");
-                        action-name: "win.export-response-body";
-                      }
-
-                      Gtk.Button {
-                        hexpand: false;
-                        halign: center;
-                        label: _("Render anyway");
-                        action-name: "response.force-binary-render";
-                      }
-                    }
-                  };
-                }
-              }
-
-              [overlay]
-              Gtk.Revealer search_revealer {
-                visible: false;
-                reveal-child: false;
-                halign: end;
-                valign: start;
-                hexpand: false;
-                vexpand: false;
-
-                $CarteroSearchBox search {
-                  editable: response_body;
-                  close => $on_search_close() swapped;
-                }
-              }
-            };
-          }
-
-          NotebookPage {
-            tab: Label {
-              label: _("Headers");
-            };
-
-            child: ScrolledWindow {
+            Box {
+              spacing: 8;
+              orientation: horizontal;
+              halign: start;
               hexpand: true;
-              vexpand: true;
 
-              Adw.Clamp {
+              Entry response_url {
                 styles [
-                  "background",
+                  "flat",
                 ]
 
-                maximum-size: 720;
-
-                $CarteroResponseHeaders response_headers {}
+                halign: fill;
+                max-width-chars: 30;
+                editable: false;
               }
-            };
+
+              Button {
+                styles [
+                  "circular",
+                ]
+
+                action-name: "response.copy-response-url";
+                icon-name: "edit-copy-symbolic";
+                tooltip-text: _("Copy to clipboard");
+              }
+            }
+
+            Box response_meta {
+              spacing: 8;
+              hexpand: false;
+              valign: center;
+              halign: end;
+
+              Label status_code {
+                visible: false;
+              }
+
+              Label duration {
+                visible: false;
+              }
+
+              Label response_size {
+                visible: false;
+              }
+            }
+          }
+
+          Separator {}
+
+          Notebook {
+            show-border: false;
+            scrollable: true;
+
+            NotebookPage {
+              tab: Label {
+                label: _("Body");
+              };
+
+              child: Gtk.Overlay {
+                Gtk.Stack response_body_stack {
+                  Gtk.StackPage {
+                    name: 'text';
+
+                    child: ScrolledWindow {
+                      hexpand: true;
+                      vexpand: true;
+
+                      $CarteroCodeView response_body {
+                        tooltip-text: _("Response body");
+                        top-margin: 10;
+                        bottom-margin: 10;
+                        left-margin: 10;
+                        right-margin: 10;
+                        smart-backspace: true;
+                        monospace: true;
+                        editable: false;
+                        buffer: buffer;
+                        search-requested => $on_search_requested() swapped;
+                      }
+                    };
+                  }
+
+                  Gtk.StackPage {
+                    name: 'binary';
+
+                    child: Adw.StatusPage {
+                      icon-name: "encode-symbolic";
+                      title: _("Binary response received");
+                      description: _("The response of this request should not be rendered in a text view.");
+
+                      Gtk.Box {
+                        orientation: vertical;
+                        spacing: 12;
+                        hexpand: false;
+                        halign: center;
+
+                        Gtk.Button {
+                          styles [
+                            "suggested-action",
+                          ]
+
+                          hexpand: false;
+                          halign: center;
+                          label: _("Export to file");
+                          action-name: "win.export-response-body";
+                        }
+
+                        Gtk.Button {
+                          hexpand: false;
+                          halign: center;
+                          label: _("Render anyway");
+                          action-name: "response.force-binary-render";
+                        }
+                      }
+                    };
+                  }
+                }
+
+                [overlay]
+                Gtk.Revealer search_revealer {
+                  visible: false;
+                  reveal-child: false;
+                  halign: end;
+                  valign: start;
+                  hexpand: false;
+                  vexpand: false;
+
+                  $CarteroSearchBox search {
+                    editable: response_body;
+                    close => $on_search_close() swapped;
+                  }
+                }
+              };
+            }
+
+            NotebookPage {
+              tab: Label {
+                label: _("Headers");
+              };
+
+              child: ScrolledWindow {
+                hexpand: true;
+                vexpand: true;
+
+                Adw.Clamp {
+                  styles [
+                    "background",
+                  ]
+
+                  maximum-size: 720;
+
+                  $CarteroResponseHeaders response_headers {}
+                }
+              };
+            }
           }
         }
       };

--- a/data/ui/response_panel.blp
+++ b/data/ui/response_panel.blp
@@ -41,11 +41,69 @@ template $CarteroResponsePanel: Adw.Bin {
     StackPage {
       name: "response";
 
-      child: Overlay {
+      child: Box {
         hexpand: true;
         vexpand: true;
+        orientation: vertical;
 
-        [overlay]
+        Box {
+          orientation: horizontal;
+          hexpand: true;
+          spacing: 6;
+          margin-top: 4;
+          margin-start: 12;
+          margin-end: 12;
+          margin-bottom: 4;
+
+          Box {
+            spacing: 8;
+            orientation: horizontal;
+            halign: start;
+            hexpand: true;
+
+            Entry response_url {
+              styles [
+                "flat",
+              ]
+
+              halign: fill;
+              max-width-chars: 30;
+              editable: false;
+            }
+
+            Button {
+              styles [
+                "circular",
+              ]
+
+              action-name: "response.copy-response-url";
+              icon-name: "edit-copy-symbolic";
+              tooltip-text: _("Copy to clipboard");
+            }
+          }
+
+          Box response_meta {
+            spacing: 8;
+            hexpand: false;
+            valign: center;
+            halign: end;
+
+            Label status_code {
+              visible: false;
+            }
+
+            Label duration {
+              visible: false;
+            }
+
+            Label response_size {
+              visible: false;
+            }
+          }
+        }
+
+        Separator {}
+
         Notebook {
           show-border: false;
           scrollable: true;
@@ -153,38 +211,21 @@ template $CarteroResponsePanel: Adw.Bin {
             };
           }
         }
-
-        [overlay]
-        Stack metadata_stack {
-          halign: end;
-          valign: start;
-          margin-top: 10;
-          margin-end: 10;
-
-          Box response_meta {
-            spacing: 10;
-
-            Label status_code {
-              visible: false;
-            }
-
-            Label duration {
-              visible: false;
-            }
-
-            Label response_size {
-              visible: false;
-            }
-          }
-
-          Spinner spinner {
-            halign: end;
-            spinning: true;
-          }
-        }
       };
     }
   }
 }
 
 GtkSource.Buffer buffer {}
+
+Stack metadata_stack {
+  halign: end;
+  valign: start;
+  margin-top: 10;
+  margin-end: 10;
+
+  Spinner spinner {
+    halign: end;
+    spinning: true;
+  }
+}

--- a/src/widgets/endpoint/response_panel.rs
+++ b/src/widgets/endpoint/response_panel.rs
@@ -40,9 +40,11 @@ mod imp {
     use adw::subclass::bin::BinImpl;
     use cartero_http::RequestError;
     use cartero_objects::Response;
+    use gettextrs::gettext;
     use glib::object::Cast;
     use glib::subclass::InitializingObject;
     use glib::Properties;
+    use gtk::gdk::{ContentProvider, Display};
     use gtk::gio::{SimpleAction, SimpleActionGroup};
     use gtk::subclass::prelude::*;
     use gtk::{
@@ -79,6 +81,8 @@ mod imp {
         pub metadata_stack: TemplateChild<Stack>,
         #[template_child]
         buffer: TemplateChild<sourceview5::Buffer>,
+        #[template_child]
+        pub response_url: TemplateChild<gtk::Entry>,
         #[template_child]
         search: TemplateChild<SearchBox>,
         #[template_child]
@@ -133,8 +137,33 @@ mod imp {
                 }
             ));
 
+            let action_copy_response_url = SimpleAction::new("copy-response-url", None);
+            action_copy_response_url.connect_activate(glib::clone!(
+                #[weak(rename_to = imp)]
+                self,
+                move |_, _| {
+                    let content = {
+                        let blob = imp
+                            .obj()
+                            .response()
+                            .map(|response| response.effective_url())
+                            .unwrap_or_default();
+                        let blob = glib::Bytes::from(blob.as_bytes());
+                        ContentProvider::new_union(&[
+                            ContentProvider::for_bytes("text/plain", &blob),
+                            ContentProvider::for_bytes("text/plain;charset=utf-8", &blob),
+                        ])
+                    };
+                    if let Some(display) = Display::default() {
+                        let clipboard = display.clipboard();
+                        clipboard.set_content(Some(&content)).unwrap();
+                    }
+                }
+            ));
+
             let action_group = SimpleActionGroup::new();
             action_group.add_action(&action_force_binary_render);
+            action_group.add_action(&action_copy_response_url);
             obj.insert_action_group("response", Some(&action_group));
         }
 
@@ -264,6 +293,7 @@ impl ResponsePanel {
         self.set_response(Some(resp.clone()));
 
         let imp = self.imp();
+        imp.response_url.set_text(&resp.effective_url());
 
         let headers = resp.headers().clone();
         imp.response_headers.set_headers(headers);

--- a/src/widgets/endpoint/response_panel.rs
+++ b/src/widgets/endpoint/response_panel.rs
@@ -36,8 +36,8 @@ mod imp {
 
     use crate::widgets::endpoint::ResponseHeaders;
     use crate::widgets::{CodeView, ErrorPane, SearchBox};
-    use adw::prelude::*;
     use adw::subclass::bin::BinImpl;
+    use adw::{prelude::*, ToastOverlay};
     use cartero_http::RequestError;
     use cartero_objects::Response;
     use gettextrs::gettext;
@@ -87,7 +87,8 @@ mod imp {
         search: TemplateChild<SearchBox>,
         #[template_child]
         search_revealer: TemplateChild<Revealer>,
-
+        #[template_child]
+        toaster: TemplateChild<ToastOverlay>,
         #[property(get, set = Self::set_response, nullable)]
         response: RefCell<Option<Response>>,
         #[property(get = Self::spinning, set = Self::set_spinning)]
@@ -157,6 +158,10 @@ mod imp {
                     if let Some(display) = Display::default() {
                         let clipboard = display.clipboard();
                         clipboard.set_content(Some(&content)).unwrap();
+
+                        let msg = gettext("Content copied to the clipboard");
+                        let toast = adw::Toast::new(&msg);
+                        imp.toaster.add_toast(toast);
                     }
                 }
             ));


### PR DESCRIPTION
Displays the response URL in the response tab. Has a button to copy the URL to the clipboard.

The reason, as described in #276, is to make it easier to see the response URL when there are variables in the original URL, since all those {{curly}}/{{braces}}` makes copying the final URL more difficult.

Also, when redirects are followed, the response URL is the effective one from the final destination page. So if you request an http:// or a non-www endpoint and you get redirected to the https:// or with-www version, you will see the real one.

<img width="1193" height="679" alt="image" src="https://github.com/user-attachments/assets/e296b880-8f8a-4701-a8be-115acd8b87cc" />