### PR TITLE
Compile for macOS using jhbuild

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -134,21 +134,34 @@ jobs:
     strategy:
       matrix:
         platform:
-          - runs-on: macos-14
+          - runs-on: macos-15-intel
             name: x64
-          - runs-on: macos-15
+          - runs-on: macos-26
             name: arm64
       fail-fast: false
     name: "macOS ${{ matrix.platform.name }}"
     runs-on: ${{ matrix.platform.runs-on }}
     steps:
     - uses: actions/checkout@v4
+    - name: Fetch jhbuild
+      id: cache-jhbuild
+      uses: actions/cache/restore@v4
+      with:
+        path: /Users/Shared/work
+        key: jhb-${{ matrix.platform.name }}
+    - name: Compile jhbuild
+      if: ${{ steps.cache-jhbuild.outputs.cache-hit != 'true' }}
+      run: packaging/macos/jhbuild/main.sh
+    - name: Cache jhbuild
+      if: ${{ steps.cache-jhbuild.outputs.cache-hit != 'true' }}
+      uses: actions/cache/save@v4
+      with:
+        path: /Users/Shared/work
+        key: jhb-${{ matrix.platform.name }}
     - name: Install dependencies
-      run: brew install meson gtk4 gtksourceview5 desktop-file-utils pygobject3 libadwaita adwaita-icon-theme shared-mime-info create-dmg
-    - name: Fix PYTHONPATH for blueprint-compiler
-      run: echo "PYTHONPATH=$(brew --prefix)/lib/python3.13/site-packages:$PYTHONPATH" >> $GITHUB_ENV
+      run: brew install create-dmg
     - name: Fix GETTEXT_DIR for macOS
-      run: echo "GETTEXT_DIR=$(brew --prefix)/opt/gettext" >> $GITHUB_ENV
+      run: echo "GETTEXT_DIR=/Users/Shared/work/jhb-1.3+meson184" >> $GITHUB_ENV
     - name: Generate version code
       id: version-code
       run: |
@@ -157,6 +170,7 @@ jobs:
         echo "full-version=$(build-aux/gen-version.py --nightly)-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
     - name: Build macOS version
       run: |
+        export PATH=/Users/Shared/work/jhb-1.3+meson184:${PATH}
         meson setup -Dprofile=development -Dmacos-app=enabled --prefix=/ build
         DESTDIR=$PWD/output ninja -C build install
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,7 +148,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: /Users/Shared/work
-        key: jhb-${{ matrix.platform.name }}
+        key: jhb-${{ matrix.platform.name }}-49.3
     - name: Compile jhbuild
       if: ${{ steps.cache-jhbuild.outputs.cache-hit != 'true' }}
       run: packaging/macos/jhbuild/main.sh
@@ -157,7 +157,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: /Users/Shared/work
-        key: jhb-${{ matrix.platform.name }}
+        key: jhb-${{ matrix.platform.name }}-49.3
     - name: Install dependencies
       run: brew install create-dmg
     - name: Fix GETTEXT_DIR for macOS

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -170,7 +170,7 @@ jobs:
         echo "full-version=$(build-aux/gen-version.py --nightly)-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
     - name: Build macOS version
       run: |
-        export PATH=/Users/Shared/work/jhb-1.3+meson184:${PATH}
+        export PATH=/Users/Shared/work/jhb-1.3+meson184/bin:${PATH}
         meson setup -Dprofile=development -Dmacos-app=enabled --prefix=/ build
         DESTDIR=$PWD/output ninja -C build install
     - uses: actions/upload-artifact@v4

--- a/NEWS.d/26.0/fixed
+++ b/NEWS.d/26.0/fixed
@@ -1,1 +1,2 @@
 Responses were being treated as binary if they contained the CR (\r) character.
+MacOS: the main application window could sometimes stop receiving mouse clicks on macOS 26.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -69,6 +69,15 @@ SPDX-FileCopyrightText = "Copyright Canonical"
 SPDX-FileComment = "Taken from https://commons.wikimedia.org/wiki/File:Snapcraft-logo-bird.svg"
 
 [[annotations]]
+path = [
+    "packaging/macos/jhbuild/modulesets/*",
+    "packaging/macos/jhbuild/modulesets/patches/*",
+]
+SPDX-License-Identifier = "GPL-3.0-or-later"
+SPDX-FileCopyrightText = "NONE" # TODO: these are derived, find out who I have to credit
+SPDX-FileComment = "Derived from https://gitlab.gnome.org/GNOME/gtk-osx"
+
+[[annotations]]
 path = "website/src/assets/vendor-icons/windows.svg"
 SPDX-License-Identifier = "CC0-1.0"
 SPDX-FileCopyrightText = "NONE"

