### PR TITLE
Conceal and reveal .env variables

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@ These are the user-visible changes that you will notice when you use Cartero.
 
 ### Changed
 
+* It is now possible to reveal the values of .env variables in the endpoint pane.
 * Translation updates: Simplified Chinese.
 
 ## [25.0] - 2025-11-14

--- a/data/ui/endpoint_pane.blp
+++ b/data/ui/endpoint_pane.blp
@@ -255,7 +255,9 @@ template $CarteroEndpointPane: $CarteroBasePane {
                 Gtk.StackPage {
                   name: "toggle";
 
-                  child: $CarteroCollapsedFieldTable env_variables {};
+                  child: $CarteroCollapsedFieldTable env_variables {
+                    masked: true;
+                  };
                 }
               }
 

--- a/data/ui/field_list_box_static_row.blp
+++ b/data/ui/field_list_box_static_row.blp
@@ -46,10 +46,13 @@ template $CarteroFieldListBoxStaticRow: Gtk.Box {
       tooltip-text: _("Value");
     }
 
-    Gtk.MenuButton {
-      // This exists just to make some padding
-      opacity: 0.0;
-      sensitive: false;
+    Gtk.Button conceal {
+      styles [
+        "circular",
+        "flat",
+      ]
+
+      clicked => $on_conceal_toggle() swapped;
     }
   }
 }

--- a/src/widgets/endpoint/endpoint_pane.rs
+++ b/src/widgets/endpoint/endpoint_pane.rs
@@ -279,7 +279,7 @@ mod imp {
                 .obj()
                 .env_file()
                 .iter::<Field>()
-                .filter_map(|item| item.ok().map(|field| (field.key(), "*".repeat(4))))
+                .filter_map(|item| item.ok().map(|field| (field.key(), field.value())))
                 .collect::<Vec<(String, String)>>();
             let toggle_prompt = formatx!(
                 ngettext(

--- a/src/widgets/field/collapsed_field_table.rs
+++ b/src/widgets/field/collapsed_field_table.rs
@@ -114,6 +114,14 @@ mod imp {
                 if let Ok(field) = field {
                     let row: FieldListBoxStaticRow =
                         glib::Object::builder().property("field", field).build();
+                    self.obj()
+                        .bind_property("masked", &row, "allow-concealing")
+                        .sync_create()
+                        .build();
+                    self.obj()
+                        .bind_property("masked", &row, "concealed")
+                        .sync_create()
+                        .build();
                     let widget = row.upcast();
                     self.expander.add_row(&widget);
                     nodes.push(widget);

--- a/src/widgets/field/field_list_box_static_row.rs
+++ b/src/widgets/field/field_list_box_static_row.rs
@@ -23,6 +23,7 @@ mod imp {
 
     use super::*;
     use cartero_objects::Field;
+    use gettextrs::gettext;
     use glib::{subclass::InitializingObject, BindingGroup, Properties};
     use gtk::CompositeTemplate;
 
@@ -32,6 +33,10 @@ mod imp {
     pub struct FieldListBoxStaticRow {
         #[property(get, set)]
         field: RefCell<Field>,
+        #[property(get, set)]
+        allow_concealing: RefCell<bool>,
+        #[property(get, set)]
+        concealed: RefCell<bool>,
 
         #[template_child]
         key: TemplateChild<gtk::Entry>,
@@ -39,6 +44,8 @@ mod imp {
         value: TemplateChild<gtk::Entry>,
         #[template_child]
         checked: TemplateChild<gtk::CheckButton>,
+        #[template_child]
+        conceal: TemplateChild<gtk::Button>,
 
         binding_group: OnceCell<glib::BindingGroup>,
     }
@@ -51,6 +58,7 @@ mod imp {
 
         fn class_init(klass: &mut Self::Class) {
             klass.bind_template();
+            klass.bind_template_callbacks();
         }
 
         fn instance_init(obj: &InitializingObject<Self>) {
@@ -63,6 +71,7 @@ mod imp {
         fn constructed(&self) {
             self.parent_constructed();
             self.init_binding_group();
+            self.init_concealing();
         }
     }
 
@@ -70,6 +79,7 @@ mod imp {
 
     impl BoxImpl for FieldListBoxStaticRow {}
 
+    #[gtk::template_callbacks]
     impl FieldListBoxStaticRow {
         fn init_binding_group(&self) {
             let binding_group = BindingGroup::new();
@@ -85,11 +95,6 @@ mod imp {
                 .bind("active", &*self.checked, "active")
                 .sync_create()
                 .build();
-            binding_group
-                .bind("masked", &*self.value, "visibility")
-                .sync_create()
-                .invert_boolean()
-                .build();
             binding_group.set_source(Some(&self.obj().field()));
             self.obj().connect_field_notify(glib::clone!(
                 #[weak]
@@ -101,6 +106,63 @@ mod imp {
             self.binding_group
                 .set(binding_group)
                 .expect("Couldn't initialise BindingGroup here");
+        }
+
+        fn init_concealing(&self) {
+            self.obj()
+                .bind_property("allow-concealing", &*self.conceal, "sensitive")
+                .sync_create()
+                .build();
+            self.obj()
+                .bind_property("allow-concealing", &*self.conceal, "opacity")
+                .transform_to(|_, value: &glib::Value| {
+                    let allows_conceal = value
+                        .get::<bool>()
+                        .expect("allow-concealing is of invalid type");
+                    if allows_conceal {
+                        Some(1.0)
+                    } else {
+                        Some(0.0)
+                    }
+                })
+                .sync_create()
+                .build();
+
+            self.obj()
+                .bind_property("concealed", &*self.value, "visibility")
+                .sync_create()
+                .invert_boolean()
+                .build();
+            self.obj()
+                .bind_property("concealed", &*self.conceal, "icon-name")
+                .transform_to(|_, value: &glib::Value| {
+                    let concealed = value.get::<bool>().expect("concealed is of invalid type");
+                    if concealed {
+                        Some("view-reveal")
+                    } else {
+                        Some("view-conceal")
+                    }
+                })
+                .sync_create()
+                .build();
+            self.obj()
+                .bind_property("concealed", &*self.conceal, "tooltip-text")
+                .transform_to(|_, value: &glib::Value| {
+                    let concealed = value.get::<bool>().expect("concealed is of invalid type");
+                    if concealed {
+                        Some(gettext("Show value"))
+                    } else {
+                        Some(gettext("Hide value"))
+                    }
+                })
+                .sync_create()
+                .build();
+        }
+
+        #[template_callback]
+        fn on_conceal_toggle(&self) {
+            let next_conceal = !self.obj().concealed();
+            self.obj().set_concealed(next_conceal);
         }
     }
 }


### PR DESCRIPTION
With this change, the dotenv table will add buttons to reveal the values of the loaded variables. Pressing the button will reveal or conceal per variable. By default the value will be concealed but the purpose of this change is to make it easier to view the value of the variable.

<img width="597" height="250" alt="image" src="https://github.com/user-attachments/assets/9fe5d7f0-c2fd-4c90-853a-2e2eb4e1eee9" />
