### PR TITLE
Bump macOS runner version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,7 +134,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runs-on: macos-13
+          - runs-on: macos-14
             name: x64
           - runs-on: macos-15
             name: arm64


### PR DESCRIPTION
Quick fix, GitHub Actions does not carry macos-13 anymore.