--- a/packaging/macos/jhbuild/main.sh
+++ b/packaging/macos/jhbuild/main.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+if ! [ -d jhb ]; then
+    git clone https://gitlab.com/dehesselle/jhb
+fi
+
+# NOTE: Remove this once jhb receives meson >= 1.8.4
+export VERSION=1.3+meson184
+sed -i '' 's|https://gitlab.com/api/v4/projects/35965804/packages/generic/jhb/|https://github.com/danirod/runner-jhb/releases/download/|' jhb/etc/jhb.conf.d/release.sh
+
+# Force compatibility with macOS 11.
+MACOSX_DEPLOYMENT_TARGET=11.0
+
+source jhb/etc/jhb.conf.sh
+
+# Compile SDK
+rm -rf $VER_DIR
+jhb/usr/bin/bootstrap
+jhb/usr/bin/jhb configure modulesets/gnome-sdk.modules
+jhb/usr/bin/jhb build gnome-sdk
+
+function relocate {
+	file="$1"
+	for rpath in $(otool -L "$file" | grep '@rpath/' | awk '{ print $1 }'); do
+		new_path=${rpath/@rpath/$VER_DIR/lib}
+		install_name_tool -change "$rpath" "$new_path" "$file"
+	done
+}
+
+# Relocate some dependencies
+for file in $(cat $VER_DIR/var/jhbuild/manifests/* | sort -h); do
+	ftype=$(file "$VER_DIR/$file")
+	if [[ $ftype == *"Mach-O 64-bit executable"* ]]; then
+		echo Relocating $VER_DIR/$file as exe
+		relocate "$VER_DIR/$file"
+	elif [[ $ftype == *"Mach-O 64-bit dynamically linked shared library"* ]]; then
+		echo Relocating $VER_DIR/$file as lib
+		install_name_tool -id "$(greadlink -f "$VER_DIR/$file")" "$VER_DIR/$file"
+		relocate "$VER_DIR/$file"
+	elif [[ $ftype == *"Mach-O 64-bit bundle"* ]]; then
+		echo Relocating $VER_DIR/$file as bundle
+		relocate "$VER_DIR/$file"
+	fi
+done
+
+# GTK post install
+echo "Recompiling system schemas..."
+$VER_DIR/bin/glib-compile-schemas $VER_DIR/share/glib-2.0/schemas/
+
+echo "Reloading icon caches..."
+for theme in $VER_DIR/share/icons/*; do
+    $VER_DIR/bin/gtk4-update-icon-cache $theme
+done
+
+echo "Reloading pixbuf caches..."
+GDK_PIXBUF_MODULEDIR=$VER_DIR/lib/gdk-pixbuf-2.0/2.10.0/loaders/ $VER_DIR/bin/gdk-pixbuf-query-loaders > $VER_DIR/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache
+
+# Finalize system
+jhb/usr/bin/archive remove_nonessentials

--- a/packaging/macos/jhbuild/main.sh
+++ b/packaging/macos/jhbuild/main.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Copyright 2024-2026 the Cartero authors
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 set -e
 

--- a/packaging/macos/jhbuild/modulesets/desktop-file-utils.modules
+++ b/packaging/macos/jhbuild/modulesets/desktop-file-utils.modules
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+  <repository name="freedesktop"
+              href="https://www.freedesktop.org/software/"
+              type="tarball" />
+
+<meson id="desktop-file-utils">
+    <branch module="desktop-file-utils/releases/desktop-file-utils-0.26.tar.xz"
+            version="0.26"
+            hash="sha256:b26dbde79ea72c8c84fb7f9d870ffd857381d049a86d25e0038c4cef4c747309"
+            repo="freedesktop" />
+    <dependencies>
+      <dep package="glib" />
+    </dependencies>
+  </meson>
+</moduleset>

--- a/packaging/macos/jhbuild/modulesets/desktop-file-utils.modules
+++ b/packaging/macos/jhbuild/modulesets/desktop-file-utils.modules
@@ -7,9 +7,9 @@
               type="tarball" />
 
 <meson id="desktop-file-utils">
-    <branch module="desktop-file-utils/releases/desktop-file-utils-0.26.tar.xz"
-            version="0.26"
-            hash="sha256:b26dbde79ea72c8c84fb7f9d870ffd857381d049a86d25e0038c4cef4c747309"
+    <branch module="desktop-file-utils/releases/desktop-file-utils-0.28.tar.xz"
+            version="0.28"
+            hash="sha256:4401d4e231d842c2de8242395a74a395ca468cd96f5f610d822df33594898a70"
             repo="freedesktop" />
     <dependencies>
       <dep package="glib" />

--- a/packaging/macos/jhbuild/modulesets/gnome-sdk.modules
+++ b/packaging/macos/jhbuild/modulesets/gnome-sdk.modules
@@ -11,10 +11,10 @@
 
   <metamodule id="gnome-sdk">
     <dependencies>
+      <dep package="gtk-4" />
       <dep package="adwaita-icon-theme" />
       <dep package="hicolor-icon-theme" />
       <dep package="libadwaita" />
-      <dep package="gtk-4" />
       <dep package="gtksourceview-5" />
       <dep package="rust" />
       <dep package="pygobject3" />

--- a/packaging/macos/jhbuild/modulesets/gnome-sdk.modules
+++ b/packaging/macos/jhbuild/modulesets/gnome-sdk.modules
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+  <include href="gtk-osx.modules" />
+  <include href="gtk-osx-python.modules" />
+  <include href="rust.modules" />
+  <include href="libadwaita.modules" />
+  <include href="gtksourceview5.modules" />
+  <include href="desktop-file-utils.modules" />
+
+  <metamodule id="gnome-sdk">
+    <dependencies>
+      <dep package="adwaita-icon-theme" />
+      <dep package="hicolor-icon-theme" />
+      <dep package="libadwaita" />
+      <dep package="gtk-4" />
+      <dep package="gtksourceview-5" />
+      <dep package="rust" />
+      <dep package="pygobject3" />
+      <dep package="desktop-file-utils" />
+      <dep package="shared-mime-info" />
+    </dependencies>
+  </metamodule>
+</moduleset>

--- a/packaging/macos/jhbuild/modulesets/gtk-osx-python.modules
+++ b/packaging/macos/jhbuild/modulesets/gtk-osx-python.modules
@@ -27,9 +27,9 @@
     </dependencies>
   </pip>
   <meson id="pycairo">
-    <branch module="pygobject/pycairo/releases/download/v1.27.0/pycairo-1.27.0.tar.gz"
-            version="1.27.0"
-            hash="sha256:5cb21e7a00a2afcafea7f14390235be33497a2cce53a98a19389492a60628430"
+    <branch module="pygobject/pycairo/releases/download/v1.29.0/pycairo-1.29.0.tar.gz"
+            version="1.29.0"
+            hash="sha256:f3f7fde97325cae80224c09f12564ef58d0d0f655da0e3b040f5807bd5bd3142"
             repo="github-tarball" />
     <dependencies>
       <dep package="cairo" />
@@ -38,9 +38,9 @@
     </dependencies>
   </meson>
   <meson id="pygobject3">
-    <branch module="pygobject/3.51/pygobject-3.51.0.tar.xz"
-            version="3.51.0"
-            hash="sha256:5d8ec64b034a29a14c3739541436a07ea0de83c8a394c6e5ecaa9e2e5b7b4e72" />
+    <branch module="pygobject/3.54/pygobject-3.54.5.tar.gz"
+            version="3.54.5"
+            hash="sha256:b6656f6348f5245606cf15ea48c384c7f05156c75ead206c1b246c80a22fb585" />
     <dependencies>
       <dep package="pycairo" />
     </dependencies>

--- a/packaging/macos/jhbuild/modulesets/gtk-osx-python.modules
+++ b/packaging/macos/jhbuild/modulesets/gtk-osx-python.modules
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+  <!-- Please format this file using the following command:
+       tidy -config ../tidy.conf -m gtk-osx-python.modules; sed -i "" '/^ *$/d' gtk-osx-python.modules
+       You can get 'tidy' here: https://github.com/htacg/tidy-html5 -->
+  <repository name="download.gnome.org"
+              default="yes"
+              href="https://download.gnome.org/sources/"
+              type="tarball" />
+  <repository name="pymodules"
+              href="https://files.pythonhosted.org/packages/"
+              type="tarball" />
+  <repository name="github-tarball"
+              href="https://github.com"
+              type="tarball" />
+  <include href="../jhb/gtk-osx-python.modules" />
+  <!---->
+  <pip id="packaging">
+    <branch module="df/9e/d1a7217f69310c1db8fdf8ab396229f55a699ce34a203691794c5d1cad0c/packaging-21.3.tar.gz"
+            version="21.3"
+            hash="sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"
+            repo="pymodules" />
+    <dependencies>
+      <dep package="python3" />
+    </dependencies>
+  </pip>
+  <meson id="pycairo">
+    <branch module="pygobject/pycairo/releases/download/v1.27.0/pycairo-1.27.0.tar.gz"
+            version="1.27.0"
+            hash="sha256:5cb21e7a00a2afcafea7f14390235be33497a2cce53a98a19389492a60628430"
+            repo="github-tarball" />
+    <dependencies>
+      <dep package="cairo" />
+      <dep package="python3" />
+      <dep package="meta-gtk-osx-gtk3" />
+    </dependencies>
+  </meson>
+  <meson id="pygobject3">
+    <branch module="pygobject/3.51/pygobject-3.51.0.tar.xz"
+            version="3.51.0"
+            hash="sha256:5d8ec64b034a29a14c3739541436a07ea0de83c8a394c6e5ecaa9e2e5b7b4e72" />
+    <dependencies>
+      <dep package="pycairo" />
+    </dependencies>
+    <after>
+      <dep package="python3" />
+    </after>
+  </meson>
+</moduleset>

--- a/packaging/macos/jhbuild/modulesets/gtk-osx-random.modules
+++ b/packaging/macos/jhbuild/modulesets/gtk-osx-random.modules
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+  <!-- Please format this file using the following command:
+       tidy -config ../tidy.conf -m gtk-osx-random.modules; sed -i "" '/^ *$/d' gtk-osx-random.modules
+       You can get 'tidy' here: https://github.com/htacg/tidy-html5 -->
+  <repository name="download.gnome.org"
+              default="yes"
+              href="https://download.gnome.org/sources/"
+              type="tarball" />
+  <repository name="shared-mime-info"
+              href="https://gitlab.freedesktop.org/xdg/shared-mime-info/-/archive/"
+              type="tarball" />
+  <repository name="itstool"
+              href="http://files.itstool.org/"
+              type="tarball" />
+  <!---->
+  <include href="../jhb/gtk-osx-random.modules" />
+  <!---->
+  <autotools id="itstool"
+             autogen-sh="configure">
+    <branch module="itstool/itstool-2.0.7.tar.bz2"
+            version="2.0.7"
+            hash="sha256:6b9a7cd29a12bb95598f5750e8763cee78836a1a207f85b74d8b3275b27e87ca"
+            repo="itstool" />
+    <dependencies>
+      <dep package="libxml2" />
+    </dependencies>
+  </autotools>
+  <meson id="shared-mime-info">
+    <branch module="2.4/shared-mime-info-2.4.tar.bz2"
+            version="2.4"
+            hash="sha256:32dc32ae39ff1c1bf8434dd3b36770b48538a1772bc0298509d034f057005992"
+            repo="shared-mime-info" />
+    <dependencies>
+      <dep package="glib" />
+    </dependencies>
+  </meson>
+</moduleset>

--- a/packaging/macos/jhbuild/modulesets/gtk-osx.modules
+++ b/packaging/macos/jhbuild/modulesets/gtk-osx.modules
@@ -51,9 +51,9 @@
   <autotools id="libffi"
              autogen-sh="configure"
              autogenargs="--disable-multi-os-directory --disable-docs">
-    <branch module="libffi/libffi/releases/download/v3.4.7/libffi-3.4.7.tar.gz"
-            version="3.4.7"
-            hash="sha256:138607dee268bdecf374adf9144c00e839e38541f75f24a1fcf18b78fda48b2d"
+    <branch module="libffi/libffi/releases/download/v3.5.2/libffi-3.5.2.tar.gz"
+            version="3.5.2"
+            hash="sha256:f3a3082a23b37c293a4fcd1053147b371f2ff91fa7ea1b2a52e335676bac82dc"
             repo="github-tarball" />
   </autotools>
   <autotools id="libpcre2"
@@ -95,9 +95,9 @@
   -->
   <cmake id="freetype-no-harfbuzz"
          cmakeargs='-DFT_DISABLE_HARFBUZZ=ON -DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_NAME_DIR="${JHBUILD_PREFIX}/lib"'>
-    <branch module="freetype/freetype-2.13.3.tar.xz"
-            version="2.13.3"
-            hash="sha256:0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289"
+    <branch module="freetype/freetype-2.14.1.tar.xz"
+            version="2.14.1"
+            hash="sha256:32427e8c471ac095853212a37aef816c60b42052d4d9e48230bab3bdf2936ccc"
             repo="sourceforge" />
     <dependencies>
       <dep package="zlib" />
@@ -128,9 +128,9 @@
   </meson>
   <cmake id="freetype"
          cmakeargs='-DFT_REQUIRE_HARFBUZZ=ON -DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_NAME_DIR="${JHBUILD_PREFIX}/lib"'>
-    <branch module="freetype/freetype-2.13.3.tar.xz"
-            version="2.13.3"
-            hash="sha256:0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289"
+    <branch module="freetype/freetype-2.14.1.tar.xz"
+            version="2.14.1"
+            hash="sha256:32427e8c471ac095853212a37aef816c60b42052d4d9e48230bab3bdf2936ccc"
             repo="sourceforge" />
     <dependencies>
       <dep package="harfbuzz-no-cairo" />
@@ -174,9 +174,9 @@
     </dependencies>
   </meson>
   <meson id="gobject-introspection">
-    <branch module="gobject-introspection/1.82/gobject-introspection-1.82.0.tar.xz"
-            version="1.82.0"
-            hash="sha256:0f5a4c1908424bf26bc41e9361168c363685080fbdb87a196c891c8401ca2f09">
+    <branch module="gobject-introspection/1.86/gobject-introspection-1.86.0.tar.xz"
+            version="1.86.0"
+            hash="sha256:920d1a3fcedeadc32acff95c2e203b319039dd4b4a08dd1a2dfd283d19c0b9ae">
     </branch>
     <dependencies>
       <dep package="glib-no-introspection" />
@@ -293,18 +293,20 @@
   </autotools>
   <!---->
   <meson id="gtk-4"
-         mesonargs="-Dx11-backend=false -Dmedia-gstreamer=disabled -Dintrospection=enabled">
+         mesonargs="-Dx11-backend=false -Dvulkan=disabled -Dmedia-gstreamer=disabled -Dintrospection=enabled">
 
-    <branch module="gtk/4.18/gtk-4.18.4.tar.xz"
-            version="4.18.4"
-            hash="sha256:d4783ac15037c2c4275a8f1acc94f5fede28a516243fccb92ff54a11c15775ff" />
+    <branch module="gtk/4.20/gtk-4.20.3.tar.xz"
+            version="4.20.3"
+            hash="sha256:2873f2903088a66c71173ea2ed85ffae266a66b972c3a4842bbb2f6f187ec153" />
     <dependencies>
+      <dep package="glib"/>
       <dep package="pango" />
       <dep package="atk" />
       <dep package="gdk-pixbuf" />
       <dep package="graphene" />
-      <dep package="libsass" />
       <dep package="libepoxy" />
+      <dep package="libsass" />
+      <dep package="librsvg" />
     </dependencies>
   </meson>
   <autotools id="libxml2">
@@ -333,11 +335,12 @@
   </autotools>
 
   <meson id="adwaita-icon-theme">
-    <branch module="adwaita-icon-theme/47/adwaita-icon-theme-47.0.tar.xz"
-            version="47.0"
-            hash="sha256:ad088a22958cb8469e41d9f1bba0efb27e586a2102213cd89cc26db2e002bdfe" />
+    <branch module="adwaita-icon-theme/49/adwaita-icon-theme-49.0.tar.xz"
+            version="49.0"
+            hash="sha256:65166461d1b278aa942f59aa8d0fccf1108d71c65f372c6266e172449791755c" />
     <dependencies>
       <dep package="librsvg" />
+      <dep package="gtk-4" /> <!-- gtk4-update-icon-theme -->
     </dependencies>
   </meson>
 </moduleset>

--- a/packaging/macos/jhbuild/modulesets/gtk-osx.modules
+++ b/packaging/macos/jhbuild/modulesets/gtk-osx.modules
@@ -1,0 +1,343 @@
+<?xml version="1.0"?>
+<!--*- mode: nxml; indent-tabs-mode: nil -*-->
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+  <!-- Please format this file using the following command:
+       tidy -config ../tidy.conf -m gtk-osx.modules; sed -i "" '/^ *$/d' gtk-osx.modules
+       You can get 'tidy' here: https://github.com/htacg/tidy-html5 -->
+  <repository name="download.gnome.org"
+              default="yes"
+              href="https://download.gnome.org/sources/"
+              type="tarball" />
+  <repository name="cairographics"
+              href="https://www.cairographics.org/"
+              type="tarball" />
+  <repository name="fontconfig"
+              href="http://www.freedesktop.org/software/fontconfig/release/"
+              type="tarball" />
+  <repository name="hicolor"
+              href="https://icon-theme.freedesktop.org/releases/"
+              type="tarball" />
+  <repository name="github-tarball"
+              href="https://github.com/"
+              type="tarball" />
+  <repository name="sourceforge"
+              href="http://downloads.sourceforge.net/sourceforge/"
+              type="tarball" />
+  <repository name="system"
+              type="system" />
+  <!--
+    This module set works a bit differently than for example the
+    GNOME ones do. It's split up in seperate pieces:
+
+      - gtk-osx.modules: contains the core GTK+ stack. This does not
+        have a hard dependency on the bootstrap modules, in order to
+        make it easy to rebuild the whole core stack without redoing
+        the bootstrap parts. They have a soft, "after", depencency.
+
+      - gtk-osx-python.modules: Python bindings for Gtk.
+      - gtk-osx-network.modules: The network/crypto stack and WebKit.
+      - gtk-osx-random.modules: "random stuff", has apps for testing GTK+.
+  -->
+  <include href="../jhb/gtk-osx-bootstrap.modules" />
+  <include href="../jhb/gtk-osx-network.modules" />
+  <include href="gtk-osx-python.modules" />
+  <include href="gtk-osx-random.modules" />
+  <!-- Dummy meson module to shut up a jhbuild warning. -->
+  <systemmodule id="meson">
+    <branch repo="system" />
+  </systemmodule>
+  <autotools id="libffi"
+             autogen-sh="configure"
+             autogenargs="--disable-multi-os-directory --disable-docs">
+    <branch module="libffi/libffi/releases/download/v3.4.7/libffi-3.4.7.tar.gz"
+            version="3.4.7"
+            hash="sha256:138607dee268bdecf374adf9144c00e839e38541f75f24a1fcf18b78fda48b2d"
+            repo="github-tarball" />
+  </autotools>
+  <autotools id="libpcre2"
+             autogen-sh="configure"
+             autogenargs="--enable-pcre2-16 --enable-pcre2-32 --enable-jit">
+    <branch module="PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.tar.bz2"
+            version="10.45"
+
+            repo="github-tarball" />
+  </autotools>
+  <meson id="glib-no-introspection"
+         mesonargs="-Dlibmount=disabled -Dintrospection=disabled">
+    <branch module="glib/2.86/glib-2.86.3.tar.xz"
+            version="2.86.3"
+            hash="sha256:b3211d8d34b9df5dca05787ef0ad5d7ca75dec998b970e1aab0001d229977c65" >
+    </branch>
+    <dependencies>
+      <dep package="libffi" />
+      <dep package="libpcre2" />
+    </dependencies>
+  </meson>
+  <meson id="glib"
+         mesonargs="-Dlibmount=disabled">
+    <branch module="glib/2.86/glib-2.86.3.tar.xz"
+            version="2.86.3"
+            hash="sha256:b3211d8d34b9df5dca05787ef0ad5d7ca75dec998b970e1aab0001d229977c65" >
+    </branch>
+    <dependencies>
+      <dep package="gobject-introspection" />
+    </dependencies>
+  </meson>
+  <!-- To build Freetype *with* harfbuzz requires harfbuzz to be built
+       with freetype so we first have to build it *without* harfbuzz,
+       then build harfbuzz without cairo because cairo requires
+       harfbuzz.
+       Freetype2 if left to itself will create an install name without the
+       path so none of the libraries that depend on it can link. Require
+       the install name to be an absolute path.
+  -->
+  <cmake id="freetype-no-harfbuzz"
+         cmakeargs='-DFT_DISABLE_HARFBUZZ=ON -DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_NAME_DIR="${JHBUILD_PREFIX}/lib"'>
+    <branch module="freetype/freetype-2.13.3.tar.xz"
+            version="2.13.3"
+            hash="sha256:0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289"
+            repo="sourceforge" />
+    <dependencies>
+      <dep package="zlib" />
+    </dependencies>
+  </cmake>
+  <autotools id="icu"
+             autogen-sh="source/configure"
+             autogenargs="--enable-rpath"
+             makeargs='CFLAGS="$CFLAGS -DU_CHARSET_IS_UTF8=1 -DU_USING_ICU_NAMESPACE=0"'>
+    <branch module="unicode-org/icu/releases/download/release-76-1/icu4c-76_1-src.tgz"
+            version="76.1"
+
+            checkoutdir="icu"
+            repo="github-tarball" />
+  </autotools>
+  <meson id="harfbuzz-no-cairo"
+         mesonargs="-Dcoretext=enabled -Dfreetype=enabled -Dgraphite=enabled -Ddocs=disabled -Dbenchmark=disabled -Dintrospection=disabled -Dtests=disabled">
+    <branch module="harfbuzz/harfbuzz/releases/download/12.2.0/harfbuzz-12.2.0.tar.xz"
+            version="12.2.0"
+            hash="sha256:ecb603aa426a8b24665718667bda64a84c1504db7454ee4cadbd362eea64e545"
+            repo="github-tarball" />
+    <dependencies>
+      <dep package="glib-no-introspection" />
+      <dep package="graphite2" />
+      <dep package="freetype-no-harfbuzz" />
+      <dep package="icu" />
+    </dependencies>
+  </meson>
+  <cmake id="freetype"
+         cmakeargs='-DFT_REQUIRE_HARFBUZZ=ON -DBUILD_SHARED_LIBS=true -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_NAME_DIR="${JHBUILD_PREFIX}/lib"'>
+    <branch module="freetype/freetype-2.13.3.tar.xz"
+            version="2.13.3"
+            hash="sha256:0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289"
+            repo="sourceforge" />
+    <dependencies>
+      <dep package="harfbuzz-no-cairo" />
+      <dep package="zlib" />
+    </dependencies>
+  </cmake>
+  <meson id="fontconfig"
+         mesonargs="-Ddoc=disabled -Ddefault-fonts-dirs=/System/Library/Fonts -Dadditional-fonts-dirs=/Library/Fonts">
+    <branch module="fontconfig-2.16.0.tar.xz"
+            version="2.16.0"
+            hash="sha256:6a33dc555cc9ba8b10caf7695878ef134eeb36d0af366041f639b1da9b6ed220"
+            repo="fontconfig" />
+    <dependencies>
+      <dep package="freetype" />
+    </dependencies>
+  </meson>
+  <meson id="pixman"
+         mesonargs="-Dgtk=disabled -Dmmx=disabled -Da64-neon=disabled">
+    <branch module="releases/pixman-0.44.2.tar.gz"
+            version="0.44.2"
+
+            repo="cairographics" />
+    <after>
+      <dep package="meta-gtk-osx-bootstrap" />
+    </after>
+  </meson>
+  <!-- cairo doesn't really need fontconfig, but if Pango finds
+       freetype it insists that it has to have fontconfig too and that
+       they are both built into cairo. -->
+  <meson id="cairo"
+         mesonargs="-Dfontconfig=enabled -Dfreetype=enabled">
+    <branch module="releases/cairo-1.18.2.tar.xz"
+            version="1.18.2"
+            hash="sha256:a62b9bb42425e844cc3d6ddde043ff39dbabedd1542eba57a2eb79f85889d45a"
+            repo="cairographics" />
+    <dependencies>
+      <dep package="pixman" />
+      <dep package="meta-gtk-osx-bootstrap" />
+      <dep package="harfbuzz-no-cairo" />
+      <dep package="fontconfig" />
+    </dependencies>
+  </meson>
+  <meson id="gobject-introspection">
+    <branch module="gobject-introspection/1.82/gobject-introspection-1.82.0.tar.xz"
+            version="1.82.0"
+            hash="sha256:0f5a4c1908424bf26bc41e9361168c363685080fbdb87a196c891c8401ca2f09">
+    </branch>
+    <dependencies>
+      <dep package="glib-no-introspection" />
+      <dep package="cairo" />
+    </dependencies>
+    <after>
+      <dep package="python3" />
+    </after>
+  </meson>
+  <cmake id="graphite2"
+         cmakeargs='-DCMAKE_POLICY_VERSION_MINIMUM=3.5'>
+    <branch module="silnrsi/graphite/releases/download/1.3.14/graphite2-1.3.14.tgz"
+            version="1.3.14"
+            hash="sha256:f99d1c13aa5fa296898a181dff9b82fb25f6cc0933dbaa7a475d8109bd54209d"
+            repo="github-tarball" >
+      <patch file="graphite2-install_name_dir.patch" strip="1" />
+    </branch>
+  </cmake>
+  <meson id="harfbuzz"
+         mesonargs="-Dcoretext=enabled -Dfreetype=enabled -Dgraphite=enabled -Ddocs=disabled -Dbenchmark=disabled -Dintrospection=enabled -Dtests=disabled">
+    <branch module="harfbuzz/harfbuzz/releases/download/12.2.0/harfbuzz-12.2.0.tar.xz"
+            version="12.2.0"
+            hash="sha256:ecb603aa426a8b24665718667bda64a84c1504db7454ee4cadbd362eea64e545"
+            repo="github-tarball" />
+    <dependencies>
+      <dep package="gobject-introspection" />
+      <dep package="cairo" />
+      <dep package="fontconfig" />
+      <dep package="graphite2" />
+    </dependencies>
+  </meson>
+  <meson id="fribidi"
+         mesonargs="-Ddocs=false">
+    <branch module="fribidi/fribidi/releases/download/v1.0.16/fribidi-1.0.16.tar.xz"
+            version="1.0.16"
+
+            repo="github-tarball" />
+    <dependencies>
+      <!--dep package="c2man"/-->
+    </dependencies>
+  </meson>
+  <meson id="pango"
+         mesonargs="-Dfontconfig=enabled -Dintrospection=enabled">
+    <branch module="pango/1.56/pango-1.56.1.tar.xz"
+            version="1.56.1"
+            hash="sha256:426be66460c98b8378573e7f6b0b2ab450f6bb6d2ec7cecc33ae81178f246480" />
+    <dependencies>
+      <dep package="glib" />
+      <dep package="cairo" />
+      <dep package="harfbuzz" />
+      <dep package="fribidi" />
+      <dep package="gobject-introspection" />
+      <dep package="meta-gtk-osx-bootstrap" />
+    </dependencies>
+  </meson>
+  <!-- atk is archived and no longer being developed. 2.38.0 is that last release. -->
+  <meson id="atk">
+    <branch module="atk/2.38/atk-2.38.0.tar.xz"
+            version="2.38.0"
+            hash="sha256:ac4de2a4ef4bd5665052952fe169657e65e895c5057dffb3c2a810f6191a0c36" />
+    <after>
+      <dep package="glib" />
+      <dep package="meta-gtk-osx-bootstrap" />
+      <dep package="gobject-introspection" />
+    </after>
+  </meson>
+  <meson id="gdk-pixbuf"
+         mesonargs="-Drelocatable=true -Dtests=false -Dinstalled_tests=false -Dman=false -Dpng=enabled -Djpeg=enabled -Dtiff=enabled -Dothers=enabled">
+    <branch module="gdk-pixbuf/2.42/gdk-pixbuf-2.42.12.tar.xz"
+            version="2.42.12"
+            hash="sha256:b9505b3445b9a7e48ced34760c3bcb73e966df3ac94c95a148cb669ab748e3c7">
+      <patch file="gdk-pixbuf-loader-name.patch"
+             strip="1" />
+    </branch>
+    <after>
+      <dep package="pango" />
+      <dep package="gobject-introspection" />
+    </after>
+  </meson>
+  <meson id="hicolor-icon-theme">
+    <branch module="hicolor-icon-theme-0.18.tar.xz"
+            version="0.18"
+            hash="sha256:db0e50a80aa3bf64bb45cbca5cf9f75efd9348cf2ac690b907435238c3cf81d7"
+            repo="hicolor" />
+  </meson>
+  <meson id="libepoxy">
+    <branch module="anholt/libepoxy/archive/refs/tags/1.5.10.tar.gz"
+            version="1.5.10"
+            hash="sha256:a7ced37f4102b745ac86d6a70a9da399cc139ff168ba6b8002b4d8d43c900c15"
+            checkoutdir="libepoxy-1.5.10"
+            repo="github-tarball" />
+  </meson>
+  <meson id="graphene"
+         mesonargs="-Dtests=false">
+    <branch module="graphene/1.10/graphene-1.10.8.tar.xz"
+            version="1.10.8"
+            hash="a37bb0e78a419dcbeaa9c7027bcff52f5ec2367c25ec859da31dfde2928f279a"
+            repo="download.gnome.org" />
+    <dependencies>
+      <dep package="glib" />
+      <dep package="gobject-introspection" />
+    </dependencies>
+  </meson>
+  <!---->
+  <autotools id="libsass"
+             autogen-sh="autoreconf"
+             autogenargs="--disable-tests --disable-static">
+    <branch module="sass/libsass/archive/refs/tags/3.6.5.tar.gz"
+            version="3.6.5"
+            hash="sha256:89d8f2c46ae2b1b826b58ce7dde966a176bac41975b82e84ad46b01a55080582"
+            checkoutdir="libsass-3.6.5"
+            rename-tarball="libsass-3.6.5.tar.gz"
+            repo="github-tarball" />
+  </autotools>
+  <!---->
+  <meson id="gtk-4"
+         mesonargs="-Dx11-backend=false -Dmedia-gstreamer=disabled -Dintrospection=enabled">
+
+    <branch module="gtk/4.18/gtk-4.18.4.tar.xz"
+            version="4.18.4"
+            hash="sha256:d4783ac15037c2c4275a8f1acc94f5fede28a516243fccb92ff54a11c15775ff" />
+    <dependencies>
+      <dep package="pango" />
+      <dep package="atk" />
+      <dep package="gdk-pixbuf" />
+      <dep package="graphene" />
+      <dep package="libsass" />
+      <dep package="libepoxy" />
+    </dependencies>
+  </meson>
+  <autotools id="libxml2">
+    <branch module="libxml2/2.13/libxml2-2.13.5.tar.xz"
+            version="2.13.5"
+            hash="sha256:74fc163217a3964257d3be39af943e08861263c4231f9ef5b496b6f6d4c7b2b6"
+            repo="download.gnome.org"/>
+  </autotools>
+  <autotools id="librsvg"
+             autogen-sh="autoreconf"
+             autogenargs="--disable-Bsymbolic  --disable-gtk-doc">
+    <branch module="librsvg/2.57/librsvg-2.57.0.tar.xz"
+            version="2.57.0"
+            hash="sha256:335fe2e0c2cbf1b7bf0668651224a23e135451f0b1793cd813649be2bffa74e8" />
+    <dependencies>
+      <dep package="libxml2" />
+      <dep package="cairo" />
+      <dep package="pango" />
+      <dep package="harfbuzz" />
+      <dep package="freetype" />
+      <dep package="rust" />
+    </dependencies>
+    <after>
+      <dep package="gtk-4" />
+    </after>
+  </autotools>
+
+  <meson id="adwaita-icon-theme">
+    <branch module="adwaita-icon-theme/47/adwaita-icon-theme-47.0.tar.xz"
+            version="47.0"
+            hash="sha256:ad088a22958cb8469e41d9f1bba0efb27e586a2102213cd89cc26db2e002bdfe" />
+    <dependencies>
+      <dep package="librsvg" />
+    </dependencies>
+  </meson>
+</moduleset>

--- a/packaging/macos/jhbuild/modulesets/gtksourceview5.modules
+++ b/packaging/macos/jhbuild/modulesets/gtksourceview5.modules
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+<repository name="curl"
+              href="https://curl.se/download/"
+              type="tarball" />
+
+  <repository name="gnome"
+              default="yes"
+              href="https://download.gnome.org/sources/"
+              type="tarball" />
+  <repository name="github"
+              href="https://github.com/"
+              type="tarball" />
+
+  <meson id="gtksourceview-5"
+         mesonargs="-Dintrospection=enabled -Dvapi=false">
+    <branch module="gtksourceview/5.18/gtksourceview-5.18.0.tar.xz"
+            version="5.18.0"
+            hash="sha256:051a78fe38f793328047e5bcd6d855c6425c0b480c20d9432179e356742c6ac0"
+            repo="gnome" />
+    <dependencies>
+      <dep package="gobject-introspection" />
+      <dep package="cairo" />
+      <dep package="fontconfig" />
+      <dep package="fribidi" />
+      <dep package="gdk-pixbuf" />
+      <dep package="glib" />
+      <dep package="graphene" />
+      <dep package="gtk-4" />
+      <dep package="pango" />
+      <dep package="pcre2" />
+      <dep package="gettext" />
+    </dependencies>
+  </meson>
+
+</moduleset>

--- a/packaging/macos/jhbuild/modulesets/jhbuildrc
+++ b/packaging/macos/jhbuild/modulesets/jhbuildrc
@@ -1,0 +1,2 @@
+# since Xcode 15.4: https://github.com/Koka/gettext-rs/issues/114
+environ_append("CFLAGS", "-Wno-error=incompatible-function-pointer-types")

--- a/packaging/macos/jhbuild/modulesets/libadwaita.modules
+++ b/packaging/macos/jhbuild/modulesets/libadwaita.modules
@@ -1,0 +1,98 @@
+<?xml version="1.0"?>
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+<repository name="curl"
+              href="https://curl.se/download/"
+              type="tarball" />
+
+  <repository name="gnome"
+              default="yes"
+              href="https://download.gnome.org/sources/"
+              type="tarball" />
+  <repository name="github"
+              href="https://github.com/"
+              type="tarball" />
+
+<meson id="libxmlb"
+         mesonargs="-Dgtkdoc=false">
+    <branch module="hughsie/libxmlb/releases/download/0.3.14/libxmlb-0.3.14.tar.xz"
+            version="0.3.14"
+            hash="sha256:a2f0056eed14ff791aee2b08b1514a0f1b6cf215f0579138a8cae8c45a0d3b0f"
+            repo="github" />
+    <dependencies>
+      <dep package="zstd" />
+    </dependencies>
+  </meson>
+  <!---->
+  <autotools id="libyaml"
+             autogen-sh="configure">
+    <branch module="yaml/libyaml/releases/download/0.2.5/yaml-0.2.5.tar.gz"
+            version="0.2.5"
+            hash="sha256:c642ae9b75fee120b2d96c712538bd2cf283228d2337df2cf2988e3c02678ef4"
+            repo="github" />
+  </autotools>
+
+  <cmake id="zstd" cmakeargs='-DCMAKE_INSTALL_LIBDIR=$JHBUILD_PREFIX/lib -DCMAKE_POLICY_VERSION_MINIMUM=3.5'>
+    <branch module="facebook/zstd/releases/download/v1.5.5/zstd-1.5.5.tar.gz"
+            version="1.5.5"
+            hash="sha256:9c4396cc829cfae319a6e2615202e82aad41372073482fce286fac78646d3ee4"
+            repo="github">
+      <!--
+        no cmake files in the root folder
+      -->
+      <patch file="zstd-cmake.patch"
+             strip="1" />
+    </branch>
+  </cmake>
+
+
+
+<cmake id="curl">
+    <branch module="curl-8.4.0.tar.xz"
+            version="8.4.0"
+            hash="sha256:16c62a9c4af0f703d28bda6d7bbf37ba47055ad3414d70dec63e2e6336f2a82d"
+            repo="curl">
+    </branch>
+    <dependencies>
+      <dep package="openssl" />
+      <dep package="zlib" />
+      <dep package="zstd" />
+    </dependencies>
+  </cmake>
+
+<meson id="appstream"
+         mesonargs="-Dsystemd=false -Dstemming=false -Dc_args=-D_DARWIN_C_SOURCE">
+
+    <branch module="ximion/appstream/archive/refs/tags/v1.0.0.tar.gz"
+            version="1.0.0"
+            hash="sha256:e964fea8b4b7efac7976dc13da856421ddec4299acb5012a7c059f03eabcbeae"
+            checkoutdir="appstream-1.0.0"
+            rename-tarball="appstream-1.0.0.tar.gz"
+            repo="github">
+      <patch file="appstream-disable_docs.patch"
+             strip="1" />
+    </branch>
+    <dependencies>
+      <dep package="itstool" />
+      <dep package="curl" />
+      <dep package="libxmlb" />
+      <dep package="libyaml" />
+    </dependencies>
+  </meson>
+
+  <meson id="libadwaita"
+         mesonargs="-Dintrospection=enabled -Dvapi=false">
+    <branch module="libadwaita/1.7/libadwaita-1.7.2.tar.xz"
+            version="1.7.2"
+            hash="sha256:28ee2ff589c6debe47af9da7a56e37c97d6849e003918a4b223f690d25f960be"
+            repo="gnome" />
+    <dependencies>
+      <dep package="appstream" />
+      <dep package="glib" />
+      <dep package="gobject-introspection" />
+      <dep package="gtk-4" />
+    </dependencies>
+  </meson>
+
+</moduleset>

--- a/packaging/macos/jhbuild/modulesets/libadwaita.modules
+++ b/packaging/macos/jhbuild/modulesets/libadwaita.modules
@@ -83,9 +83,9 @@
 
   <meson id="libadwaita"
          mesonargs="-Dintrospection=enabled -Dvapi=false">
-    <branch module="libadwaita/1.7/libadwaita-1.7.2.tar.xz"
-            version="1.7.2"
-            hash="sha256:28ee2ff589c6debe47af9da7a56e37c97d6849e003918a4b223f690d25f960be"
+    <branch module="libadwaita/1.8/libadwaita-1.8.2.tar.xz"
+            version="1.8.2"
+            hash="sha256:589a6e0f4191740e8690a7d3298e16fa0d4061341b551da7abb2f030b550adb1"
             repo="gnome" />
     <dependencies>
       <dep package="appstream" />

--- a/packaging/macos/jhbuild/modulesets/moduleset.dtd
+++ b/packaging/macos/jhbuild/modulesets/moduleset.dtd
@@ -1,0 +1,240 @@
+<!ELEMENT moduleset (if|redirect|repository|include|autotools|metamodule|tarball|distutils|perl|linux|testmodule|cvsroot|cvsmodule|waf|cmake|meson|systemmodule)+>
+<!ATTLIST moduleset
+	name     CDATA  #IMPLIED>
+
+<!-- DTD is incapable of allowing different children of an element
+     of a given name depending on the context in which it appears so
+     this is more permissive than it ought to be.  The RNG version
+     of the schema gets this correct.
+
+     DTD also appears to be incapable of describing the fact that
+     exactly one of condition-set='' and condition-unset='' is required.
+-->
+<!ELEMENT if (if|autotools|dep|autogenargs|cmakeargs|mesonargs|makeargs|ninjaargs|makeinstallargs)+>
+<!ATTLIST if
+	condition-set	CDATA	#IMPLIED
+	condition-unset	CDATA	#IMPLIED>
+
+<!ELEMENT repository (mirror*)>
+<!ATTLIST repository
+	name	 CDATA  #REQUIRED
+	type	 (arch|bzr|cvs|darcs|fossil|git|hg|mtn|svn|system|tarball)  #REQUIRED
+	default  (yes|no)  "no"
+	password CDATA  #IMPLIED
+	cvsroot	 CDATA  #IMPLIED
+	archive	 CDATA	#IMPLIED
+	href	 CDATA  #IMPLIED
+	server   CDATA  #IMPLIED
+	database CDATA  #IMPLIED
+	defbranch CDATA #IMPLIED
+	developer-href-example CDATA #IMPLIED
+	trunk-template CDATA #IMPLIED
+	branches-template CDATA #IMPLIED
+	tags-template CDATA #IMPLIED>
+<!-- note the following attributes are specific to some repository types:
+      - CVS: password & cvsroot
+      - Arch: archive & href
+      - Monotone: server, database, defbranch
+      - Subversion: *-template -->
+
+<!ELEMENT mirror EMPTY>
+<!ATTLIST mirror
+	type	(arch|bzr|cvs|darcs|fossil|git|hg|svn|tarball)  #REQUIRED
+	trunk-template CDATA #IMPLIED
+	branches-template CDATA #IMPLIED
+	href	CDATA  #IMPLIED>
+
+<!ELEMENT include EMPTY>
+<!ATTLIST include href CDATA #REQUIRED>
+
+<!ELEMENT redirect EMPTY>
+<!ATTLIST redirect href CDATA #REQUIRED>
+
+<!ELEMENT autotools (if*,autogenargs*,makeargs*,makeinstallargs*,pkg-config?,branch,dependencies?,suggests?,after?)>
+<!-- Note: Here the ID type is not used as some existing IDs in modsets are not
+     valid XML ID types - instead CDATA is used -->
+<!ATTLIST autotools
+	id		CDATA	#REQUIRED
+	autogenargs	CDATA	#IMPLIED
+	makeargs	CDATA	#IMPLIED
+	makeinstallargs CDATA	#IMPLIED
+	autogen-sh	CDATA	#IMPLIED
+	makefile	CDATA	#IMPLIED
+	bootstrap	(true|false) "false"
+	skip-autogen	(true|false|never) "false"
+	skip-install (yes|no) "no"
+	uninstall-before-install (true|false) "false"
+	supports-non-srcdir-builds (yes|no) "yes"
+	force-non-srcdir-builds (yes|no) "no"
+	supports-parallel-builds (yes|no) "yes"
+	supports-unknown-configure-options (yes|no) "yes"
+	autogen-template CDATA  #IMPLIED
+	check-target	(true|false) "true">
+
+<!ELEMENT autogenargs EMPTY>
+<!ATTLIST autogenargs value CDATA #REQUIRED>
+<!ELEMENT makeargs EMPTY>
+<!ATTLIST makeargs value CDATA #REQUIRED>
+<!ELEMENT makeinstallargs EMPTY>
+<!ATTLIST makeinstallargs value CDATA #REQUIRED>
+
+<!ELEMENT waf (pkg-config?,branch,dependencies?,suggests?,after?)>
+<!-- Note: Here the ID type is not used as some existing IDs in modsets are not
+     valid XML ID types - instead CDATA is used -->
+<!ATTLIST waf
+	id		CDATA	#REQUIRED
+	waf-command	CDATA	#IMPLIED>
+
+<!ELEMENT metamodule (dependencies,suggests?,after?)>
+<!ATTLIST metamodule
+	id		CDATA	#REQUIRED>
+
+<!-- tarball module type is deprecated, a tarball repository inside the
+     appropriate modtype should be used instead -->
+<!ELEMENT tarball (pkg-config?,source,branch?,dependencies?,suggests?,after?,patches?)>
+<!ATTLIST tarball
+	id		CDATA	#REQUIRED
+	version		CDATA	#REQUIRED
+	checkoutdir 	CDATA	#IMPLIED
+	autogenargs	CDATA	#IMPLIED
+	makeargs	CDATA	#IMPLIED
+	autogen-sh	CDATA	#IMPLIED
+	supports-non-srcdir-builds (yes|no) "yes">
+
+<!ELEMENT distutils (pkg-config?,branch?,dependencies?,after?)>
+<!ATTLIST distutils
+	id	ID	#REQUIRED
+	python3 CDATA	#FIXED "1"
+	supports-non-srcdir-builds (yes|no) "yes">
+
+<!ELEMENT ninjaargs EMPTY>
+<!ATTLIST ninjaargs value CDATA #REQUIRED>
+
+<!ELEMENT cmake (if*,cmakeargs*,makeargs*,ninjaargs*,pkg-config?,branch?,dependencies?,suggests?,after?)>
+<!ATTLIST cmake
+	id		CDATA	#REQUIRED
+	cmakeargs	CDATA	#IMPLIED
+	makeargs	CDATA	#IMPLIED
+	ninjaargs	CDATA	#IMPLIED
+	use-ninja (yes|no) "yes"
+	supports-non-srcdir-builds (yes|no) "yes"
+	force-non-srcdir-builds (yes|no) "no">
+
+<!ELEMENT cmakeargs EMPTY>
+<!ATTLIST cmakeargs value CDATA #REQUIRED>
+
+<!ELEMENT meson (if*,mesonargs*,ninjaargs*,pkg-config?,branch?,dependencies?,suggests?,after?)>
+<!ATTLIST meson
+	id		CDATA	#REQUIRED
+	mesonargs	CDATA	#IMPLIED
+	ninjaargs	CDATA	#IMPLIED>
+
+<!ELEMENT mesonargs EMPTY>
+<!ATTLIST mesonargs value CDATA #REQUIRED>
+
+<!ELEMENT perl (pkg-config?,branch?,dependencies?,after?)>
+<!ATTLIST perl
+	id		CDATA	#REQUIRED
+	makeargs	CDATA	#IMPLIED>
+
+<!ELEMENT linux (pkg-config?,branch?,dependencies?,after?,kconfig+)>
+<!ATTLIST linux
+	id		CDATA	#REQUIRED>
+
+<!ELEMENT systemmodule (pkg-config?,branch,dependencies?,suggests?,after?,systemdependencies?)>
+<!ATTLIST systemmodule
+	id		CDATA	#REQUIRED
+	supports-parallel-builds (yes|no) "yes">
+
+<!ELEMENT testmodule (pkg-config?,branch?,dependencies?,after?,testedmodules?)>
+<!ATTLIST testmodule
+	id		CDATA	#REQUIRED
+	type		CDATA	#REQUIRED>
+
+<!ELEMENT cvsroot EMPTY>
+<!ATTLIST cvsroot
+	name	CDATA	#REQUIRED
+	root	CDATA	#REQUIRED
+	password CDATA	"">
+
+
+<!ELEMENT cvsmodule (suggests?,dependencies?,after?)>
+<!ATTLIST cvsmodule
+	id	CDATA	#REQUIRED
+	cvsroot	CDATA	#REQUIRED
+	supports-non-srcdir-builds (yes|no) "yes">
+
+<!-- Tarball's children -->
+<!ELEMENT source EMPTY>
+<!ATTLIST source
+	href	CDATA	#REQUIRED
+	size	CDATA	#IMPLIED
+	md5sum	CDATA	#IMPLIED
+	hash    CDATA   #IMPLIED>
+
+<!ELEMENT patches (patch*)>
+<!ELEMENT patch EMPTY>
+<!ATTLIST patch
+	file	CDATA	#REQUIRED
+	strip	CDATA	"0">
+
+
+<!-- Linux's children -->
+<!ELEMENT kconfig EMPTY>
+<!ATTLIST kconfig
+	repo	CDATA	#IMPLIED
+	version	CDATA	#REQUIRED
+	module	CDATA	#IMPLIED
+	config	CDATA	#IMPLIED>
+
+
+<!-- Testmodule's children -->
+<!ELEMENT testedmodules (tested)>
+<!ELEMENT tested EMPTY>
+<!ATTLIST tested
+	package	CDATA	#REQUIRED>
+
+<!-- Other children -->
+<!ELEMENT pkg-config (#PCDATA)>
+<!ELEMENT dependencies (dep|if)*>
+<!ELEMENT suggests (dep|if)*>
+<!ELEMENT after (dep|if)*>
+<!ELEMENT systemdependencies (dep*)>
+<!ELEMENT dep (altdep*)>
+<!-- This is actually 2 different types of element: <dep package=""/> as used in <dependencies>
+     and <dep type="" name=""/> as used in <systemdependencies>. The DTD can't specify both
+     separately since they have the same element name. -->
+<!ATTLIST dep
+	package	CDATA	#IMPLIED
+	type	CDATA	#IMPLIED
+	name	CDATA	#IMPLIED>
+<!-- <altdep> is only used in <systemdependencies> to specify alternative dependencies. -->
+<!ELEMENT altdep EMPTY>
+<!ATTLIST altdep
+	type	CDATA	#IMPLIED
+	name	CDATA	#IMPLIED>
+
+<!ELEMENT branch (patch*,quilt*)>
+<!ATTLIST branch
+	repo		CDATA	#IMPLIED
+	module		CDATA	#IMPLIED
+	checkoutdir	CDATA	#IMPLIED
+	override-checkoutdir (yes|no) "yes"
+	update-new-dirs (yes|no) "yes"
+	source-subdir   CDATA   #IMPLIED
+	revision	CDATA	#IMPLIED
+	tag             CDATA   #IMPLIED
+        user            CDATA   #IMPLIED
+        revspec         CDATA   #IMPLIED
+        branch          CDATA   #IMPLIED
+	version		CDATA	#IMPLIED
+	size		CDATA	#IMPLIED
+	md5sum		CDATA	#IMPLIED
+	hash		CDATA	#IMPLIED
+        rename-tarball  CDATA   #IMPLIED>
+	<!-- override-checkoutdir and update-new-dirs are CVS only
+	     source-subdir is tarballs only -->
+
+<!ELEMENT quilt (branch)>
+<!ATTLIST quilt
+	id		CDATA	#REQUIRED>

--- a/packaging/macos/jhbuild/modulesets/moduleset.xsl
+++ b/packaging/macos/jhbuild/modulesets/moduleset.xsl
@@ -1,0 +1,196 @@
+<?xml version='1.0'?> <!--*- mode: nxml -*-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="1.0">
+
+  <xsl:output method="html" encoding="ISO-8859-1" indent="yes" />
+  <xsl:key name="module-id" match="moduleset/*" use="@id" />
+
+  <xsl:template match="/">
+    <html>
+      <head>
+        <title>Module Set</title>
+        <style type="text/css">
+          <xsl:text>
+            dl {
+              -moz-column-width: 40em;
+              -moz-column-gap: 2em;
+            }
+            dt {
+              font-weight: bold;
+              background: #8f8;
+              display: inline;
+              padding: 0 1ex;
+            }
+            dt.metamodule {
+              background: #F08080;
+            }
+            dt.tarball {
+              background: #EEDD82;
+            }
+            dd {
+              font-size: smaller;
+            }
+            dd {
+              margin-bottom: 0.5em;
+            }
+            th {
+              text-align: left;
+              vertical-align: top;
+            }
+            ul.patches {
+              list-style: none;
+              padding: 0;
+              margin: 0;
+            }
+          </xsl:text>
+        </style>
+      </head>
+      <body>
+        <xsl:apply-templates />
+      </body>
+    </html>
+  </xsl:template>
+
+  <xsl:template match="moduleset">
+    <h1>JHBuild Module Set</h1>
+    <dl>
+    <xsl:apply-templates />
+    </dl>
+  </xsl:template>
+
+  <xsl:template match="dependencies|suggests|after">
+    <xsl:variable name="deps" select="dep/@package" />
+    <xsl:for-each select="$deps">
+      <a href="#{generate-id(key('module-id', .))}">
+        <xsl:value-of select="." />
+      </a>
+      <xsl:if test="not($deps[last()] = .)">
+        <xsl:text>, </xsl:text>
+      </xsl:if>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template match="moduleset/*">
+    <xsl:param name="reponame">
+      <xsl:choose>
+        <xsl:when test="branch/@repo"><xsl:value-of select="branch/@repo"/></xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="//repository[@default = 'yes']/@name"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:param>
+
+    <dt id="{generate-id(.)}">
+      <xsl:attribute name="class">module
+        <xsl:if test="name(.) = 'tarball' or
+                      //repository[@name = $reponame]/@type = 'tarball'">tarball</xsl:if>
+      </xsl:attribute>
+      <xsl:value-of select="@id" />
+    </dt>
+
+    <dd>
+      <table>
+        <tr>
+          <th>Module:</th>
+          <td>
+            <xsl:choose>
+              <xsl:when test="@module">
+                <xsl:value-of select="@module" />
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="@id" />
+              </xsl:otherwise>
+            </xsl:choose>
+            <xsl:if test="branch/@revision">
+              <xsl:text> revision: </xsl:text>
+              <xsl:value-of select="branch/@revision" />
+            </xsl:if>
+          </td>
+        </tr>
+        <xsl:if test="name(.) = 'tarball' or //repository[@name = $reponame]/@type = 'tarball'">
+          <tr>
+            <th>URL:</th>
+            <td>
+              <xsl:variable name="url">
+                <xsl:choose>
+                  <xsl:when test="name(.) = 'tarball'">
+                    <xsl:value-of select="source/@href"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:value-of select="//repository[@name=$reponame]/@href"
+                     /><xsl:value-of select="branch/@module"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </xsl:variable>
+              <a href="{$url}"><xsl:value-of select="$url"/></a>
+              <xsl:if test="branch/@size"> (<xsl:value-of select="branch/@size"/> bytes)</xsl:if>
+              <xsl:if test="source/@size"> (<xsl:value-of select="source/@size"/> bytes)</xsl:if>
+            </td>
+          </tr>
+        </xsl:if>
+        <xsl:if test="branch/patch">
+          <tr>
+            <th>Patches:</th>
+            <td>
+              <ul class="patches">
+                <xsl:apply-templates select="branch/patch"/>
+              </ul>
+            </td>
+          </tr>
+        </xsl:if>
+        <xsl:if test="@checkoutdir">
+          <tr>
+            <th>Checkout directory:</th>
+            <td><xsl:value-of select="@checkoutdir" /></td>
+          </tr>
+        </xsl:if>
+        <xsl:if test="@autogenargs">
+          <tr>
+            <th>Autogen args:</th>
+            <td><xsl:value-of select="@autogenargs" /></td>
+          </tr>
+        </xsl:if>
+        <xsl:if test="dependencies/dep">
+          <tr>
+            <th>Dependencies:</th>
+            <td><xsl:apply-templates select="dependencies" /></td>
+          </tr>
+        </xsl:if>
+        <xsl:if test="suggests">
+          <tr>
+            <th>Suggests:</th>
+            <td><xsl:apply-templates select="suggests" /></td>
+          </tr>
+        </xsl:if>
+        <xsl:if test="after">
+          <tr>
+            <th>After:</th>
+            <td><xsl:apply-templates select="after" /></td>
+          </tr>
+        </xsl:if>
+      </table>
+    </dd>
+  </xsl:template>
+
+  <xsl:template match="moduleset/repository|moduleset/include">
+  </xsl:template>
+
+  <xsl:template match="moduleset/metamodule">
+    <dt id="{generate-id(.)}" class="metamodule"><xsl:value-of select="@id" /></dt>
+    <dd>
+      <table>
+        <xsl:if test="dependencies/dep">
+          <tr>
+            <th>Dependencies:</th>
+            <td><xsl:apply-templates select="dependencies" /></td>
+          </tr>
+        </xsl:if>
+      </table>
+    </dd>
+  </xsl:template>
+
+  <xsl:template match="patch">
+    <li><xsl:value-of select="@file" /></li>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/packaging/macos/jhbuild/modulesets/patches/appstream-disable_docs.patch
+++ b/packaging/macos/jhbuild/modulesets/patches/appstream-disable_docs.patch
@@ -1,0 +1,11 @@
+--- a/meson.build	2023-12-08 14:27:22
++++ b/meson.build	2023-12-08 14:27:15
+@@ -203,7 +203,7 @@
+ subdir('po/')
+ subdir('data/')
+ subdir('contrib/')
+-subdir('docs/')
++#subdir('docs/')
+ subdir('tests/')
+ if get_option('qt') or get_option('qt5')
+     subdir('qt/')

--- a/packaging/macos/jhbuild/modulesets/patches/gdk-pixbuf-loader-name.patch
+++ b/packaging/macos/jhbuild/modulesets/patches/gdk-pixbuf-loader-name.patch
@@ -1,0 +1,25 @@
+diff -c /Users/john/Development/gtk-build/gtk-stable-10.9-x86_64/src/gdk-pixbuf-2.38.0/gdk-pixbuf/meson.build\~ /Users/john/Development/gtk-build/gtk-stable-10.9-x86_64/src/gdk-pixbuf-2.38.0/gdk-pixbuf/meson.build
+--- a/gdk-pixbuf/meson.build	Mon Sep  3 07:41:50 2018
++++ b/gdk-pixbuf/meson.build	Wed Jul 31 16:04:12 2019
+@@ -246,7 +246,8 @@
+                         include_directories: [ root_inc, gdk_pixbuf_inc ],
+                         c_args: common_cflags + gdk_pixbuf_cflags + cflags,
+                         install: true,
+-                        install_dir: gdk_pixbuf_loaderdir)
++                        install_dir: gdk_pixbuf_loaderdir,
++                        name_suffix: 'so')
+ 
+     # We need the path to build loaders.cache for tests
+     dynamic_loaders += mod.full_path()
+@@ -265,7 +266,8 @@
+                           include_directories: [ root_inc, gdk_pixbuf_inc ],
+                           c_args: common_cflags + gdk_pixbuf_cflags + cflags,
+                           install: true,
+-                          install_dir: gdk_pixbuf_loaderdir)
++                          install_dir: gdk_pixbuf_loaderdir,
++                          name_suffix: 'so')
+       dynamic_loaders += mod.full_path()
+     endforeach
+   endif
+
+Diff finished.  Wed Jul 31 16:09:09 2019

--- a/packaging/macos/jhbuild/modulesets/patches/graphite2-install_name_dir.patch
+++ b/packaging/macos/jhbuild/modulesets/patches/graphite2-install_name_dir.patch
@@ -1,0 +1,10 @@
+--- a/src/CMakeLists.txt	2020-04-01 04:53:13
++++ b/src/CMakeLIsts.txt	2025-11-28 14:59:27
+@@ -139,6 +139,7 @@
+         COMPILE_FLAGS   "-Wall -Wextra -Wno-unknown-pragmas -Wimplicit-fallthrough -Wendif-labels -Wshadow -Wno-ctor-dtor-privacy -Wno-non-virtual-dtor -fno-rtti -fno-exceptions -fvisibility=hidden -fvisibility-inlines-hidden"
+         LINK_FLAGS      "-nodefaultlibs"
+         LINKER_LANGUAGE C)
++    set_target_properties(graphite2 PROPERTIES INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib")
+     if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86|i.86")
+         add_definitions(-mfpmath=sse -msse2)
+     endif()

--- a/packaging/macos/jhbuild/modulesets/patches/rust-cmake_install.patch
+++ b/packaging/macos/jhbuild/modulesets/patches/rust-cmake_install.patch
@@ -1,0 +1,24 @@
+--- a/CMakeLists.txt	2020-11-29 02:35:19.000000000 +0100
++++ b/CMakeLists.txt	2020-11-29 02:35:44.000000000 +0100
+@@ -0,0 +1,21 @@
++# This is a wrapper to install Rust via cmake. Its only purpose is to supply an
++# interface that can be used from JHBuild.
++#
++# usage:
++#   cmake -DVERSION=<Rust version>
++#   make install
++
++cmake_minimum_required(VERSION 3.1)
++project(rust)
++
++add_custom_command(OUTPUT rust
++  # use bash so we can supply environment variables to rustup-init.sh
++  COMMAND bash "-c" "RUSTUP_HOME=${CMAKE_INSTALL_PREFIX}/home/.rustup CARGO_HOME=${CMAKE_INSTALL_PREFIX}/home/.cargo ${CMAKE_CURRENT_SOURCE_DIR}/rustup-init.sh -y --default-toolchain=${VERSION} --no-modify-path --profile minimal"
++)
++
++add_custom_target(
++  install_rust ALL
++  DEPENDS rust
++)
++
++install(DIRECTORY ${CMAKE_INSTALL_PREFIX}/home/.cargo/bin/ DESTINATION bin USE_SOURCE_PERMISSIONS)

--- a/packaging/macos/jhbuild/modulesets/patches/zstd-cmake.patch
+++ b/packaging/macos/jhbuild/modulesets/patches/zstd-cmake.patch
@@ -1,0 +1,5 @@
+--- a/CMakeLists.txt	2018-06-10 14:37:39.000000000 +0200
++++ b/CMakeLists.txt	2018-06-10 14:37:05.000000000 +0200
+@@ -0,0 +1,2 @@
++cmake_minimum_required(VERSION 3.10)
++add_subdirectory("build/cmake")

--- a/packaging/macos/jhbuild/modulesets/rust.modules
+++ b/packaging/macos/jhbuild/modulesets/rust.modules
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<!DOCTYPE moduleset SYSTEM "moduleset.dtd">
+<?xml-stylesheet type="text/xsl" href="moduleset.xsl"?>
+<moduleset>
+  <repository name="github"
+              href="https://github.com/"
+              type="tarball" />
+  <cmake id="rust"
+         cmakeargs="-DVERSION=1.92.0 -DCMAKE_POLICY_VERSION_MINIMUM=3.5"
+         supports-non-srcdir-builds="no"
+         use-ninja="no">
+    <branch module="rust-lang/rustup/archive/1.28.2.tar.gz"
+            version="1.28.2"
+            hash="sha256:5987dcb828068a4a5e29ba99ab26f2983ac0c6e2e4dc3e5b3a3c0fafb69abbc0"
+            checkoutdir="rustup-1.28.2"
+            rename-tarball="rustup-1.28.2.tar.gz"
+            repo="github">
+      <patch file="rust-cmake_install.patch"
+             strip="1" />
+    </branch>
+  </cmake>
+</moduleset>

--- a/packaging/macos/jhbuild/modulesets/tidy.conf
+++ b/packaging/macos/jhbuild/modulesets/tidy.conf
@@ -1,0 +1,8 @@
+indent-attributes: yes
+sort-attributes: alpha
+indent-spaces: 2
+input-xml: yes
+output-xml: yes
+newline: LF
+indent: yes
+priority-attributes: id, name, module, version, hash

--- a/packaging/macos/vendoring.py
+++ b/packaging/macos/vendoring.py
@@ -68,13 +68,18 @@ def shared_libraries(path):
 
 
 def vtool_show_minver(path):
-    args = ["vtool", "-show", path]
+    args = ["vtool", "-show-build", path]
     output = subprocess.check_output(args).decode("utf-8")
     print({
         'args': args,
         'output': output,
     })
-    sdkver = next(l for l in output.splitlines() if "minos" in l)
+    if "LC_VERSION_MIN_MACOSX" in output:
+        # Is x86_64, look for version
+        sdkver = next(l for l in output.splitlines() if "version" in l)
+    elif "LC_BUILD_VERSION" in output:
+        # Is arm64, look for minos.
+        sdkver = next(l for l in output.splitlines() if "minos" in l)
     return sdkver.split()[1]
 
 
@@ -90,6 +95,7 @@ def vtool_set_sdkver(minver, sdkver, path):
         path,
         path,
     ]
+    print({'args': args})
     subprocess.run(args)
 
 

--- a/packaging/macos/vendoring.py
+++ b/packaging/macos/vendoring.py
@@ -67,6 +67,28 @@ def shared_libraries(path):
     return re.findall(otool_lib, output)
 
 
+def vtool_show_minver(path):
+    args = ["vtool", "-show", path]
+    output = subprocess.check_output(args).decode("utf-8")
+    sdkver = next(l for l in output.splitlines() if " minos " in l)
+    return sdkver.split()[1]
+
+
+def vtool_set_sdkver(minver, sdkver, path):
+    args = [
+        "vtool",
+        "-set-version-min",
+        "macos",
+        minver,
+        sdkver,
+        "-replace",
+        "-output",
+        path,
+        path,
+    ]
+    subprocess.run(args)
+
+
 def force_sign_file(path):
     args = [
         "codesign",
@@ -142,6 +164,8 @@ if len(sys.argv) < 2:
 _, app_id = sys.argv
 
 # Start relocating.
+minver = vtool_show_minver(bindir / "cartero")
+vtool_set_sdkver(minver, "15.0", bindir / "cartero")
 relocate_and_vendor(bindir / "cartero", "@loader_path/../lib")
 
 # Bring the gdk-pixbuf-2.0 loaders too

--- a/packaging/macos/vendoring.py
+++ b/packaging/macos/vendoring.py
@@ -171,10 +171,29 @@ loaders_cache = subprocess.check_output(
     },
 ).decode("utf-8")
 loaders_cache = loaders_cache.replace(
-    str(pixbuf_moduledir) + "/", "@loader_path/gdk-pixbuf-2.0/2.10.0/loaders/"
+    str(pixbuf_moduledir) + "/", "Resources/lib/gdk-pixbuf-2.0/2.10.0/loaders/"
 )
 with open(pixbuf_bindir / "loaders.cache", mode="w") as file:
     file.write(loaders_cache)
+
+# Bring the print backends if available
+printbackends_src = (
+    Path(pkg_config("gtk4", "libdir")) / "gtk-4.0" / "4.0.0" / "printbackends"
+)
+if printbackends_src.exists():
+    printbackends = libdir / "gtk-4.0" / "4.0.0" / "printbackends"
+    printbackends.mkdir(exist_ok=True, parents=True)
+    printbackends_rpath = [
+        Path(pkg_config("gtk4", "libdir")),
+    ]
+    for backend in printbackends_src.glob("*.so"):
+        target_path = printbackends / backend.name
+        if target_path.exists():
+            target_path.unlink()
+        shutil.copy(backend, target_path)
+        relocate_and_vendor(
+            target_path, "@loader_path/../../..", rpath=printbackends_rpath
+        )
 
 # Vendor icon theme
 adwaita_icon_theme_pc = Path(pkg_config("adwaita-icon-theme", "pcfiledir"))

--- a/packaging/macos/vendoring.py
+++ b/packaging/macos/vendoring.py
@@ -71,8 +71,8 @@ def vtool_show_minver(path):
     args = ["vtool", "-show", path]
     output = subprocess.check_output(args).decode("utf-8")
     print({
-        args=args,
-        output=output,
+        args: args,
+        output: output,
     })
     sdkver = next(l for l in output.splitlines() if "minos" in l)
     return sdkver.split()[1]

--- a/packaging/macos/vendoring.py
+++ b/packaging/macos/vendoring.py
@@ -71,8 +71,8 @@ def vtool_show_minver(path):
     args = ["vtool", "-show", path]
     output = subprocess.check_output(args).decode("utf-8")
     print({
-        args: args,
-        output: output,
+        'args': args,
+        'output': output,
     })
     sdkver = next(l for l in output.splitlines() if "minos" in l)
     return sdkver.split()[1]

--- a/packaging/macos/vendoring.py
+++ b/packaging/macos/vendoring.py
@@ -70,7 +70,11 @@ def shared_libraries(path):
 def vtool_show_minver(path):
     args = ["vtool", "-show", path]
     output = subprocess.check_output(args).decode("utf-8")
-    sdkver = next(l for l in output.splitlines() if " minos " in l)
+    print({
+        args=args,
+        output=output,
+    })
+    sdkver = next(l for l in output.splitlines() if "minos" in l)
     return sdkver.split()[1]
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,6 +115,11 @@ fn main() -> glib::ExitCode {
         if let Ok(true) = gdk_pixbuf.try_exists() {
             std::env::set_var("GDK_PIXBUF_MODULE_FILE", gdk_pixbuf);
         }
+
+        let gtk_modules_dir = app_rel_path("lib/gtk-4.0");
+        if let Ok(true) = gtk_modules_dir.try_exists() {
+            std::env::set_var("GTK_EXE_PREFIX", app_rel_path("lib"));
+        }
     }
 
     init_data_dir();


### PR DESCRIPTION
Attempts to fix the newest issue with my build infra.

Advantages:

- Doesn't rely on Homebrew packages (no more hacks, can control the version stack better.)
- Faster to build from source (less dependencies, can use rustup instead of manually compiling rust).
- Allows to set MACOSX_DEPLOYMENT_TARGET: can now build for macOS 11 even on GitHub Actions.
- One step closer to using cloud runners like GitHub Actions to compile the stable release.

Disadvantages:

- Will it require compiling the stack on every commit. We could use caches or skip compiling the macOS version on every push or merge?