### PR TITLE
vendor and .cargo/config dont exist in mode build for snap

### DIFF
--- a/packaging/snap/latest/stable/snapcraft.yaml
+++ b/packaging/snap/latest/stable/snapcraft.yaml
@@ -50,6 +50,8 @@ parts:
     parse-info: [usr/share/metainfo/es.danirod.Cartero.metainfo.xml]
     override-pull: |
       snapcraftctl pull
+      cp -rv ${CRAFT_PART_SRC}/vendor ${CRAFT_PART_BUILD}/vendor
+      cp -rv ${CRAFT_PART_SRC}/.cargo ${CRAFT_PART_BUILD}/.cargo
       sed -i.bak -e 's|Icon=@app_id@|Icon=/usr/share/icons/hicolor/scalable/apps/es.danirod.Cartero.svg|' data/cartero.desktop.in.in
 
 slots:


### PR DESCRIPTION
Snap en la etapa de contruccion no existen .cargo/config y la carpeta vendor igual
tienes que decirle que se copie

<img width="853" height="837" alt="Screenshot From 2025-12-26 10-51-38" src="https://github.com/user-attachments/assets/89ec5ee4-c3aa-416d-9a58-72cd675bd7fd" />

Con la modificacion snapcraft en su modo de compilacion ya encuentra .cargo/config y la carpeta vendor y ya no baja los crates solo los compila.

**Ready**

<img width="853" height="837" alt="Screenshot From 2025-12-26 11-02-22" src="https://github.com/user-attachments/assets/c231bdaa-befd-447b-a35b-65907e83abac" />

