### PR TITLE
Accept TLS certificates with an invalid SAN when TLS validation is not enabled

### DIFF
--- a/NEWS.d/26.0/fixed
+++ b/NEWS.d/26.0/fixed
@@ -1,2 +1,3 @@
 Responses were being treated as binary if they contained the CR (\r) character.
+Disabling TLS validation still failed a request if the certificate didn't have a matching SAN.
 MacOS: the main application window could sometimes stop receiving mouse clicks on macOS 26.

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@ These are the user-visible changes noticeable within Cartero.
 
 - Responses were being treated as binary if they contained the CR (\\r)
   character.
+- Disabling TLS validation still failed a request if the certificate
+  didn't have a matching SAN.
 - MacOS: the main application window could sometimes stop receiving
   mouse clicks on macOS 26.
 

--- a/crates/cartero-isahc-client/src/lib.rs
+++ b/crates/cartero-isahc-client/src/lib.rs
@@ -108,7 +108,7 @@ async fn build_request(
     let ssl_mode = if env.config.validate_tls {
         SslOption::NONE
     } else {
-        SslOption::DANGER_ACCEPT_INVALID_CERTS
+        SslOption::DANGER_ACCEPT_INVALID_CERTS | SslOption::DANGER_ACCEPT_INVALID_HOSTS
     };
     let redirect_policy = if env.config.redirects > 0 {
         RedirectPolicy::Limit(env.config.redirects as u32)


### PR DESCRIPTION
Before this change, a request to https://wrong.host.badssl.com/ failed even when the TLS validation was disabled. Apparently missed a flag when asking to disable TLS validation at the client level. After this change, a request to https://wrong.host.badssl.com/ succeeds if the TLS validation is disabled.

This will fix https://github.com/danirod/cartero/issues/332.