### PR TITLE
Rust project maintenance, cleanup, upgrades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,25 +13,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -96,21 +81,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "backtrace"
-version = "0.3.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,9 +119,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.3"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block"
@@ -173,17 +143,17 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cairo-rs"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1158f326d7b755a9ae2b36c5b5391400e3431f3b77418cedb6d7130126628f10"
+checksum = "b01fe135c0bd16afe262b6dea349bd5ea30e6de50708cec639aae7c5c14cc7e4"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.10.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -191,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "cairo-sys-rs"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b963177900ec8e783927e5ed99e16c0ec1b723f1f125dff8992db28ef35c62c3"
+checksum = "06c28280c6b12055b5e39e4554271ae4e6630b27c0da9148c4cf6485fc6d245c"
 dependencies = [
  "glib-sys",
  "libc",
@@ -227,10 +197,10 @@ dependencies = [
  "sourceview5",
  "srtemplate",
  "tokio",
- "toml",
- "url 2.5.6",
+ "toml 0.8.23",
+ "url 2.5.8",
  "winapi",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
  "winreg",
  "winresource",
 ]
@@ -245,10 +215,10 @@ dependencies = [
  "cartero_objects",
  "gio",
  "glib",
- "http 1.3.1",
+ "http 1.4.0",
  "serde_urlencoded",
  "srtemplate",
- "url 2.5.6",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -262,8 +232,8 @@ dependencies = [
  "glib",
  "indexmap",
  "serde",
- "toml",
- "toml_edit 0.23.3",
+ "toml 0.8.23",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
@@ -277,7 +247,7 @@ dependencies = [
  "serde_urlencoded",
  "srtemplate",
  "tokio",
- "url 2.5.6",
+ "url 2.5.8",
 ]
 
 [[package]]
@@ -308,7 +278,7 @@ dependencies = [
  "dotenvy",
  "gio",
  "glib",
- "http 1.3.1",
+ "http 1.4.0",
  "itertools",
  "srtemplate",
 ]
@@ -321,18 +291,19 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.2.34"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
 [[package]]
 name = "cfg-expr"
-version = "0.20.2"
+version = "0.20.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d458d63f0f0f482c8da9b7c8b76c21bd885a02056cc94c6404d861ca2b8206"
+checksum = "78cef5b5a1a6827c7322ae2a636368a573006b27cfa76c7ebd53e834daeaab6a"
 dependencies = [
  "smallvec",
  "target-lexicon",
@@ -340,9 +311,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "charset"
@@ -411,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.83+curl-8.15.0"
+version = "0.4.85+curl-8.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5830daf304027db10c82632a464879d46a3f7c4ba17a31592657ad16c719b483"
+checksum = "c0efa6142b5ecc05f6d3eaa39e6af4888b9d3939273fb592c92b7088a8cf3fdb"
 dependencies = [
  "cc",
  "libc",
@@ -457,9 +428,9 @@ checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtor"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58a0764cddb55ab28955347b45be00ade43d4d6f3ba4bf3dc354e4ec9432934"
+checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
 dependencies = [
  "dtor-proc-macro",
 ]
@@ -557,12 +528,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -597,6 +568,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,7 +603,7 @@ dependencies = [
  "encoding",
  "httparse",
  "hyper",
- "log 0.4.27",
+ "log 0.4.29",
  "mime 0.2.6",
  "mime_multipart",
  "textnonce",
@@ -725,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7330cdbbc653df431331ae3d9d59e985a0fecaf33d74c7c1c5d13ab0245f6c"
+checksum = "debb0d39e3cdd84626edfd54d6e4a6ba2da9a0ef2e796e691c4e9f8646fda00c"
 dependencies = [
  "gdk-pixbuf-sys",
  "gio",
@@ -737,9 +714,9 @@ dependencies = [
 
 [[package]]
 name = "gdk-pixbuf-sys"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25899cc931dc28cba912ebec793b730f53d2d419f90a562fcb29b53bd10aa82"
+checksum = "bd95ad50b9a3d2551e25dd4f6892aff0b772fe5372d84514e9d0583af60a0ce7"
 dependencies = [
  "gio-sys",
  "glib-sys",
@@ -750,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a67b064d2f35e649232455c7724f56f977555d2608c43300eabc530eaa4e359"
+checksum = "756564212bbe4a4ce05d88ffbd2582581ac6003832d0d32822d0825cca84bfbf"
 dependencies = [
  "cairo-rs",
  "gdk-pixbuf",
@@ -765,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-sys"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2edbda0d879eb85317bdb49a3da591ed70a804a10776e358ef416be38c6db2c5"
+checksum = "a6d4e5b3ccf591826a4adcc83f5f57b4e59d1925cb4bf620b0d645f79498b034"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -782,9 +759,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-win32"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cc947b0056bff5bb2d9c8788c12c176fcd1a76b5bf891592090a85630bd7c96"
+checksum = "a004ec8cbf0daecfc4f00590683dd1e61dd2d6b0b4a130c09340ff82ea59cc63"
 dependencies = [
  "gdk4",
  "gdk4-win32-sys",
@@ -795,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "gdk4-win32-sys"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbcb474613d6cdca18d1e8571b7dd6d708a6ff33b227bee0e969a8566694fe96"
+checksum = "eddc1ec7b8be04fec1feec2766ba53225c09d58ddfc7bd9054512fcae16f416f"
 dependencies = [
  "gdk4-sys",
  "glib-sys",
@@ -818,21 +795,21 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasip2",
 ]
 
 [[package]]
 name = "gettext-rs"
-version = "0.7.2"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44e92f7dc08430aca7ed55de161253a22276dfd69c5526e5c5e95d1f7cf338a"
+checksum = "5d5857dc1b7f0fee86961de833f434e29494d72af102ce5355738c0664222bdf"
 dependencies = [
  "gettext-sys",
  "locale_config",
@@ -840,25 +817,19 @@ dependencies = [
 
 [[package]]
 name = "gettext-sys"
-version = "0.22.5"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb45773f5b8945f12aecd04558f545964f943dacda1b1155b3d738f5469ef661"
+checksum = "4ea859ab0dd7e70ff823032b3e077d03d39c965d68c6c10775add60e999d8ee9"
 dependencies = [
  "cc",
  "temp-dir",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "gio"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5e3f390d01b79e30da451dd00e27cd1ac2de81658e3abf6c1fc3229b24c5f"
+checksum = "c5ff48bf600c68b476e61dc6b7c762f2f4eb91deef66583ba8bb815c30b5811a"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -873,24 +844,24 @@ dependencies = [
 
 [[package]]
 name = "gio-sys"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03f2234671e5a588cfe1f59c2b22c103f5772ea351be9cc824a9ce0d06d99fd"
+checksum = "0071fe88dba8e40086c8ff9bbb62622999f49628344b1d1bf490a48a29d80f22"
 dependencies = [
  "glib-sys",
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "glib"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60bdc26493257b5794ba9301f7cbaf7ab0d69a570bfbefa4d7d360e781cb5205"
+checksum = "16de123c2e6c90ce3b573b7330de19be649080ec612033d397d72da265f1bd8b"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.10.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -907,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.21.0"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e772291ebea14c28eb11bb75741f62f4a4894f25e60ce80100797b6b010ef0f9"
+checksum = "cf59b675301228a696fe01c3073974643365080a76cc3ed5bc2cbc466ad87f17"
 dependencies = [
  "heck",
  "proc-macro-crate",
@@ -920,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "glib-sys"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc7c43cff6a7dc43821e45ebf172399437acd6716fa2186b6852d2b397bf622d"
+checksum = "2d95e1a3a19ae464a7286e14af9a90683c64d70c02532d88d87ce95056af3e6c"
 dependencies = [
  "libc",
  "system-deps",
@@ -930,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "gobject-sys"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e9a190eef2bce144a6aa8434e306974c6062c398e0a33a146d60238f9062d5c"
+checksum = "2dca35da0d19a18f4575f3cb99fe1c9e029a2941af5662f326f738a21edaf294"
 dependencies = [
  "glib-sys",
  "libc",
@@ -941,9 +912,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-rs"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96914394464c04df8279c23976293afd53b2588e03c9d8d9662ef6528654a85"
+checksum = "2730030ac9db663fd8bfe1e7093742c1cafb92db9c315c9417c29032341fe2f9"
 dependencies = [
  "glib",
  "graphene-sys",
@@ -952,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "graphene-sys"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf8205bb19b7a041cf059be3c94d6b23b3f2c6c96362c44311dcf184e4a9422a"
+checksum = "915e32091ea9ad241e4b044af62b7351c2d68aeb24f489a0d7f37a0fc484fd93"
 dependencies = [
  "glib-sys",
  "libc",
@@ -964,9 +935,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5dbe33ceed6fc20def67c03d36e532f5a4a569ae437ae015a7146094f31e10c"
+checksum = "e755de9d8c5896c5beaa028b89e1969d067f1b9bf1511384ede971f5983aa153"
 dependencies = [
  "cairo-rs",
  "gdk4",
@@ -979,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "gsk4-sys"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d76011d55dd19fde16ffdedee08877ae6ec942818cfa7bc08a91259bc0b9fc9"
+checksum = "7ce91472391146f482065f1041876d8f869057b195b95399414caa163d72f4f7"
 dependencies = [
  "cairo-sys-rs",
  "gdk4-sys",
@@ -995,9 +966,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938d68ad43080ad5ee710c30d467c1bc022ee5947856f593855691d726305b3e"
+checksum = "acb21d53cfc6f7bfaf43549731c43b67ca47d87348d81c8cfc4dcdd44828e1a4"
 dependencies = [
  "cairo-rs",
  "field-offset",
@@ -1016,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-macros"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0912d2068695633002b92c5966edc108b2e4f54b58c509d1eeddd4cbceb7315c"
+checksum = "3ccfb5a14a3d941244815d5f8101fa12d4577b59cc47245778d8d907b0003e42"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1028,9 +999,9 @@ dependencies = [
 
 [[package]]
 name = "gtk4-sys"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a923bdcf00e46723801162de24432cbce38a6810e0178a2d0b6dd4ecc26a1c74"
+checksum = "842577fe5a1ee15d166cd3afe804ce0cab6173bc789ca32e21308834f20088dd"
 dependencies = [
  "cairo-sys-rs",
  "gdk-pixbuf-sys",
@@ -1053,9 +1024,9 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -1082,12 +1053,11 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -1118,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1131,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1144,11 +1114,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1159,42 +1128,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -1236,13 +1201,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1252,17 +1218,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "io-uring"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
-dependencies = [
- "bitflags 2.9.3",
- "cfg-if",
- "libc",
 ]
 
 [[package]]
@@ -1280,7 +1235,7 @@ dependencies = [
  "event-listener",
  "futures-lite 1.13.0",
  "http 0.2.12",
- "log 0.4.27",
+ "log 0.4.29",
  "mime 0.3.17",
  "once_cell",
  "polling",
@@ -1288,7 +1243,7 @@ dependencies = [
  "sluice",
  "tracing",
  "tracing-futures",
- "url 2.5.6",
+ "url 2.5.8",
  "waker-fn",
 ]
 
@@ -1303,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "language-tags"
@@ -1321,9 +1276,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libadwaita"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df6715d1257bd8c093295b77a276ed129d73543b10304fec5829ced5d5b7c41"
+checksum = "fb09e12bf8f73342b3315c839d0a7668cc0ccebd78490c49fec48bab15d5484b"
 dependencies = [
  "gdk4",
  "gio",
@@ -1336,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "libadwaita-sys"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdf8950090cc180250cdb1ff859a39748feeda7a53a9f28ead3a17a14cc37ae2"
+checksum = "6d7f94227ba87eb596fecada2491f04e357d507324142f77bf76d9e6be4a3e31"
 dependencies = [
  "gdk4-sys",
  "gio-sys",
@@ -1352,9 +1307,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1368,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.22"
+version = "1.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b70e7a7df205e92a1a4cd9aaae7898dac0aa555503cc0a649494d0d60e7651d"
+checksum = "15d118bbf3771060e7311cc7bb0545b01d08a8b4a7de949198dec1fa0ca1c0f7"
 dependencies = [
  "cc",
  "libc",
@@ -1380,15 +1335,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "locale_config"
@@ -1405,11 +1360,10 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
@@ -1419,14 +1373,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.27",
+ "log 0.4.29",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "malloc_buf"
@@ -1445,9 +1399,9 @@ checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -1483,30 +1437,10 @@ dependencies = [
  "encoding",
  "httparse",
  "hyper",
- "log 0.4.27",
+ "log 0.4.29",
  "mime 0.2.6",
  "tempfile",
  "textnonce",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
-]
-
-[[package]]
-name = "mio"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
-dependencies = [
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1549,15 +1483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,9 +1496,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -1583,9 +1508,9 @@ dependencies = [
 
 [[package]]
 name = "pango"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab47feb3403aa564edaeb68620c5b9159f8814733a7dd45f0b1a27d19de362fe"
+checksum = "52d1d85e2078077a065bb7fc072783d5bcd4e51b379f22d67107d0a16937eb69"
 dependencies = [
  "gio",
  "glib",
@@ -1595,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "pango-sys"
-version = "0.21.1"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f855bccb447644e149fae79086e1f81514c30fe5e9b8bd257d9d3c941116c86"
+checksum = "b4f06627d36ed5ff303d2df65211fc2e52ba5b17bf18dd80ff3d9628d6e06cfd"
 dependencies = [
  "glib-sys",
  "gobject-sys",
@@ -1613,15 +1538,15 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.11"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1691,16 +1616,16 @@ dependencies = [
  "cfg-if",
  "concurrent-queue",
  "libc",
- "log 0.4.27",
+ "log 0.4.29",
  "pin-project-lite",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -1716,27 +1641,27 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
- "toml_edit 0.22.27",
+ "toml_edit 0.23.10+spec-1.0.0",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "psl"
-version = "2.1.139"
+version = "2.1.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "932e0fd76ba376581e5e99b80f9b9b5ce5eb4e3d506b7d89fecd3314b8f256cf"
+checksum = "81dc6a90669f481b41cae3005c68efa36bef275b95aa9123a7af7f1c68c6e5b2"
 dependencies = [
  "psl-types",
 ]
@@ -1749,9 +1674,9 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "quote"
-version = "1.0.40"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -1805,18 +1730,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.17"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1826,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1837,15 +1762,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustc-hash"
@@ -1864,22 +1783,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.9.3",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "safemem"
@@ -1889,11 +1808,11 @@ checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1904,24 +1823,34 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1930,15 +1859,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.143"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1952,11 +1882,11 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2002,12 +1932,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2058,15 +1988,15 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "syn"
-version = "2.0.106"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2086,22 +2016,22 @@ dependencies = [
 
 [[package]]
 name = "system-deps"
-version = "7.0.5"
+version = "7.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4be53aa0cba896d2dc615bd42bbc130acdcffa239e0a2d965ea5b3b2a86ffdb"
+checksum = "48c8f33736f986f16d69b6cb8b03f55ddcad5c41acc4ccc39dd88e84aa805e7f"
 dependencies = [
  "cfg-expr",
  "heck",
  "pkg-config",
- "toml",
+ "toml 0.9.11+spec-1.1.0",
  "version-compare",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "temp-dir"
@@ -2111,15 +2041,15 @@ checksum = "83176759e9416cf81ee66cb6508dbfe9c96f20b8b56265a39917551c23c70964"
 
 [[package]]
 name = "tempfile"
-version = "3.21.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand 2.3.0",
- "getrandom 0.3.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2165,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2190,24 +2120,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.47.1"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
- "backtrace",
- "io-uring",
- "libc",
- "mio",
  "pin-project-lite",
- "slab",
  "tokio-macros",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2227,6 +2152,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.9.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3afc9a848309fe1aaffaed6e1546a7a14de1f935dc9d89d32afd9a44bab7c46"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,11 +2177,11 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2260,14 +2200,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.3"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17d3b47e6b7a040216ae5302712c94d1cf88c95b47efa80e2c59ce96c878267e"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
  "indexmap",
- "serde",
- "serde_spanned 1.0.0",
- "toml_datetime 0.7.0",
+ "serde_core",
+ "serde_spanned 1.0.4",
+ "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -2275,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
@@ -2290,17 +2230,17 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log 0.4.27",
+ "log 0.4.29",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2308,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2319,9 +2259,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -2365,15 +2305,15 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
@@ -2391,13 +2331,14 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.6"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "137a3c834eaf7139b73688502f3f1141a0337c5d8e4d9b536f9b8c796e26a7c4"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna 1.1.0",
  "percent-encoding 2.3.2",
+ "serde",
 ]
 
 [[package]]
@@ -2414,9 +2355,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -2449,18 +2390,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
-name = "wasi"
-version = "0.14.2+wasi-0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2487,9 +2422,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -2515,7 +2450,16 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.3",
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2551,19 +2495,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.3"
+version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link",
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2580,9 +2524,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2598,9 +2542,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2616,9 +2560,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -2628,9 +2572,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2646,9 +2590,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2664,9 +2608,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2682,9 +2626,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2700,15 +2644,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.0"
+version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -2725,36 +2669,32 @@ dependencies = [
 
 [[package]]
 name = "winresource"
-version = "0.1.23"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edcacf11b6f48dd21b9ba002f991bdd5de29b2da8cc2800412f4b80f677e4957"
+checksum = "e287ced0f21cd11f4035fe946fd3af145f068d1acb708afd248100f89ec7432d"
 dependencies = [
- "toml",
+ "toml 0.9.11+spec-1.1.0",
  "version_check 0.9.5",
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.3",
-]
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -2762,9 +2702,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2774,18 +2714,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "7456cf00f0685ad319c5b1693f291a650eaf345e941d082fc4e03df8a03996ac"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "1328722bbf2115db7e19d69ebcc15e795719e2d66b60827c6a69a117365e37a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2815,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2826,9 +2766,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2837,11 +2777,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@
 members = ["crates/*"]
 
 [workspace.package]
-edition = "2021"
+edition = "2024"
 version = "26.1.0"
 license = "GPL-3.0-or-later"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,16 +29,16 @@ base64 = "0.22.1"
 content_disposition = "0.4.0"
 formdata = "0.13.0"
 futures-lite = "2.6.1"
-glib = { version = "0.21.1", features = ["v2_80"] }
-gio = { version = "0.21.1", features = ["v2_80"] }
+glib = { version = "0.21.5", features = ["v2_80"] }
+gio = { version = "0.21.5", features = ["v2_80"] }
 http = "1.3.1"
-indexmap = { version = "2.10.0", features = ["serde"] }
-serde = { version = "1.0.219", features = ["derive"] }
+indexmap = { version = "2.13.0", features = ["serde"] }
+serde = { version = "1.0.228", features = ["derive"] }
 srtemplate = "0.3.3"
 serde_urlencoded = "0.7.1"
 toml = "0.8.23"
-tokio = { version = "1.47.1", features = ["rt", "macros", "sync"] }
-url = "2.5.6"
+tokio = { version = "1.49.0", features = ["rt", "macros", "sync"] }
+url = "2.5.8"
 
 [package]
 name = "cartero"
@@ -54,7 +54,7 @@ app_updater = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-adw = { version = "0.8.0", package = "libadwaita", features = ["v1_5"] }
+adw = { version = "0.8.1", package = "libadwaita", features = ["v1_5"] }
 base64.workspace = true
 cartero_http = { path = "crates/cartero-http" }
 cartero_interop = { path = "crates/cartero-interop" }
@@ -65,12 +65,12 @@ cartero_file_format = { path = "crates/cartero-file-format" }
 formatx = "0.2.4"
 formdata.workspace = true
 futures-lite.workspace = true
-gettext-rs = { version = "0.7.2", features = ["gettext-system"] }
+gettext-rs = { version = "0.7.7", features = ["gettext-system"] }
 glib.workspace = true
-gtk = { package = "gtk4", version = "0.10.0", features = ["v4_14"] }
+gtk = { package = "gtk4", version = "0.10.3", features = ["v4_14"] }
 indexmap.workspace = true
 serde.workspace = true
-serde_json = { version = "1.0.143", features = ["preserve_order"] }
+serde_json = { version = "1.0.149", features = ["preserve_order"] }
 serde_urlencoded.workspace = true
 sourceview5 = { version = "0.10.0", features = ["v5_12"]}
 srtemplate.workspace = true
@@ -81,14 +81,14 @@ addr = "0.15.6"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.9", features = ["dwmapi", "winnt", "sysinfoapi"] }
-windows-sys = { version = "0.60.2", features = [
+windows-sys = { version = "0.61.2", features = [
     "Wdk",
     "Wdk_System",
     "Wdk_System_SystemServices",
     "Win32_System_SystemInformation",
 ]}
 winreg = "0.55"
-gdk4-win32 = '0.10.0'
+gdk4-win32 = '0.10.3'
 
 [build-dependencies]
-winresource = "0.1.23"
+winresource = "0.1.30"

--- a/NEWS.d/26.1/changed
+++ b/NEWS.d/26.1/changed
@@ -1,0 +1,2 @@
+- Updated Rust project dependencies.
+- Updated codebase Rust edition to Rust 2024.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ These are the user-visible changes noticeable within Cartero.
 
 ## [26.1] - unreleased
 
+### Changed
+
+- - Updated Rust project dependencies.
+- - Updated codebase Rust edition to Rust 2024.
+
 ## [26.0] - 2026-01-25
 
 ### Added

--- a/crates/cartero-code-exporters/src/plain.rs
+++ b/crates/cartero-code-exporters/src/plain.rs
@@ -32,7 +32,7 @@ use crate::ExportError;
 #[derive(Eq, PartialEq, Clone)]
 pub(crate) enum Auth {
     None,
-    BasicAuth { username: String, password: String },
+    Basic { username: String, password: String },
     BearerToken { token: String },
 }
 
@@ -191,7 +191,7 @@ impl From<RequestAuthenticationData> for Auth {
                 let basic = value
                     .downcast::<RequestAuthenticationBasic>()
                     .expect("No basic?");
-                Self::BasicAuth {
+                Self::Basic {
                     username: basic.username(),
                     password: basic.password(),
                 }

--- a/crates/cartero-code-exporters/templates/curl.j2
+++ b/crates/cartero-code-exporters/templates/curl.j2
@@ -5,7 +5,7 @@ curl -X {{ request.method }} '{{ request.url }}'
 {%- if let Some(auth) = request.auth -%}
 {{- " \\\n" -}}
 {%- match auth -%}
-{%- when Auth::BasicAuth { username, password } %}    --basic -u '{{ username }}:{{ password }}'
+{%- when Auth::Basic { username, password } %}    --basic -u '{{ username }}:{{ password }}'
 {%- when Auth::BearerToken { token } %}    --oauth2-bearer '{{ token }}'
 {%- when _ -%}
 {%- endmatch -%}

--- a/crates/cartero-code-exporters/templates/ijhttp.j2
+++ b/crates/cartero-code-exporters/templates/ijhttp.j2
@@ -3,7 +3,7 @@
   {{ "\n" }}{{ key }}: {{ value }}
 {%- endfor -%}
 {%- match request.auth -%}
-  {%- when Some(Auth::BasicAuth { username, password }) -%}
+  {%- when Some(Auth::Basic { username, password }) -%}
     {{ "\n" }}Authorization: Basic {{ username }} {{ password }}
   {%- when Some(Auth::BearerToken { token }) -%}
     {{ "\n" }}Authorization: Bearer {{ token }}

--- a/crates/cartero-code-exporters/tests/test_exporters.rs
+++ b/crates/cartero-code-exporters/tests/test_exporters.rs
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use cartero_code_exporters::{export_request, Format};
+use cartero_code_exporters::{Format, export_request};
 
 macro_rules! test_suites {
     (

--- a/crates/cartero-file-format/src/field_table_value.rs
+++ b/crates/cartero-file-format/src/field_table_value.rs
@@ -208,15 +208,21 @@ mod tests {
         let value = FieldTable::from(table);
         assert_eq!(3, value.n_items());
 
-        assert!(value
-            .iter::<Field>()
-            .any(|f| f.is_ok_and(|f| f.key() == "Content-Type" && f.value() == "text/html")));
-        assert!(value
-            .iter::<Field>()
-            .any(|f| f.is_ok_and(|f| f.key() == "Cookie" && f.value() == "admin=1234")));
-        assert!(value
-            .iter::<Field>()
-            .any(|f| f.is_ok_and(|f| f.key() == "Cookie" && f.value() == "session=2345")));
+        assert!(
+            value
+                .iter::<Field>()
+                .any(|f| f.is_ok_and(|f| f.key() == "Content-Type" && f.value() == "text/html"))
+        );
+        assert!(
+            value
+                .iter::<Field>()
+                .any(|f| f.is_ok_and(|f| f.key() == "Cookie" && f.value() == "admin=1234"))
+        );
+        assert!(
+            value
+                .iter::<Field>()
+                .any(|f| f.is_ok_and(|f| f.key() == "Cookie" && f.value() == "session=2345"))
+        );
     }
 
     #[test]

--- a/crates/cartero-file-format/src/payload_value.rs
+++ b/crates/cartero-file-format/src/payload_value.rs
@@ -105,13 +105,9 @@ impl From<RequestBody> for PayloadValue {
             }
             RequestBodyType::File => {
                 let file = value.file().unwrap();
-                let content_type = file.content_type().and_then(|ct| {
-                    if ct.trim().is_empty() {
-                        None
-                    } else {
-                        Some(ct)
-                    }
-                });
+                let content_type = file
+                    .content_type()
+                    .and_then(|ct| if ct.trim().is_empty() { None } else { Some(ct) });
                 Self::File {
                     path: file.path(),
                     content_type,
@@ -192,12 +188,16 @@ mod tests {
 
         let body_params = body.params();
         assert_eq!(2, body_params.n_items());
-        assert!(body_params
-            .iter::<Field>()
-            .any(|f| f.is_ok_and(|f| f.key() == "group_id" && f.value() == "200")));
-        assert!(body_params
-            .iter::<Field>()
-            .any(|f| f.is_ok_and(|f| f.key() == "user_id" && f.value() == "1234")));
+        assert!(
+            body_params
+                .iter::<Field>()
+                .any(|f| f.is_ok_and(|f| f.key() == "group_id" && f.value() == "200"))
+        );
+        assert!(
+            body_params
+                .iter::<Field>()
+                .any(|f| f.is_ok_and(|f| f.key() == "user_id" && f.value() == "1234"))
+        );
     }
 
     #[test]
@@ -300,12 +300,16 @@ mod tests {
 
         let body_params = body.params();
         assert_eq!(2, body_params.n_items());
-        assert!(body_params
-            .iter::<Field>()
-            .any(|f| f.is_ok_and(|f| f.key() == "group_id" && f.value() == "200")));
-        assert!(body_params
-            .iter::<Field>()
-            .any(|f| f.is_ok_and(|f| f.key() == "user_id" && f.value() == "1234")));
+        assert!(
+            body_params
+                .iter::<Field>()
+                .any(|f| f.is_ok_and(|f| f.key() == "group_id" && f.value() == "200"))
+        );
+        assert!(
+            body_params
+                .iter::<Field>()
+                .any(|f| f.is_ok_and(|f| f.key() == "user_id" && f.value() == "1234"))
+        );
     }
 
     #[test]

--- a/crates/cartero-file-format/src/request_value.rs
+++ b/crates/cartero-file-format/src/request_value.rs
@@ -149,10 +149,7 @@ impl From<Request> for RequestValue {
         };
         let authorization = match value.authentication().auth_type() {
             cartero_objects::RequestAuthenticationType::None => None,
-            _ => match AuthorizationValue::try_from(value.authentication()) {
-                Ok(result) => Some(result),
-                Err(_) => None,
-            },
+            _ => AuthorizationValue::try_from(value.authentication()).ok(),
         };
 
         let inactive_params = value

--- a/crates/cartero-file-format/src/serializer.rs
+++ b/crates/cartero-file-format/src/serializer.rs
@@ -19,11 +19,11 @@ use cartero_interop::FileSaveError;
 use cartero_objects::Field;
 use serde::{Serialize, Serializer};
 use toml_edit::{
-    visit_mut::{self, VisitMut},
     InlineTable, Item, KeyMut, Value,
+    visit_mut::{self, VisitMut},
 };
 
-use crate::{field_table_value::FieldTableValue, ToField};
+use crate::{ToField, field_table_value::FieldTableValue};
 
 pub(crate) fn alphabetical_field_table<T, S>(
     field_table: &Option<FieldTableValue<T>>,

--- a/crates/cartero-http/src/body.rs
+++ b/crates/cartero-http/src/body.rs
@@ -23,7 +23,7 @@ use std::{
 use cartero_objects::{Request, RequestBodyDataExt, RequestBodyType};
 use gio::prelude::FileExt;
 
-use crate::{active_pairs, RequestEnvironment, RequestError};
+use crate::{RequestEnvironment, RequestError, active_pairs};
 
 #[derive(Default)]
 pub(crate) struct BoundBody {
@@ -250,9 +250,11 @@ mod tests {
         assert_eq!(1, result.headers.len());
         assert_eq!("Content-Type", result.headers[0].0);
 
-        assert!(result.headers[0]
-            .1
-            .starts_with("multipart/form-data; boundary="));
+        assert!(
+            result.headers[0]
+                .1
+                .starts_with("multipart/form-data; boundary=")
+        );
         let boundary = result.headers[0]
             .1
             .replace("multipart/form-data; boundary=", "");
@@ -307,9 +309,11 @@ mod tests {
         assert_eq!(1, result.headers.len());
         assert_eq!("Content-Type", result.headers[0].0);
 
-        assert!(result.headers[0]
-            .1
-            .starts_with("multipart/form-data; boundary="));
+        assert!(
+            result.headers[0]
+                .1
+                .starts_with("multipart/form-data; boundary=")
+        );
         let boundary = result.headers[0]
             .1
             .replace("multipart/form-data; boundary=", "");

--- a/crates/cartero-http/src/request.rs
+++ b/crates/cartero-http/src/request.rs
@@ -20,8 +20,8 @@ use std::collections::HashMap;
 use cartero_objects::{FieldTable, Request, RequestMethod};
 
 use crate::{
-    active_pairs, auth::BoundHeaders, body::BoundBody, url::normalize_url, RequestEnvironment,
-    RequestError,
+    RequestEnvironment, RequestError, active_pairs, auth::BoundHeaders, body::BoundBody,
+    url::normalize_url,
 };
 
 pub struct BoundRequest {

--- a/crates/cartero-http/src/url.rs
+++ b/crates/cartero-http/src/url.rs
@@ -38,7 +38,7 @@ pub(crate) fn normalize_url(url: &str) -> Result<String, RequestError> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{url::normalize_url, RequestError};
+    use crate::{RequestError, url::normalize_url};
 
     #[test]
     pub fn test_url_normalization() {

--- a/crates/cartero-isahc-client/src/lib.rs
+++ b/crates/cartero-isahc-client/src/lib.rs
@@ -23,9 +23,9 @@ use std::time::{Duration, Instant};
 use cartero_http::{BoundRequest, RequestEnvironment, RequestError};
 use cartero_objects::{Field, FieldTable, Request, RequestMethod, Response};
 use isahc::{
+    AsyncBody, RequestExt, ResponseExt,
     config::{Configurable, RedirectPolicy, SslOption},
     http::{HeaderName, HeaderValue, Uri},
-    AsyncBody, RequestExt, ResponseExt,
 };
 
 pub fn default_user_agent() -> String {

--- a/crates/cartero-isahc-client/src/lib.rs
+++ b/crates/cartero-isahc-client/src/lib.rs
@@ -118,7 +118,7 @@ async fn build_request(
     let request_timeout = Duration::from_secs_f64(env.config.timeout);
 
     // Build the request entity.
-    let bound_request = BoundRequest::new(&request, &env).await?;
+    let bound_request = BoundRequest::new(request, env).await?;
 
     let builder = isahc::Request::builder()
         .uri(bound_request.url.clone())

--- a/crates/cartero-objects/src/env_file.rs
+++ b/crates/cartero-objects/src/env_file.rs
@@ -43,15 +43,16 @@ impl EnvFile {
     }
 
     pub fn locate_for_path(file: &gio::File) -> Option<gio::File> {
-        if let Some(parent) = file.parent() {
-            let env = parent.child(".env");
-            if env.query_exists(gio::Cancellable::NONE) {
-                return Some(env);
-            } else {
-                return Self::locate_for_path(&parent);
+        match file.parent() {
+            Some(parent) => {
+                let env = parent.child(".env");
+                if env.query_exists(gio::Cancellable::NONE) {
+                    return Some(env);
+                } else {
+                    return Self::locate_for_path(&parent);
+                }
             }
-        } else {
-            None
+            _ => None,
         }
     }
 }
@@ -90,7 +91,7 @@ mod imp {
         prelude::{FileExt, FileMonitorExt, ListModelExt},
         subclass::prelude::ListModelImpl,
     };
-    use glib::{property::PropertySet, Properties, SignalHandlerId};
+    use glib::{Properties, SignalHandlerId, property::PropertySet};
 
     use crate::{Field, FieldTable};
 

--- a/crates/cartero-objects/src/env_file.rs
+++ b/crates/cartero-objects/src/env_file.rs
@@ -47,9 +47,9 @@ impl EnvFile {
             Some(parent) => {
                 let env = parent.child(".env");
                 if env.query_exists(gio::Cancellable::NONE) {
-                    return Some(env);
+                    Some(env)
                 } else {
-                    return Self::locate_for_path(&parent);
+                    Self::locate_for_path(&parent)
                 }
             }
             _ => None,
@@ -64,6 +64,12 @@ mod builder {
 
     pub struct EnvFileBuilder {
         builder: ObjectBuilder<'static, EnvFile>,
+    }
+
+    impl Default for EnvFileBuilder {
+        fn default() -> Self {
+            Self::new()
+        }
     }
 
     impl EnvFileBuilder {
@@ -142,10 +148,10 @@ mod imp {
     impl EnvFile {
         fn set_monitor(&self) {
             // Disconnect the old monitor if one is present.
-            if let Some(old_monitor_handler) = self.monitor_handler.replace(None) {
-                if let Some(old_monitor) = &*self.monitor.borrow() {
-                    old_monitor.disconnect(old_monitor_handler);
-                }
+            if let Some(old_monitor_handler) = self.monitor_handler.replace(None)
+                && let Some(old_monitor) = &*self.monitor.borrow()
+            {
+                old_monitor.disconnect(old_monitor_handler);
             }
 
             let next_monitor = match self.obj().file() {
@@ -160,7 +166,7 @@ mod imp {
                             self,
                             move |_, file, _, event_type| {
                                 dbg!(event_type);
-                                imp.reload_env(&file);
+                                imp.reload_env(file);
                             }
                         ));
                     }

--- a/crates/cartero-objects/src/field.rs
+++ b/crates/cartero-objects/src/field.rs
@@ -72,8 +72,8 @@ impl Field {
 
     pub fn dup(&self) -> Self {
         builder::FieldBuilder::default()
-            .key(self.key().to_string())
-            .value(self.value().to_string())
+            .key(self.key())
+            .value(self.value())
             .active(self.active())
             .masked(self.masked())
             .build()

--- a/crates/cartero-objects/src/field.rs
+++ b/crates/cartero-objects/src/field.rs
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use glib::subclass::prelude::*;
-use glib::{prelude::*, Object};
+use glib::{Object, prelude::*};
 
 glib::wrapper! {
     /// A key-valued string container with additional metadata.
@@ -102,7 +102,7 @@ mod imp {
     use std::{cell::RefCell, sync::OnceLock};
 
     use super::*;
-    use glib::{subclass::Signal, Properties};
+    use glib::{Properties, subclass::Signal};
 
     #[derive(Properties)]
     #[properties(wrapper_type = super::Field)]
@@ -159,9 +159,11 @@ mod imp {
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
-                vec![Signal::builder("changed")
-                    .param_types([String::static_type()])
-                    .build()]
+                vec![
+                    Signal::builder("changed")
+                        .param_types([String::static_type()])
+                        .build(),
+                ]
             })
         }
     }

--- a/crates/cartero-objects/src/field_table.rs
+++ b/crates/cartero-objects/src/field_table.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 
 use gio::prelude::{ListModelExt, ListModelExtManual};
 use glib::subclass::prelude::*;
-use glib::{prelude::*, Object};
+use glib::{Object, prelude::*};
 use itertools::{EitherOrBoth, Itertools};
 use srtemplate::SrTemplate;
 
@@ -484,7 +484,7 @@ impl FromIterator<Field> for FieldTable {
 
 mod imp {
     use gio::subclass::prelude::ListModelImpl;
-    use glib::{subclass::Signal, SignalHandlerId};
+    use glib::{SignalHandlerId, subclass::Signal};
 
     use super::*;
     use std::{cell::RefCell, sync::OnceLock};
@@ -507,9 +507,11 @@ mod imp {
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
-                vec![Signal::builder("changed")
-                    .param_types([String::static_type()])
-                    .build()]
+                vec![
+                    Signal::builder("changed")
+                        .param_types([String::static_type()])
+                        .build(),
+                ]
             })
         }
     }
@@ -1122,11 +1124,13 @@ mod tests {
 
     #[test]
     fn test_template_processor_deactivated_variable() {
-        let table = FieldTable::from_iter(vec![Field::builder()
-            .key("API_ROOT")
-            .value("http://localhost:8000")
-            .active(false)
-            .build()]);
+        let table = FieldTable::from_iter(vec![
+            Field::builder()
+                .key("API_ROOT")
+                .value("http://localhost:8000")
+                .active(false)
+                .build(),
+        ]);
 
         let processor = table.template_processor();
         assert!(!processor.contains_variable("API_ROOT"));
@@ -1236,10 +1240,12 @@ mod tests {
     fn test_render_with_invalid_variables() {
         let template = SrTemplate::default();
 
-        let table = FieldTable::from_iter(vec![Field::builder()
-            .key("Location")
-            .value("{{ API_ROOT }}/v1/users")
-            .build()]);
+        let table = FieldTable::from_iter(vec![
+            Field::builder()
+                .key("Location")
+                .value("{{ API_ROOT }}/v1/users")
+                .build(),
+        ]);
         let render_table = table.render(&template);
         let Err(srtemplate::Error::VariableNotFound(var)) = render_table else {
             panic!("expected err");

--- a/crates/cartero-objects/src/field_table.rs
+++ b/crates/cartero-objects/src/field_table.rs
@@ -134,10 +134,10 @@ impl FieldTable {
     /// upwards from this table.
     fn disconnect_signal(&self, field: &Field) {
         let mut signals = self.imp().signals.borrow_mut();
-        if let Some(handler) = signals.remove(field) {
-            if let Some(signal) = handler {
-                field.disconnect(signal);
-            }
+        if let Some(handler) = signals.remove(field)
+            && let Some(signal) = handler
+        {
+            field.disconnect(signal);
         }
     }
 

--- a/crates/cartero-objects/src/request.rs
+++ b/crates/cartero-objects/src/request.rs
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use glib::subclass::prelude::*;
-use glib::{prelude::*, Object};
+use glib::{Object, prelude::*};
 use srtemplate::SrTemplate;
 
 use crate::RequestMethod;
@@ -112,9 +112,9 @@ mod imp {
         sync::OnceLock,
     };
 
-    use glib::{subclass::Signal, Properties, SignalGroup};
+    use glib::{Properties, SignalGroup, subclass::Signal};
 
-    use crate::{field_table::FieldTable, RequestAuthentication, RequestBody, RequestMethod};
+    use crate::{RequestAuthentication, RequestBody, RequestMethod, field_table::FieldTable};
 
     use super::*;
 
@@ -253,9 +253,11 @@ mod imp {
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
-                vec![Signal::builder("changed")
-                    .param_types([String::static_type()])
-                    .build()]
+                vec![
+                    Signal::builder("changed")
+                        .param_types([String::static_type()])
+                        .build(),
+                ]
             })
         }
     }
@@ -438,9 +440,9 @@ mod tests {
     use gio::prelude::ListModelExt;
 
     use crate::{
-        utils::test::assert_emits_signal, Field, FieldTable, RequestAuthentication,
-        RequestAuthenticationBearer, RequestAuthenticationType, RequestBody, RequestBodyRaw,
-        RequestBodyRawType, RequestBodyType,
+        Field, FieldTable, RequestAuthentication, RequestAuthenticationBearer,
+        RequestAuthenticationType, RequestBody, RequestBodyRaw, RequestBodyRawType,
+        RequestBodyType, utils::test::assert_emits_signal,
     };
 
     use super::*;

--- a/crates/cartero-objects/src/request_authentication.rs
+++ b/crates/cartero-objects/src/request_authentication.rs
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use glib::subclass::prelude::*;
-use glib::{prelude::*, Object};
+use glib::{Object, prelude::*};
 use srtemplate::SrTemplate;
 
 use crate::{
@@ -317,7 +317,7 @@ mod imp {
         sync::OnceLock,
     };
 
-    use glib::{subclass::Signal, Properties, SignalGroup};
+    use glib::{Properties, SignalGroup, subclass::Signal};
 
     use crate::RequestAuthenticationData;
 
@@ -365,9 +365,11 @@ mod imp {
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
-                vec![Signal::builder("changed")
-                    .param_types([String::static_type()])
-                    .build()]
+                vec![
+                    Signal::builder("changed")
+                        .param_types([String::static_type()])
+                        .build(),
+                ]
             })
         }
     }
@@ -415,7 +417,10 @@ mod imp {
                 self.obj().notify_auth_data();
             } else {
                 #[cfg(not(test))]
-                glib::g_critical!("Cartero", "set_auth_data() was called with a RequestAuthenticationData of invalid RequestAuthenticationType for this RequestAuthentication object");
+                glib::g_critical!(
+                    "Cartero",
+                    "set_auth_data() was called with a RequestAuthenticationData of invalid RequestAuthenticationType for this RequestAuthentication object"
+                );
             }
         }
     }
@@ -476,8 +481,8 @@ mod builder {
 #[cfg(test)]
 mod tests {
     use crate::{
-        utils::test::{assert_emits_signal, assert_emits_signals, assert_not_emits_signal},
         RequestAuthenticationDataExt,
+        utils::test::{assert_emits_signal, assert_emits_signals, assert_not_emits_signal},
     };
 
     use super::*;
@@ -641,9 +646,11 @@ mod tests {
             RequestAuthenticationType::BasicAuth,
             RequestAuthenticationData::NONE,
         );
-        assert!(authentication
-            .auth_data()
-            .is_some_and(|data| data.auth_type() == RequestAuthenticationType::BasicAuth));
+        assert!(
+            authentication
+                .auth_data()
+                .is_some_and(|data| data.auth_type() == RequestAuthenticationType::BasicAuth)
+        );
         assert_emits_signals(
             &authentication,
             &["notify::auth-type", "notify::auth-data"],
@@ -651,9 +658,11 @@ mod tests {
                 authentication.set_auth_type(RequestAuthenticationType::BearerToken);
             },
         );
-        assert!(authentication
-            .auth_data()
-            .is_some_and(|data| data.auth_type() == RequestAuthenticationType::BearerToken));
+        assert!(
+            authentication
+                .auth_data()
+                .is_some_and(|data| data.auth_type() == RequestAuthenticationType::BearerToken)
+        );
     }
 
     #[test]

--- a/crates/cartero-objects/src/request_authentication.rs
+++ b/crates/cartero-objects/src/request_authentication.rs
@@ -400,7 +400,7 @@ mod imp {
         fn set_auth_type(&self, auth_type: RequestAuthenticationType) {
             let next = default_authentication_data(auth_type);
 
-            let current_type = { self.auth_type.borrow().clone() };
+            let current_type = { *self.auth_type.borrow() };
             if current_type != auth_type {
                 self.auth_type.replace(auth_type);
                 self.obj().set_auth_data(next);

--- a/crates/cartero-objects/src/request_authentication_basic.rs
+++ b/crates/cartero-objects/src/request_authentication_basic.rs
@@ -106,8 +106,8 @@ mod imp {
     impl RequestAuthenticationDataImpl for RequestAuthenticationBasic {
         fn dup(&self) -> crate::RequestAuthenticationData {
             super::RequestAuthenticationBasic::builder()
-                .username(self.obj().username().to_string())
-                .password(self.obj().password().to_string())
+                .username(self.obj().username())
+                .password(self.obj().password())
                 .build()
                 .upcast()
         }

--- a/crates/cartero-objects/src/request_authentication_basic.rs
+++ b/crates/cartero-objects/src/request_authentication_basic.rs
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use glib::subclass::prelude::*;
-use glib::{prelude::*, Object};
+use glib::{Object, prelude::*};
 
 glib::wrapper! {
     /// Authentication type based on the RFC 7617 spec.
@@ -65,7 +65,7 @@ impl RequestAuthenticationBasic {
 mod imp {
     use std::cell::RefCell;
 
-    use base64::{prelude::BASE64_STANDARD, Engine};
+    use base64::{Engine, prelude::BASE64_STANDARD};
     use glib::Properties;
 
     use crate::RequestAuthenticationDataImpl;
@@ -184,7 +184,7 @@ mod tests {
     use srtemplate::SrTemplate;
 
     use crate::{
-        utils::test::assert_emits_signal, RequestAuthenticationDataExt, RequestAuthenticationType,
+        RequestAuthenticationDataExt, RequestAuthenticationType, utils::test::assert_emits_signal,
     };
 
     use super::*;

--- a/crates/cartero-objects/src/request_authentication_bearer.rs
+++ b/crates/cartero-objects/src/request_authentication_bearer.rs
@@ -96,7 +96,7 @@ mod imp {
     impl RequestAuthenticationDataImpl for RequestAuthenticationBearer {
         fn dup(&self) -> crate::RequestAuthenticationData {
             super::RequestAuthenticationBearer::builder()
-                .token(self.obj().token().to_string())
+                .token(self.obj().token())
                 .build()
                 .upcast()
         }

--- a/crates/cartero-objects/src/request_authentication_bearer.rs
+++ b/crates/cartero-objects/src/request_authentication_bearer.rs
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use glib::subclass::prelude::*;
-use glib::{prelude::*, Object};
+use glib::{Object, prelude::*};
 
 glib::wrapper! {
     /// Authentication type based on the RFC 6750 spec.
@@ -160,7 +160,7 @@ mod tests {
     use srtemplate::SrTemplate;
 
     use crate::{
-        utils::test::assert_emits_signal, RequestAuthenticationDataExt, RequestAuthenticationType,
+        RequestAuthenticationDataExt, RequestAuthenticationType, utils::test::assert_emits_signal,
     };
 
     use super::*;

--- a/crates/cartero-objects/src/request_authentication_data.rs
+++ b/crates/cartero-objects/src/request_authentication_data.rs
@@ -105,9 +105,11 @@ mod imp {
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
-                vec![Signal::builder("changed")
-                    .param_types([String::static_type()])
-                    .build()]
+                vec![
+                    Signal::builder("changed")
+                        .param_types([String::static_type()])
+                        .build(),
+                ]
             })
         }
     }
@@ -193,14 +195,14 @@ pub trait RequestAuthenticationDataImplExt: RequestAuthenticationDataImpl {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let dup = parent_class.dup;
-        dup(unsafe { self.obj().unsafe_cast_ref() })
+        unsafe { dup(self.obj().unsafe_cast_ref()) }
     }
 
     fn parent_auth_type(&self) -> RequestAuthenticationType {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let auth_type = parent_class.auth_type;
-        auth_type(unsafe { self.obj().unsafe_cast_ref() })
+        unsafe { auth_type(self.obj().unsafe_cast_ref()) }
     }
 
     fn parent_resolve(
@@ -210,14 +212,14 @@ pub trait RequestAuthenticationDataImplExt: RequestAuthenticationDataImpl {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let resolve = parent_class.resolve;
-        resolve(unsafe { self.obj().unsafe_cast_ref() }, tpl)
+        unsafe { resolve(self.obj().unsafe_cast_ref(), tpl) }
     }
 
     fn parent_rendered_headers(&self) -> Vec<(String, String)> {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let rendered_headers = parent_class.rendered_headers;
-        rendered_headers(unsafe { self.obj().unsafe_cast_ref() })
+        unsafe { rendered_headers(self.obj().unsafe_cast_ref()) }
     }
 }
 

--- a/crates/cartero-objects/src/request_body.rs
+++ b/crates/cartero-objects/src/request_body.rs
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use glib::subclass::prelude::*;
-use glib::{prelude::*, Object};
+use glib::{Object, prelude::*};
 use srtemplate::SrTemplate;
 
 use crate::{
@@ -358,7 +358,7 @@ mod imp {
         sync::OnceLock,
     };
 
-    use glib::{subclass::Signal, Properties, SignalGroup};
+    use glib::{Properties, SignalGroup, subclass::Signal};
 
     use crate::{RequestBodyData, RequestBodyDataExt};
 
@@ -406,9 +406,11 @@ mod imp {
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
-                vec![Signal::builder("changed")
-                    .param_types([String::static_type()])
-                    .build()]
+                vec![
+                    Signal::builder("changed")
+                        .param_types([String::static_type()])
+                        .build(),
+                ]
             })
         }
     }
@@ -456,7 +458,10 @@ mod imp {
                 self.obj().notify_body_data();
             } else {
                 #[cfg(not(test))]
-                glib::g_critical!("Cartero", "set_body_data() was called with a RequestBodyData of invalid RequestBodyType for this RequestBody object");
+                glib::g_critical!(
+                    "Cartero",
+                    "set_body_data() was called with a RequestBodyData of invalid RequestBodyType for this RequestBody object"
+                );
             }
         }
     }
@@ -469,10 +474,10 @@ mod tests {
     use srtemplate::SrTemplate;
 
     use crate::{
-        utils::test::{assert_emits_signal, assert_emits_signals, assert_not_emits_signal},
         Field, FieldTable, RequestBodyData, RequestBodyDataExt, RequestBodyFile,
         RequestBodyMultipart, RequestBodyRaw, RequestBodyRawType, RequestBodyType,
         RequestBodyUrlencoded,
+        utils::test::{assert_emits_signal, assert_emits_signals, assert_not_emits_signal},
     };
 
     use super::RequestBody;
@@ -582,15 +587,17 @@ mod tests {
     #[test]
     pub fn set_body_type_changes_data_type() {
         let body = RequestBody::new(RequestBodyType::UrlEncoded, RequestBodyData::NONE);
-        assert!(body
-            .body_data()
-            .is_some_and(|data| data.body_type() == RequestBodyType::UrlEncoded));
+        assert!(
+            body.body_data()
+                .is_some_and(|data| data.body_type() == RequestBodyType::UrlEncoded)
+        );
         assert_emits_signals(&body, &["notify::body-type", "notify::body-data"], || {
             body.set_body_type(RequestBodyType::Multipart)
         });
-        assert!(body
-            .body_data()
-            .is_some_and(|data| data.body_type() == RequestBodyType::Multipart));
+        assert!(
+            body.body_data()
+                .is_some_and(|data| data.body_type() == RequestBodyType::Multipart)
+        );
     }
 
     #[test]

--- a/crates/cartero-objects/src/request_body_data.rs
+++ b/crates/cartero-objects/src/request_body_data.rs
@@ -103,9 +103,11 @@ mod imp {
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
-                vec![Signal::builder("changed")
-                    .param_types([String::static_type()])
-                    .build()]
+                vec![
+                    Signal::builder("changed")
+                        .param_types([String::static_type()])
+                        .build(),
+                ]
             })
         }
     }
@@ -184,28 +186,28 @@ pub trait RequestBodyDataImplExt: RequestBodyDataImpl {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let dup = parent_class.dup;
-        dup(unsafe { self.obj().unsafe_cast_ref() })
+        unsafe { dup(self.obj().unsafe_cast_ref()) }
     }
 
     fn parent_body_type(&self) -> RequestBodyType {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let body_type = parent_class.body_type;
-        body_type(unsafe { self.obj().unsafe_cast_ref() })
+        unsafe { body_type(self.obj().unsafe_cast_ref()) }
     }
 
     fn resolve(&self, tpl: &SrTemplate) -> Result<RequestBodyData, srtemplate::Error> {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let resolve = parent_class.resolve;
-        resolve(unsafe { self.obj().unsafe_cast_ref() }, tpl)
+        unsafe { resolve(self.obj().unsafe_cast_ref(), tpl) }
     }
 
     fn parent_rendered_headers(&self) -> Vec<(String, String)> {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let rendered_headers = parent_class.rendered_headers;
-        rendered_headers(unsafe { self.obj().unsafe_cast_ref() })
+        unsafe { rendered_headers(self.obj().unsafe_cast_ref()) }
     }
 }
 

--- a/crates/cartero-objects/src/request_body_file.rs
+++ b/crates/cartero-objects/src/request_body_file.rs
@@ -15,9 +15,9 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use glib::Object;
 use glib::prelude::*;
 use glib::subclass::prelude::*;
-use glib::Object;
 
 glib::wrapper! {
     /// Body payload that is read from a file.
@@ -180,7 +180,7 @@ mod builder {
 mod tests {
     use srtemplate::SrTemplate;
 
-    use crate::{utils::test::assert_emits_signal, RequestBodyDataExt};
+    use crate::{RequestBodyDataExt, utils::test::assert_emits_signal};
 
     use super::*;
 
@@ -253,9 +253,11 @@ mod tests {
             .content_type(Some("application/xml"))
             .build();
         assert_eq!(request_body.path(), "./assets/report.xml");
-        assert!(request_body
-            .content_type()
-            .is_some_and(|content_type| content_type == "application/xml"));
+        assert!(
+            request_body
+                .content_type()
+                .is_some_and(|content_type| content_type == "application/xml")
+        );
     }
 
     #[test]

--- a/crates/cartero-objects/src/request_body_file.rs
+++ b/crates/cartero-objects/src/request_body_file.rs
@@ -118,7 +118,7 @@ mod imp {
             &self,
             tpl: &srtemplate::SrTemplate,
         ) -> Result<RequestBodyData, srtemplate::Error> {
-            let path = tpl.render(&self.obj().path())?;
+            let path = tpl.render(self.obj().path())?;
             let content_type = self
                 .obj()
                 .content_type()
@@ -148,6 +148,12 @@ mod builder {
 
     pub struct RequestBodyFileBuilder {
         builder: ObjectBuilder<'static, RequestBodyFile>,
+    }
+
+    impl Default for RequestBodyFileBuilder {
+        fn default() -> Self {
+            Self::new()
+        }
     }
 
     impl RequestBodyFileBuilder {

--- a/crates/cartero-objects/src/request_body_multipart.rs
+++ b/crates/cartero-objects/src/request_body_multipart.rs
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use glib::subclass::prelude::*;
-use glib::{prelude::*, Object};
+use glib::{Object, prelude::*};
 
 use crate::FieldTable;
 
@@ -221,7 +221,7 @@ mod tests {
     use srtemplate::SrTemplate;
 
     use crate::{
-        utils::test::assert_emits_signal, Field, FieldTable, RequestBodyDataExt, RequestBodyType,
+        Field, FieldTable, RequestBodyDataExt, RequestBodyType, utils::test::assert_emits_signal,
     };
 
     use super::RequestBodyMultipart;

--- a/crates/cartero-objects/src/request_body_multipart.rs
+++ b/crates/cartero-objects/src/request_body_multipart.rs
@@ -136,7 +136,7 @@ mod imp {
             &self,
             tpl: &srtemplate::SrTemplate,
         ) -> Result<RequestBodyData, srtemplate::Error> {
-            let params = self.obj().params().render(&tpl)?;
+            let params = self.obj().params().render(tpl)?;
             Ok(super::RequestBodyMultipart::builder()
                 .params(&params)
                 .build()

--- a/crates/cartero-objects/src/request_body_raw.rs
+++ b/crates/cartero-objects/src/request_body_raw.rs
@@ -148,7 +148,7 @@ mod imp {
     impl RequestBodyDataImpl for RequestBodyRaw {
         fn dup(&self) -> RequestBodyData {
             super::RequestBodyRaw::builder(self.obj().payload_type())
-                .payload(self.obj().payload().to_string())
+                .payload(self.obj().payload())
                 .build()
                 .upcast()
         }
@@ -161,7 +161,7 @@ mod imp {
             &self,
             tpl: &srtemplate::SrTemplate,
         ) -> Result<RequestBodyData, srtemplate::Error> {
-            let payload = tpl.render(&self.obj().payload())?;
+            let payload = tpl.render(self.obj().payload())?;
             let payload_type = self.obj().payload_type();
             Ok(super::RequestBodyRaw::builder(payload_type)
                 .payload(payload)

--- a/crates/cartero-objects/src/request_body_raw.rs
+++ b/crates/cartero-objects/src/request_body_raw.rs
@@ -15,9 +15,9 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use glib::Object;
 use glib::prelude::*;
 use glib::subclass::prelude::*;
-use glib::Object;
 
 glib::wrapper! {
     /// Body payload with the request body encoded as provided.
@@ -213,7 +213,7 @@ mod tests {
     use srtemplate::SrTemplate;
 
     use crate::{
-        utils::test::assert_emits_signal, RequestBodyDataExt, RequestBodyRawType, RequestBodyType,
+        RequestBodyDataExt, RequestBodyRawType, RequestBodyType, utils::test::assert_emits_signal,
     };
 
     use super::RequestBodyRaw;

--- a/crates/cartero-objects/src/request_body_urlencoded.rs
+++ b/crates/cartero-objects/src/request_body_urlencoded.rs
@@ -16,7 +16,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use glib::subclass::prelude::*;
-use glib::{prelude::*, Object};
+use glib::{Object, prelude::*};
 
 use crate::FieldTable;
 
@@ -216,7 +216,7 @@ mod tests {
     use srtemplate::SrTemplate;
 
     use crate::{
-        utils::test::assert_emits_signal, Field, FieldTable, RequestBodyDataExt, RequestBodyType,
+        Field, FieldTable, RequestBodyDataExt, RequestBodyType, utils::test::assert_emits_signal,
     };
 
     use super::RequestBodyUrlencoded;

--- a/crates/cartero-objects/src/request_body_urlencoded.rs
+++ b/crates/cartero-objects/src/request_body_urlencoded.rs
@@ -131,7 +131,7 @@ mod imp {
             &self,
             tpl: &srtemplate::SrTemplate,
         ) -> Result<RequestBodyData, srtemplate::Error> {
-            let params = self.obj().params().render(&tpl)?;
+            let params = self.obj().params().render(tpl)?;
             Ok(super::RequestBodyUrlencoded::builder()
                 .params(&params)
                 .build()

--- a/crates/cartero-objects/src/request_method.rs
+++ b/crates/cartero-objects/src/request_method.rs
@@ -87,7 +87,7 @@ impl TryFrom<u32> for RequestMethod {
     type Error = ();
 
     fn try_from(value: u32) -> Result<Self, Self::Error> {
-        let values = vec![
+        let values = [
             Self::Get,
             Self::Post,
             Self::Put,
@@ -97,7 +97,7 @@ impl TryFrom<u32> for RequestMethod {
             Self::Head,
             Self::Trace,
         ];
-        values.get(value as usize).map(|s| s.clone()).ok_or(())
+        values.get(value as usize).copied().ok_or(())
     }
 }
 

--- a/crates/cartero-objects/src/response.rs
+++ b/crates/cartero-objects/src/response.rs
@@ -181,7 +181,7 @@ mod imp {
 }
 
 mod builder {
-    use glib::{object::ObjectBuilder, Object};
+    use glib::{Object, object::ObjectBuilder};
 
     use super::*;
 

--- a/crates/cartero-objects/src/response.rs
+++ b/crates/cartero-objects/src/response.rs
@@ -113,8 +113,7 @@ impl Response {
                 body.clone()
                     .to_vec()
                     .into_iter()
-                    .find(|ch| *ch < 0x08 || (*ch > 0x0D && *ch < 0x20))
-                    .is_some()
+                    .any(|ch| ch < 0x08 || (ch > 0x0D && ch < 0x20))
             })
     }
 

--- a/crates/cartero-objects/src/utils.rs
+++ b/crates/cartero-objects/src/utils.rs
@@ -18,7 +18,7 @@
 /// TODO: convert into a macro?
 #[cfg(test)]
 pub(crate) mod test {
-    use std::sync::{atomic::AtomicBool, Arc, Mutex};
+    use std::sync::{Arc, Mutex, atomic::AtomicBool};
 
     use glib::object::IsA;
     use glib::object::ObjectExt;

--- a/default.nix
+++ b/default.nix
@@ -14,7 +14,6 @@ in
 
     src = ./.;
 
-    useFetchCargoVendor = true;
     cargoLock.lockFile = ./Cargo.lock;
 
     nativeBuildInputs = with pkgs; [
@@ -29,7 +28,7 @@ in
       gtk4
       shared-mime-info
       glib
-      wrapGAppsHook
+      wrapGAppsHook4
       hicolor-icon-theme
     ];
 
@@ -37,7 +36,7 @@ in
       gtksourceview5
       pango
       gdk-pixbuf
-      openssl_3
+      openssl
       graphene
       libadwaita
     ];

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1720957393,
-        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
+        "lastModified": 1770019141,
+        "narHash": "sha256-VKS4ZLNx4PNrABoB0L8KUpc1fE7CLpQXQs985tGfaCU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
+        "rev": "cb369ef2efd432b3cdf8622b0ffc0a97a02f3137",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1745116541,
-        "narHash": "sha256-5xzA6dTfqCfTTDCo3ipPZzrg3wp01xmcr73y4cTNMP8=",
+        "lastModified": 1769742225,
+        "narHash": "sha256-roSD/OJ3x9nF+Dxr+/bLClX3U8FP9EkCQIFpzxKjSUM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e2142ef330a61c02f274ac9a9cb6f8487a5d0080",
+        "rev": "bcdd8d37594f0e201639f55889c01c827baf5c75",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
               gtk4
               shared-mime-info
               glib
-              wrapGAppsHook
+              wrapGAppsHook4
               hicolor-icon-theme
             ];
 
@@ -72,7 +72,7 @@
               gtksourceview5
               pango
               gdk-pixbuf
-              openssl_3
+              openssl
               graphene
               libadwaita
             ];

--- a/src/app.rs
+++ b/src/app.rs
@@ -104,10 +104,10 @@ mod imp {
                 if let Some(settings) = gtk::Settings::default() {
                     settings.set_gtk_font_name(Some("Segoe UI 10"));
                 }
-            } else if cfg!(target_os = "macos") {
-                if let Some(settings) = gtk::Settings::default() {
-                    settings.set_gtk_font_name(Some(".AppleSystemUIFont 14.5"));
-                }
+            } else if cfg!(target_os = "macos")
+                && let Some(settings) = gtk::Settings::default()
+            {
+                settings.set_gtk_font_name(Some(".AppleSystemUIFont 14.5"));
             }
 
             let obj = self.obj();
@@ -212,7 +212,7 @@ impl CarteroApplication {
         #[allow(deprecated)]
         StyleContext::add_provider_for_display(
             &gtk::gdk::Display::default().expect("No display"),
-            self.imp().app_theme.get_or_init(|| gtk::CssProvider::new()),
+            self.imp().app_theme.get_or_init(gtk::CssProvider::new),
             STYLE_PROVIDER_PRIORITY_APPLICATION,
         );
 
@@ -262,7 +262,7 @@ impl CarteroApplication {
             .unwrap_or_default();
         self.imp()
             .app_theme
-            .get_or_init(|| gtk::CssProvider::new())
+            .get_or_init(gtk::CssProvider::new)
             .load_from_string(css.as_str());
     }
 
@@ -276,7 +276,7 @@ impl CarteroApplication {
                     let window = app
                         .windows_by_type::<crate::windows::settings::Shell>()
                         .first()
-                        .map(|win| win.clone())
+                        .cloned()
                         .unwrap_or_else(|| {
                             let settings_shell = crate::windows::settings::Shell::new();
                             let window = app.new_window(&settings_shell);
@@ -308,7 +308,7 @@ impl CarteroApplication {
                     let window = app
                         .windows_by_type::<crate::windows::settings::Shell>()
                         .first()
-                        .map(|win| win.clone())
+                        .cloned()
                         .unwrap_or_else(|| {
                             let settings_shell = crate::windows::settings::Shell::new();
                             let window = app.new_window(&settings_shell);

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,13 +17,13 @@
 
 use adw::prelude::*;
 use gettextrs::gettext;
-use glib::subclass::types::ObjectSubclassIsExt;
 use glib::Object;
-use gtk::gio::{self, ActionEntryBuilder};
-use gtk::prelude::ActionMapExtManual;
+use glib::subclass::types::ObjectSubclassIsExt;
+use gtk::STYLE_PROVIDER_PRIORITY_APPLICATION;
 #[allow(deprecated)]
 use gtk::StyleContext;
-use gtk::STYLE_PROVIDER_PRIORITY_APPLICATION;
+use gtk::gio::{self, ActionEntryBuilder};
+use gtk::prelude::ActionMapExtManual;
 use sourceview5::StyleSchemeManager;
 
 use crate::config::{APP_ID, RESOURCE_PATH};
@@ -49,9 +49,9 @@ mod imp {
     use adw::prelude::*;
     use adw::subclass::application::AdwApplicationImpl;
     use glib::subclass::{object::ObjectImpl, types::ObjectSubclass};
+    use gtk::CssProvider;
     use gtk::subclass::prelude::*;
     use gtk::subclass::{application::GtkApplicationImpl, prelude::ApplicationImpl};
-    use gtk::CssProvider;
 
     use super::*;
 

--- a/src/css.rs
+++ b/src/css.rs
@@ -59,7 +59,7 @@ fn generate_window_css(scheme: &StyleScheme) -> String {
         css.alias("card_bg_color", "alpha(white, .5)");
     }
 
-    match (
+    if let (Some(accent_bg), Some(accent_fg)) = (
         locate_meta_color(scheme, "accent_bg_color").or(locate_scheme_color(
             scheme,
             "selection",
@@ -70,18 +70,14 @@ fn generate_window_css(scheme: &StyleScheme) -> String {
             "selection",
             "foreground",
         )),
-    ) {
-        (Some(accent_bg), Some(accent_fg)) => {
-            if !accent_bg.is_clear() {
-                css.variable("accent_bg_color", &accent_bg);
-                if accent_fg.is_clear() {
-                    css.variable("accent_fg_color", &text_fg);
-                } else {
-                    css.variable("accent_fg_color", &accent_fg);
-                }
-            }
+    ) && !accent_bg.is_clear()
+    {
+        css.variable("accent_bg_color", &accent_bg);
+        if accent_fg.is_clear() {
+            css.variable("accent_fg_color", &text_fg);
+        } else {
+            css.variable("accent_fg_color", &accent_fg);
         }
-        _ => {}
     }
 
     css.alias("card_fg_color", "@window_fg_color");
@@ -136,8 +132,10 @@ impl CssTheme {
             variable, hex_a, hex_b, clamp_level
         ));
     }
+}
 
-    fn to_string(&self) -> String {
-        self.0.clone()
+impl std::fmt::Display for CssTheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
     }
 }

--- a/src/interop.rs
+++ b/src/interop.rs
@@ -29,8 +29,12 @@ impl std::fmt::Display for InnerError<FileLoadError> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let message = match self {
             Self::InteropError(fe) => match fe {
-                FileLoadError::SchemaTooNew => gettext("This file was created with a newer version of this application; please update!"),
-                FileLoadError::DeserializationError(_) => gettext("The file is corrupt or does not contain valid data for this application")
+                FileLoadError::SchemaTooNew => gettext(
+                    "This file was created with a newer version of this application; please update!",
+                ),
+                FileLoadError::DeserializationError(_) => gettext(
+                    "The file is corrupt or does not contain valid data for this application",
+                ),
             },
             Self::GlibError(e) => e.message().to_string(),
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ fn init_data_dir() {
         let mut xdg_final_dirs = vec![datadir];
         xdg_final_dirs.extend(xdg_data_dirs);
         let xdg_data_dir = std::env::join_paths(&xdg_final_dirs).unwrap();
-        std::env::set_var("XDG_DATA_DIRS", xdg_data_dir);
+        unsafe { std::env::set_var("XDG_DATA_DIRS", xdg_data_dir) };
     }
 }
 
@@ -125,7 +125,7 @@ fn main() -> glib::ExitCode {
     init_data_dir();
     if let Some(locale) = get_locale_from_schema() {
         if locale != std::env::var("LANGUAGE").unwrap_or_default() {
-            std::env::set_var("LANGUAGE", locale);
+            unsafe { std::env::set_var("LANGUAGE", locale) };
             if cfg!(windows) {
                 // Windows actually will ignore this change to the env var, so
                 // the whole program needs to be relaunched to take effect.

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,22 +123,22 @@ fn main() -> glib::ExitCode {
     }
 
     init_data_dir();
-    if let Some(locale) = get_locale_from_schema() {
-        if locale != std::env::var("LANGUAGE").unwrap_or_default() {
-            unsafe { std::env::set_var("LANGUAGE", locale) };
-            if cfg!(windows) {
-                // Windows actually will ignore this change to the env var, so
-                // the whole program needs to be relaunched to take effect.
-                let exe = std::env::current_exe().expect("No argv[0]?");
-                let mut args = std::env::args_os();
-                let _ = args.next();
+    if let Some(locale) = get_locale_from_schema()
+        && locale != std::env::var("LANGUAGE").unwrap_or_default()
+    {
+        unsafe { std::env::set_var("LANGUAGE", locale) };
+        if cfg!(windows) {
+            // Windows actually will ignore this change to the env var, so
+            // the whole program needs to be relaunched to take effect.
+            let exe = std::env::current_exe().expect("No argv[0]?");
+            let mut args = std::env::args_os();
+            let _ = args.next();
 
-                let status = std::process::Command::new(exe)
-                    .args(args)
-                    .status()
-                    .expect("Invalid re-call for cartero.exe");
-                std::process::exit(status.code().unwrap_or(1));
-            }
+            let status = std::process::Command::new(exe)
+                .args(args)
+                .status()
+                .expect("Invalid re-call for cartero.exe");
+            std::process::exit(status.code().unwrap_or(1));
         }
     }
     init_locale();

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -76,7 +76,7 @@ pub(crate) fn prepare_window(win: &gtk::Window) {
     win.connect_realize(|win| {
         let style_manager = adw::StyleManager::default();
         let color_scheme = style_manager.color_scheme();
-        set_window_theme(&win, color_scheme);
+        set_window_theme(win, color_scheme);
     });
 
     let style_manager = adw::StyleManager::default();

--- a/src/native/win32/helpers.rs
+++ b/src/native/win32/helpers.rs
@@ -18,8 +18,8 @@
 use std::sync::OnceLock;
 use windows_sys::Wdk::System::SystemServices::RtlGetVersion;
 use windows_sys::Win32::System::SystemInformation::OSVERSIONINFOW;
-use winreg::enums::HKEY_CURRENT_USER;
 use winreg::RegKey;
+use winreg::enums::HKEY_CURRENT_USER;
 
 #[allow(unused)]
 pub(super) fn windows_build_number() -> u32 {

--- a/src/updates/ui.rs
+++ b/src/updates/ui.rs
@@ -16,8 +16,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use adw::{
-    prelude::{AlertDialogExt, AlertDialogExtManual},
     AlertDialog,
+    prelude::{AlertDialogExt, AlertDialogExtManual},
 };
 use formatx::formatx;
 use gettextrs::gettext;

--- a/src/widgets/authentication/authentication_pane.rs
+++ b/src/widgets/authentication/authentication_pane.rs
@@ -28,7 +28,7 @@ mod imp {
         RequestAuthentication, RequestAuthenticationBasic, RequestAuthenticationBearer,
         RequestAuthenticationType,
     };
-    use glib::{subclass::InitializingObject, Object, Properties};
+    use glib::{Object, Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     #[derive(Default, Properties, CompositeTemplate)]

--- a/src/widgets/authentication/basic_auth.rs
+++ b/src/widgets/authentication/basic_auth.rs
@@ -25,7 +25,7 @@ mod imp {
 
     use super::*;
     use cartero_objects::RequestAuthenticationBasic;
-    use glib::{subclass::InitializingObject, BindingGroup, Properties};
+    use glib::{BindingGroup, Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     #[derive(Default, Properties, CompositeTemplate)]

--- a/src/widgets/authentication/bearer_token.rs
+++ b/src/widgets/authentication/bearer_token.rs
@@ -25,7 +25,7 @@ mod imp {
 
     use super::*;
     use cartero_objects::RequestAuthenticationBearer;
-    use glib::{subclass::InitializingObject, BindingGroup, Properties};
+    use glib::{BindingGroup, Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     #[derive(Default, Properties, CompositeTemplate)]

--- a/src/widgets/code_view.rs
+++ b/src/widgets/code_view.rs
@@ -15,7 +15,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use glib::{object::ObjectExt, Object};
+use glib::{Object, object::ObjectExt};
 use gtk::{glib, pango::FontDescription, prelude::SettingsExtManual};
 
 use crate::settings::Settings;
@@ -24,21 +24,21 @@ mod imp {
     use std::cell::RefCell;
     use std::sync::OnceLock;
 
+    use glib::Properties;
     use glib::object::{Cast, ObjectExt};
     use glib::subclass::Signal;
     use glib::value::ToValue;
-    use glib::Properties;
     use gtk::gio::SettingsBindFlags;
     #[allow(deprecated)]
     use gtk::prelude::StyleContextExt;
     use gtk::prelude::{EventControllerExt, WidgetExt};
     use gtk::prelude::{SettingsExt, SettingsExtManual, TextViewExt};
     use gtk::subclass::prelude::*;
-    use gtk::{gdk, EventControllerScroll, EventControllerScrollFlags, PropagationPhase};
-    use gtk::{glib, WrapMode};
+    use gtk::{EventControllerScroll, EventControllerScrollFlags, PropagationPhase, gdk};
+    use gtk::{WrapMode, glib};
+    use sourceview5::StyleSchemeManager;
     use sourceview5::prelude::BufferExt;
     use sourceview5::subclass::view::ViewImpl;
-    use sourceview5::StyleSchemeManager;
 
     use crate::settings::Settings;
     use crate::widgets::code_view::{get_monospace_font_descriptor, render_css_rules};
@@ -361,11 +361,7 @@ fn get_monospace_font_descriptor() -> FontDescription {
 /// Given the zoom level, returns the scaling percentage.
 fn map_zoom_level(zoom: i32) -> f32 {
     let perc = 1.0 + (zoom as f32 / 8.0);
-    if perc < 0.25 {
-        0.25
-    } else {
-        perc
-    }
+    if perc < 0.25 { 0.25 } else { perc }
 }
 
 /// Returns the CSS document that should be provided to the StyleContext of a CodeView

--- a/src/widgets/code_view.rs
+++ b/src/widgets/code_view.rs
@@ -341,16 +341,14 @@ fn get_monospace_font_descriptor() -> FontDescription {
             "Menlo 14".to_string()
         } else if cfg!(target_os = "windows") {
             "Consolas 11".to_string()
+        } else if gtk::gio::SettingsSchemaSource::default()
+            .and_then(|source| source.lookup("org.gnome.desktop.interface", true))
+            .is_some()
+        {
+            let settings = gtk::gio::Settings::new("org.gnome.desktop.interface");
+            settings.get::<String>("monospace-font-name")
         } else {
-            if gtk::gio::SettingsSchemaSource::default()
-                .and_then(|source| source.lookup("org.gnome.desktop.interface", true))
-                .is_some()
-            {
-                let settings = gtk::gio::Settings::new("org.gnome.desktop.interface");
-                settings.get::<String>("monospace-font-name")
-            } else {
-                "Monospace 10".to_string()
-            }
+            "Monospace 10".to_string()
         }
     } else {
         settings.get::<String>("custom-font")

--- a/src/widgets/dialogs.rs
+++ b/src/widgets/dialogs.rs
@@ -155,10 +155,10 @@ pub async fn file_save_error(
 /// Renders an error message associated with a FileDialog.
 pub async fn glib_file_dialog_error(root: &impl IsA<gtk::Widget>, error: &glib::Error) {
     let alert = AlertDialog::builder()
-        .heading(&gettext(
+        .heading(gettext(
             "Could not select a valid file from the file chooser",
         ))
-        .body(&error.to_string())
+        .body(error.to_string())
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
@@ -183,7 +183,7 @@ pub async fn export_dialog_error(root: &impl IsA<gtk::Widget>, cause: CodeExport
         }
     };
     let alert = AlertDialog::builder()
-        .heading(&gettext("Could not export the request"))
+        .heading(gettext("Could not export the request"))
         .body(&error)
         .default_response("close")
         .build();
@@ -196,8 +196,8 @@ pub async fn export_dialog_error(root: &impl IsA<gtk::Widget>, cause: CodeExport
 // chose to keep the window for now.
 pub async fn confirm_close_window(root: &impl IsA<gtk::Widget>) -> bool {
     let question = AlertDialog::builder()
-        .heading(&gettext("There are unsaved changes"))
-        .body(&gettext(
+        .heading(gettext("There are unsaved changes"))
+        .body(gettext(
             "Closing this window will lose all unsaved data. Do you really want to proceed?",
         ))
         .build();
@@ -231,7 +231,7 @@ pub async fn confirm_save(
     };
     let question = AlertDialog::builder()
         .heading(&question_title)
-        .body(&gettext(
+        .body(gettext(
             "There are changes that have not been saved yet. What do you want to do?",
         ))
         .build();

--- a/src/widgets/dialogs.rs
+++ b/src/widgets/dialogs.rs
@@ -59,7 +59,7 @@ pub async fn file_load_error_dialog(
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
-    alert.choose_future(root).await;
+    alert.choose_future(Some(root)).await;
 }
 
 /// Renders an error message that shows the warnings found while loading a file.
@@ -90,7 +90,7 @@ pub async fn file_load_warning_dialog(
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
-    alert.choose_future(root).await;
+    alert.choose_future(Some(root)).await;
 }
 
 fn pretty_warning(warning: FileWarningTag) -> String {
@@ -120,7 +120,7 @@ pub async fn file_pick_out_of_prefix_error(
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
-    alert.choose_future(root).await;
+    alert.choose_future(Some(root)).await;
 }
 
 /// Renders an error message that shows the error that prevents the file from
@@ -143,7 +143,7 @@ pub async fn file_save_error(
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
-    alert.choose_future(root).await;
+    alert.choose_future(Some(root)).await;
 }
 
 /// Renders an error message associated with a FileDialog.
@@ -156,7 +156,7 @@ pub async fn glib_file_dialog_error(root: &impl IsA<gtk::Widget>, error: &glib::
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
-    alert.choose_future(root).await;
+    alert.choose_future(Some(root)).await;
 }
 
 pub async fn export_dialog_error(root: &impl IsA<gtk::Widget>, cause: CodeExportError) {
@@ -180,7 +180,7 @@ pub async fn export_dialog_error(root: &impl IsA<gtk::Widget>, cause: CodeExport
         .default_response("close")
         .build();
     alert.add_response("close", &gettext("Close"));
-    alert.choose_future(root).await;
+    alert.choose_future(Some(root)).await;
 }
 
 // Asks the user whether to actually close the window when there is unsaved
@@ -199,7 +199,7 @@ pub async fn confirm_close_window(root: &impl IsA<gtk::Widget>) -> bool {
     ]);
     question.set_response_appearance("continue", adw::ResponseAppearance::Destructive);
     question.set_default_response(Some("cancel"));
-    let response = question.choose_future(root).await;
+    let response = question.choose_future(Some(root)).await;
     response == "continue"
 }
 
@@ -234,7 +234,7 @@ pub async fn confirm_save(
     ]);
     question.set_response_appearance("save", adw::ResponseAppearance::Suggested);
     question.set_response_appearance("discard", adw::ResponseAppearance::Destructive);
-    let response = question.choose_future(root).await;
+    let response = question.choose_future(Some(root)).await;
     match response.as_str() {
         "discard" => SaveAlertDialogResponse::Discard,
         "save" => SaveAlertDialogResponse::Save,

--- a/src/widgets/dialogs.rs
+++ b/src/widgets/dialogs.rs
@@ -18,8 +18,8 @@
 use crate::interop::InnerError;
 
 use adw::{
-    prelude::{AlertDialogExt, AlertDialogExtManual},
     AlertDialog,
+    prelude::{AlertDialogExt, AlertDialogExtManual},
 };
 use cartero_code_exporters::ExportError as CodeExportError;
 use cartero_interop::{FileLoadError, FileSaveError, FileWarningTag};
@@ -136,7 +136,13 @@ pub async fn file_save_error(
         Some(name) => formatx!(gettext("Cannot save '{}'"), name).unwrap(),
         None => gettext("Cannot save the requested file"),
     };
-    let error_msg = format!("{}\n\n{}", gettext("There was an error during the saving process. Assume that your changes are still not saved."), error);
+    let error_msg = format!(
+        "{}\n\n{}",
+        gettext(
+            "There was an error during the saving process. Assume that your changes are still not saved."
+        ),
+        error
+    );
     let alert = AlertDialog::builder()
         .heading(&error_title)
         .body(&error_msg)
@@ -169,7 +175,9 @@ pub async fn export_dialog_error(root: &impl IsA<gtk::Widget>, cause: CodeExport
             gettext("There was a problem with a variable interpolation, review your inputs")
         }
         CodeExportError::TemplateError(cause) => {
-            let top = gettext("There has been an internal error during the export process. This is most likely a development error. (If you could report your test case and this error, we might be able to fix this in the future.)");
+            let top = gettext(
+                "There has been an internal error during the export process. This is most likely a development error. (If you could report your test case and this error, we might be able to fix this in the future.)",
+            );
             let error_cause = gettext("Error cause:");
             format!("{}\n\n{} {}", top, error_cause, cause)
         }

--- a/src/widgets/endpoint/endpoint_pane.rs
+++ b/src/widgets/endpoint/endpoint_pane.rs
@@ -40,7 +40,7 @@ mod imp {
     use glib::{JoinHandle, Properties};
     use gtk::gio::{self, Cancellable, FileCreateFlags, SimpleAction, SimpleActionGroup};
     use gtk::subclass::prelude::*;
-    use gtk::{prelude::*, ClosureExpression, CompositeTemplate};
+    use gtk::{ClosureExpression, CompositeTemplate, prelude::*};
 
     use crate::interop::{InnerError, LoadResult, SaveResult};
     use crate::settings::Settings;
@@ -50,7 +50,7 @@ mod imp {
     use crate::widgets::field::{CollapsedFieldTable, FieldTableListView};
     use crate::widgets::req_body::RequestBodyPane;
     use crate::widgets::shell::BasePaneImpl;
-    use crate::widgets::{file_dialogs, ExportDialog, MethodDropdown};
+    use crate::widgets::{ExportDialog, MethodDropdown, file_dialogs};
 
     #[derive(CompositeTemplate, Properties, Default)]
     #[template(resource = "/es/danirod/Cartero/endpoint_pane.ui")]

--- a/src/widgets/endpoint/endpoint_pane.rs
+++ b/src/widgets/endpoint/endpoint_pane.rs
@@ -579,12 +579,11 @@ mod imp {
                 .body_data()
                 .map(|body| {
                     let mut headers = body.rendered_headers();
-                    if body.body_type() == RequestBodyType::Multipart {
-                        if let Some((_, value)) =
+                    if body.body_type() == RequestBodyType::Multipart
+                        && let Some((_, value)) =
                             headers.iter_mut().find(|(key, _)| key == "Content-Type")
-                        {
-                            *value = format!("{}{}", *value, gettext("(generated during request)"));
-                        }
+                    {
+                        *value = format!("{}{}", *value, gettext("(generated during request)"));
                     }
                     headers
                 })

--- a/src/widgets/endpoint/response_headers.rs
+++ b/src/widgets/endpoint/response_headers.rs
@@ -23,7 +23,7 @@ mod imp {
     use adw::prelude::*;
     use adw::subclass::prelude::*;
     use cartero_objects::{Field, FieldTable};
-    use glib::{subclass::InitializingObject, Properties};
+    use glib::{Properties, subclass::InitializingObject};
     use gtk::{Box, CompositeTemplate, ListBox, TemplateChild};
 
     use crate::widgets::field::FieldActionRow;

--- a/src/widgets/endpoint/response_panel.rs
+++ b/src/widgets/endpoint/response_panel.rs
@@ -26,8 +26,8 @@ use gtk::glib;
 use gtk::prelude::TextViewExt;
 use gtk::prelude::*;
 use serde_json::Value;
-use sourceview5::prelude::BufferExt;
 use sourceview5::LanguageManager;
+use sourceview5::prelude::BufferExt;
 
 use glib::subclass::types::ObjectSubclassIsExt;
 
@@ -37,19 +37,19 @@ mod imp {
     use crate::widgets::endpoint::ResponseHeaders;
     use crate::widgets::{CodeView, ErrorPane, SearchBox};
     use adw::subclass::bin::BinImpl;
-    use adw::{prelude::*, ToastOverlay};
+    use adw::{ToastOverlay, prelude::*};
     use cartero_http::RequestError;
     use cartero_objects::Response;
     use gettextrs::gettext;
+    use glib::Properties;
     use glib::object::Cast;
     use glib::subclass::InitializingObject;
-    use glib::Properties;
     use gtk::gdk::{ContentProvider, Display};
     use gtk::gio::{SimpleAction, SimpleActionGroup};
     use gtk::subclass::prelude::*;
     use gtk::{
-        subclass::widget::{CompositeTemplateClass, CompositeTemplateInitializingExt, WidgetImpl},
         Box, CompositeTemplate, Label, TemplateChild,
+        subclass::widget::{CompositeTemplateClass, CompositeTemplateInitializingExt, WidgetImpl},
     };
     use gtk::{Revealer, Spinner, Stack};
 

--- a/src/widgets/endpoint/response_panel.rs
+++ b/src/widgets/endpoint/response_panel.rs
@@ -199,11 +199,11 @@ mod imp {
         }
 
         fn get_selected_text(&self) -> Option<String> {
-            if self.buffer.has_selection() {
-                if let Some((start, end)) = self.buffer.selection_bounds() {
-                    let text = self.buffer.slice(&start, &end, false);
-                    return Some(text.into());
-                }
+            if self.buffer.has_selection()
+                && let Some((start, end)) = self.buffer.selection_bounds()
+            {
+                let text = self.buffer.slice(&start, &end, false);
+                return Some(text.into());
             }
             None
         }
@@ -325,7 +325,7 @@ impl ResponsePanel {
         imp.duration.set_text(&format_duration(resp.duration()));
         imp.duration.set_visible(true);
 
-        let size = glib::format_size(resp.size() as u64);
+        let size = glib::format_size(resp.size());
         imp.response_size.set_text(&size);
         imp.response_size.set_visible(true);
 

--- a/src/widgets/error_pane.rs
+++ b/src/widgets/error_pane.rs
@@ -19,8 +19,8 @@ use adw::prelude::*;
 use adw::subclass::prelude::*;
 use cartero_http::RequestError;
 use gettextrs::gettext;
-use glib::subclass::InitializingObject;
 use glib::Properties;
+use glib::subclass::InitializingObject;
 use gtk::CompositeTemplate;
 use std::cell::RefCell;
 

--- a/src/widgets/export_dialog.rs
+++ b/src/widgets/export_dialog.rs
@@ -26,10 +26,10 @@ mod imp {
     use super::*;
     use formatx::formatx;
     use gettextrs::gettext;
-    use glib::{subclass::InitializingObject, Properties};
+    use glib::{Properties, subclass::InitializingObject};
     use gtk::{
-        gdk::{ContentProvider, Display},
         CompositeTemplate,
+        gdk::{ContentProvider, Display},
     };
 
     #[derive(Default, CompositeTemplate, Properties)]

--- a/src/widgets/field/collapsed_field_table.rs
+++ b/src/widgets/field/collapsed_field_table.rs
@@ -110,22 +110,20 @@ mod imp {
             nodes.clear();
 
             // Reset the list.
-            for field in self.obj().field_table().iter::<Field>() {
-                if let Ok(field) = field {
-                    let row: FieldListBoxStaticRow =
-                        glib::Object::builder().property("field", field).build();
-                    self.obj()
-                        .bind_property("masked", &row, "allow-concealing")
-                        .sync_create()
-                        .build();
-                    self.obj()
-                        .bind_property("masked", &row, "concealed")
-                        .sync_create()
-                        .build();
-                    let widget = row.upcast();
-                    self.expander.add_row(&widget);
-                    nodes.push(widget);
-                }
+            for field in self.obj().field_table().iter::<Field>().flatten() {
+                let row: FieldListBoxStaticRow =
+                    glib::Object::builder().property("field", field).build();
+                self.obj()
+                    .bind_property("masked", &row, "allow-concealing")
+                    .sync_create()
+                    .build();
+                self.obj()
+                    .bind_property("masked", &row, "concealed")
+                    .sync_create()
+                    .build();
+                let widget = row.upcast();
+                self.expander.add_row(&widget);
+                nodes.push(widget);
             }
         }
     }

--- a/src/widgets/field/collapsed_field_table.rs
+++ b/src/widgets/field/collapsed_field_table.rs
@@ -26,7 +26,7 @@ mod imp {
     use super::*;
 
     use cartero_objects::{Field, FieldTable};
-    use glib::{subclass::InitializingObject, Properties};
+    use glib::{Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     #[derive(Default, Properties, CompositeTemplate)]

--- a/src/widgets/field/field_action_row.rs
+++ b/src/widgets/field/field_action_row.rs
@@ -23,7 +23,7 @@ mod imp {
     use std::cell::RefCell;
 
     use cartero_objects::Field;
-    use glib::{subclass::InitializingObject, Properties};
+    use glib::{Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     use super::*;

--- a/src/widgets/field/field_list_box_row.rs
+++ b/src/widgets/field/field_list_box_row.rs
@@ -24,10 +24,10 @@ mod imp {
     use super::*;
     use cartero_objects::Field;
     use glib::{
-        subclass::{InitializingObject, Signal},
         Properties,
+        subclass::{InitializingObject, Signal},
     };
-    use gtk::{gio::SimpleAction, CompositeTemplate};
+    use gtk::{CompositeTemplate, gio::SimpleAction};
 
     #[derive(Default, CompositeTemplate, Properties)]
     #[properties(wrapper_type = super::FieldListBoxRow)]

--- a/src/widgets/field/field_list_box_static_row.rs
+++ b/src/widgets/field/field_list_box_static_row.rs
@@ -24,7 +24,7 @@ mod imp {
     use super::*;
     use cartero_objects::Field;
     use gettextrs::gettext;
-    use glib::{subclass::InitializingObject, BindingGroup, Properties};
+    use glib::{BindingGroup, Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     #[derive(Default, CompositeTemplate, Properties)]
@@ -119,11 +119,7 @@ mod imp {
                     let allows_conceal = value
                         .get::<bool>()
                         .expect("allow-concealing is of invalid type");
-                    if allows_conceal {
-                        Some(1.0)
-                    } else {
-                        Some(0.0)
-                    }
+                    if allows_conceal { Some(1.0) } else { Some(0.0) }
                 })
                 .sync_create()
                 .build();

--- a/src/widgets/field/field_placeholder_row.rs
+++ b/src/widgets/field/field_placeholder_row.rs
@@ -24,8 +24,8 @@ mod imp {
     use super::*;
     use cartero_objects::{Field, FieldTable};
     use glib::{
-        subclass::{InitializingObject, Signal},
         Properties,
+        subclass::{InitializingObject, Signal},
     };
     use gtk::CompositeTemplate;
 
@@ -90,9 +90,11 @@ mod imp {
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
-                vec![Signal::builder("insert-field")
-                    .param_types([Field::static_type()])
-                    .build()]
+                vec![
+                    Signal::builder("insert-field")
+                        .param_types([Field::static_type()])
+                        .build(),
+                ]
             })
         }
     }

--- a/src/widgets/field/field_table_list_view.rs
+++ b/src/widgets/field/field_table_list_view.rs
@@ -26,8 +26,8 @@ mod imp {
     use super::*;
     use cartero_objects::{Field, FieldTable};
     use glib::{
-        subclass::{InitializingObject, Signal},
         Properties,
+        subclass::{InitializingObject, Signal},
     };
     use gtk::CompositeTemplate;
 
@@ -88,9 +88,11 @@ mod imp {
         fn signals() -> &'static [Signal] {
             static SIGNALS: OnceLock<Vec<Signal>> = OnceLock::new();
             SIGNALS.get_or_init(|| {
-                vec![Signal::builder("changed")
-                    .param_types([String::static_type()])
-                    .build()]
+                vec![
+                    Signal::builder("changed")
+                        .param_types([String::static_type()])
+                        .build(),
+                ]
             })
         }
     }

--- a/src/widgets/field/field_table_list_view.rs
+++ b/src/widgets/field/field_table_list_view.rs
@@ -105,7 +105,7 @@ mod imp {
     impl FieldTableListView {
         #[template_callback]
         fn on_insert_field(&self, field: &Field) {
-            self.obj().table().insert(&field);
+            self.obj().table().insert(field);
 
             // Get a reference to the last row.
             let last_id = self.obj().table().n_items() - 1;
@@ -188,28 +188,28 @@ mod imp {
             let rows = self.table.borrow().n_items() as i32;
             let mut seen = HashSet::new();
             for row in (0..rows).rev() {
-                if let Some(widget) = self.list_box.row_at_index(row) {
-                    if let Some(field_row) = widget.child().and_downcast::<FieldListBoxRow>() {
-                        if !field_row.field().active() {
-                            field_row.set_overriden(false);
-                            continue;
-                        }
+                if let Some(widget) = self.list_box.row_at_index(row)
+                    && let Some(field_row) = widget.child().and_downcast::<FieldListBoxRow>()
+                {
+                    if !field_row.field().active() {
+                        field_row.set_overriden(false);
+                        continue;
+                    }
 
-                        let key = {
-                            let key = field_row.field().key();
-                            if self.obj().check_overriden_icase() {
-                                key.to_ascii_lowercase()
-                            } else {
-                                key
-                            }
-                        };
-
-                        if seen.contains(&key) {
-                            field_row.set_overriden(true);
+                    let key = {
+                        let key = field_row.field().key();
+                        if self.obj().check_overriden_icase() {
+                            key.to_ascii_lowercase()
                         } else {
-                            seen.insert(key.clone());
-                            field_row.set_overriden(false);
+                            key
                         }
+                    };
+
+                    if seen.contains(&key) {
+                        field_row.set_overriden(true);
+                    } else {
+                        seen.insert(key.clone());
+                        field_row.set_overriden(false);
                     }
                 }
             }

--- a/src/widgets/file_dialogs.rs
+++ b/src/widgets/file_dialogs.rs
@@ -62,11 +62,11 @@ fn new_file_dialog() -> FileDialog {
 
 /// The settings key to use where the directory of the last opened file is.
 /// The next time the open file dialog is called, this is where we start.
-const LAST_OPEN_DIR: &'static str = "last-open-dir";
+const LAST_OPEN_DIR: &str = "last-open-dir";
 
 /// The settings key to use where the directory of the last saved file is.
 /// The next time the save file dialog is called, this is where we start.
-const LAST_SAVE_DIR: &'static str = "last-save-dir";
+const LAST_SAVE_DIR: &str = "last-save-dir";
 
 /// Returns the gio::File for the path stored in the settings under the key.
 fn get_file_setting(key: &str) -> Option<gio::File> {
@@ -192,7 +192,7 @@ where
             if in_prefix {
                 Ok(Some(result))
             } else {
-                file_pick_out_of_prefix_error(parent.upcast_ref(), &result, &prefix_path.unwrap())
+                file_pick_out_of_prefix_error(parent.upcast_ref(), &result, prefix_path.unwrap())
                     .await;
                 Ok(None)
             }

--- a/src/widgets/file_dialogs.rs
+++ b/src/widgets/file_dialogs.rs
@@ -19,9 +19,9 @@ use formatx::formatx;
 use gettextrs::gettext;
 use glib::{object::IsA, prelude::Cast, types::StaticType};
 use gtk::{
+    DialogError, FileDialog, FileFilter,
     gio::{self, ListStore},
     prelude::{FileExt, ListModelExtManual, SettingsExtManual},
-    DialogError, FileDialog, FileFilter,
 };
 use std::path::PathBuf;
 

--- a/src/widgets/method_dropdown.rs
+++ b/src/widgets/method_dropdown.rs
@@ -23,7 +23,7 @@ use cartero_objects::RequestMethod;
 mod imp {
     use super::*;
     use adw::EnumListItem;
-    use glib::{subclass::InitializingObject, Properties};
+    use glib::{Properties, subclass::InitializingObject};
     use gtk::{ClosureExpression, CompositeTemplate};
     use std::cell::RefCell;
 

--- a/src/widgets/req_body/file.rs
+++ b/src/widgets/req_body/file.rs
@@ -28,7 +28,7 @@ mod imp {
 
     use super::*;
     use cartero_objects::RequestBodyFile;
-    use glib::{subclass::InitializingObject, BindingGroup, Properties};
+    use glib::{BindingGroup, Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     #[derive(Default, Properties, CompositeTemplate)]

--- a/src/widgets/req_body/multipart.rs
+++ b/src/widgets/req_body/multipart.rs
@@ -23,7 +23,7 @@ mod imp {
 
     use super::*;
     use cartero_objects::FieldTable;
-    use glib::{subclass::InitializingObject, Properties};
+    use glib::{Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     #[derive(Default, Properties, CompositeTemplate)]

--- a/src/widgets/req_body/raw.rs
+++ b/src/widgets/req_body/raw.rs
@@ -25,9 +25,9 @@ mod imp {
 
     use super::*;
     use cartero_objects::{RequestBodyRaw, RequestBodyRawType};
-    use glib::{subclass::InitializingObject, Properties};
+    use glib::{Properties, subclass::InitializingObject};
     use gtk::{CompositeTemplate, Revealer};
-    use sourceview5::{prelude::BufferExt, Buffer, LanguageManager};
+    use sourceview5::{Buffer, LanguageManager, prelude::BufferExt};
 
     #[derive(Default, Properties, CompositeTemplate)]
     #[properties(wrapper_type = super::Raw)]

--- a/src/widgets/req_body/raw.rs
+++ b/src/widgets/req_body/raw.rs
@@ -97,11 +97,11 @@ mod imp {
         }
 
         fn get_selected_text(&self) -> Option<String> {
-            if self.buffer.has_selection() {
-                if let Some((start, end)) = self.buffer.selection_bounds() {
-                    let text = self.buffer.slice(&start, &end, false);
-                    return Some(text.into());
-                }
+            if self.buffer.has_selection()
+                && let Some((start, end)) = self.buffer.selection_bounds()
+            {
+                let text = self.buffer.slice(&start, &end, false);
+                return Some(text.into());
             }
             None
         }

--- a/src/widgets/req_body/request_body_pane.rs
+++ b/src/widgets/req_body/request_body_pane.rs
@@ -149,10 +149,10 @@ mod imp {
             let body = self.obj().body();
             let (body_type, raw_body_type) = cast_selected_entry(self.combo.selected());
             body.set_body_type(body_type);
-            if let Some(raw_body_type) = raw_body_type {
-                if let Some(raw) = body.raw() {
-                    raw.set_payload_type(raw_body_type);
-                }
+            if let Some(raw_body_type) = raw_body_type
+                && let Some(raw) = body.raw()
+            {
+                raw.set_payload_type(raw_body_type);
             }
             self.pop_body();
             self.sync_container();

--- a/src/widgets/req_body/request_body_pane.rs
+++ b/src/widgets/req_body/request_body_pane.rs
@@ -30,7 +30,7 @@ mod imp {
     use cartero_objects::{
         FieldTable, RequestBody, RequestBodyFile, RequestBodyRawType, RequestBodyType,
     };
-    use glib::{subclass::InitializingObject, Properties};
+    use glib::{Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     #[derive(Default, Properties, CompositeTemplate)]

--- a/src/widgets/req_body/urlencoded.rs
+++ b/src/widgets/req_body/urlencoded.rs
@@ -23,7 +23,7 @@ mod imp {
 
     use super::*;
     use cartero_objects::FieldTable;
-    use glib::{subclass::InitializingObject, Properties};
+    use glib::{Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     #[derive(Default, Properties, CompositeTemplate)]

--- a/src/widgets/search_box.rs
+++ b/src/widgets/search_box.rs
@@ -28,14 +28,14 @@ mod imp {
 
     use formatx::formatx;
     use gettextrs::{gettext, ngettext};
+    use glib::Properties;
     use glib::object::{Cast, ObjectExt};
     use glib::subclass::{InitializingObject, Signal};
-    use glib::Properties;
     use gtk::gio::{ActionEntry, SimpleActionGroup};
     use gtk::prelude::{ActionMapExtManual, EditableExt, TextBufferExt, TextViewExt, WidgetExt};
     use gtk::subclass::prelude::*;
-    use gtk::{gdk, glib, TextIter};
     use gtk::{CompositeTemplate, TemplateChild};
+    use gtk::{TextIter, gdk, glib};
     use sourceview5::prelude::SearchSettingsExt;
     use sourceview5::{Buffer, SearchContext, SearchSettings};
 

--- a/src/widgets/shell/base_pane.rs
+++ b/src/widgets/shell/base_pane.rs
@@ -168,28 +168,28 @@ pub trait BasePaneImplExt: BasePaneImpl {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let lookup_action = parent_class.lookup_action;
-        lookup_action(unsafe { self.obj().unsafe_cast_ref() }, name)
+        unsafe { lookup_action(self.obj().unsafe_cast_ref(), name) }
     }
 
     fn parent_load(&self) -> LoadResult {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let parent_load = parent_class.load;
-        parent_load(unsafe { self.obj().unsafe_cast_ref() })
+        unsafe { parent_load(self.obj().unsafe_cast_ref()) }
     }
 
     fn parent_save(&self) -> SaveResult {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let parent_save = parent_class.save;
-        parent_save(unsafe { self.obj().unsafe_cast_ref() })
+        unsafe { parent_save(self.obj().unsafe_cast_ref()) }
     }
 
     fn parent_duplicate(&self) -> BasePane {
         let data = Self::type_data();
         let parent_class = unsafe { &*(data.as_ref().parent_class() as *const ffi::Class) };
         let parent_duplicate = parent_class.duplicate;
-        parent_duplicate(unsafe { self.obj().unsafe_cast_ref() })
+        unsafe { parent_duplicate(self.obj().unsafe_cast_ref()) }
     }
 }
 

--- a/src/widgets/welcome/welcome_pane.rs
+++ b/src/widgets/welcome/welcome_pane.rs
@@ -24,8 +24,8 @@ mod imp {
     use super::*;
     use glib::subclass::InitializingObject;
     use gtk::{
-        gio::{SimpleAction, SimpleActionGroup},
         CompositeTemplate,
+        gio::{SimpleAction, SimpleActionGroup},
     };
 
     #[derive(Default, CompositeTemplate)]

--- a/src/win.rs
+++ b/src/win.rs
@@ -16,8 +16,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use crate::{app::CarteroApplication, interop::LoadResult, widgets::shell::BasePane};
-use glib::subclass::types::ObjectSubclassIsExt;
 use glib::Object;
+use glib::subclass::types::ObjectSubclassIsExt;
 use gtk::{gio, glib};
 use indexmap::IndexMap;
 
@@ -28,10 +28,10 @@ mod imp {
     use std::cell::OnceCell;
 
     use adw::AboutDialog;
-    use adw::{prelude::*, subclass::prelude::*, TabPage};
+    use adw::{TabPage, prelude::*, subclass::prelude::*};
     use gettextrs::gettext;
-    use gtk::gio::{self, ActionEntry};
     use gtk::ClosureExpression;
+    use gtk::gio::{self, ActionEntry};
     use indexmap::IndexMap;
 
     use crate::app::CarteroApplication;

--- a/src/win.rs
+++ b/src/win.rs
@@ -140,7 +140,7 @@ mod imp {
                     .build();
             }
             tab_binding_group
-                .bind("title", &*obj, "title")
+                .bind("title", obj, "title")
                 .sync_create()
                 .transform_to(|_, value| {
                     value
@@ -164,7 +164,7 @@ mod imp {
             /* Enable these actions only if there is an open page. */
             let tab_dependent_actions = ["save", "save-as", "duplicate", "close", "request"];
             for tab in tab_dependent_actions {
-                if let Some(action) = obj.lookup_action(&tab) {
+                if let Some(action) = obj.lookup_action(tab) {
                     has_page.bind(&action, "enabled", Some(&*self.tabview));
                 }
             }
@@ -342,7 +342,7 @@ mod imp {
                 .collect::<HashSet<String>>();
 
             endpoints
-                .into_iter()
+                .iter()
                 .filter_map(|file| {
                     if opened.contains(file.uri().as_str()) {
                         None
@@ -377,7 +377,7 @@ mod imp {
                     LoadResult::Error(_) => false,
                 };
                 if can_open {
-                    self.insert_pane_into_tabs(&pane);
+                    self.insert_pane_into_tabs(pane);
                 }
             }
         }
@@ -392,10 +392,10 @@ mod imp {
 
             if not_opened_paths.is_empty() {
                 /* Every requested file is opened. Just switch to one of the requested panes. */
-                if let Some(path) = all_paths.first() {
-                    if let Some(page) = self.find_pane_by_path(path) {
-                        self.tabview.set_selected_page(&page);
-                    }
+                if let Some(path) = all_paths.first()
+                    && let Some(page) = self.find_pane_by_path(path)
+                {
+                    self.tabview.set_selected_page(&page);
                 }
             } else {
                 let results = self.preload_panes(not_opened_paths).await;
@@ -422,10 +422,10 @@ mod imp {
             let not_opened_paths = self.filter_endpoints_to_open(files);
             if not_opened_paths.is_empty() {
                 /* Every requested file is opened. Just switch to one of the requested panes. */
-                if let Some(path) = files.first() {
-                    if let Some(page) = self.find_pane_by_path(path) {
-                        self.tabview.set_selected_page(&page);
-                    }
+                if let Some(path) = files.first()
+                    && let Some(page) = self.find_pane_by_path(path)
+                {
+                    self.tabview.set_selected_page(&page);
                 }
                 IndexMap::new()
             } else {
@@ -449,10 +449,10 @@ mod imp {
                 match failures {
                     LoadResult::Successful | LoadResult::Anonymous => {}
                     LoadResult::Warning(warnings) => {
-                        if let Some(file) = pane.file() {
-                            if let Some(page) = self.find_pane_by_path(&file) {
-                                self.tabview.set_selected_page(&page);
-                            }
+                        if let Some(file) = pane.file()
+                            && let Some(page) = self.find_pane_by_path(&file)
+                        {
+                            self.tabview.set_selected_page(&page);
                         }
                         dialogs::file_load_warning_dialog(
                             &*obj,
@@ -506,7 +506,7 @@ mod imp {
         /// The error is swallowed because the user is already notified.
         async fn gracefully_prompt_save_file(&self) -> Option<gio::File> {
             let obj = self.obj();
-            match crate::widgets::save_file(&*obj).await {
+            match crate::widgets::save_file(&obj).await {
                 Ok(maybe_file) => maybe_file,
                 Err(e) => {
                     dialogs::glib_file_dialog_error(&*obj, &e).await;
@@ -592,7 +592,7 @@ mod imp {
                 /* The window has not been modified, so there is nothing to do besides closing it. */
                 true
             };
-            self.tabview.close_page_finish(&tabpage, close_page);
+            self.tabview.close_page_finish(tabpage, close_page);
 
             if self.tabview.selected_page().is_none() {
                 /* No more tabs to present, switch to the welcome view. */

--- a/src/windows/settings/locale.rs
+++ b/src/windows/settings/locale.rs
@@ -89,7 +89,7 @@ impl LocaleRepr {
 
         let store = ListStore::new::<Self>();
         for (iso, name) in languages {
-            if iso == "" || iso == "en" || locale_exists(iso) {
+            if iso.is_empty() || iso == "en" || locale_exists(iso) {
                 let repr: Self = Object::builder()
                     .property("iso", iso.to_string())
                     .property("name", name.to_string())

--- a/src/windows/settings/locale.rs
+++ b/src/windows/settings/locale.rs
@@ -38,7 +38,7 @@ const LOCALES: [(&str, &str); 16] = [
 ];
 
 use glib::subclass::prelude::*;
-use glib::{prelude::*, Object};
+use glib::{Object, prelude::*};
 
 // Returns true if there is a file called locale/{iso}/LC_MESSAGES/cartero.mo in the datadir.
 fn locale_exists(iso: &str) -> bool {

--- a/src/windows/settings/pages/appearance.rs
+++ b/src/windows/settings/pages/appearance.rs
@@ -24,6 +24,12 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
+impl Default for Appearance {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Appearance {
     pub fn new() -> Self {
         glib::Object::new()

--- a/src/windows/settings/pages/appearance.rs
+++ b/src/windows/settings/pages/appearance.rs
@@ -37,7 +37,7 @@ mod imp {
 
     use glib::subclass::InitializingObject;
     use gtk::{
-        gio::SimpleActionGroup, pango::FontDescription, CompositeTemplate, FlowBox, FlowBoxChild,
+        CompositeTemplate, FlowBox, FlowBoxChild, gio::SimpleActionGroup, pango::FontDescription,
     };
     use sourceview5::{StyleSchemeManager, StyleSchemePreview};
 

--- a/src/windows/settings/pages/application.rs
+++ b/src/windows/settings/pages/application.rs
@@ -24,6 +24,12 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
+impl Default for Application {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Application {
     pub fn new() -> Self {
         glib::Object::new()

--- a/src/windows/settings/pages/code_editor.rs
+++ b/src/windows/settings/pages/code_editor.rs
@@ -24,6 +24,12 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
+impl Default for CodeEditor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CodeEditor {
     pub fn new() -> Self {
         glib::Object::new()

--- a/src/windows/settings/pages/code_editor.rs
+++ b/src/windows/settings/pages/code_editor.rs
@@ -36,7 +36,7 @@ mod imp {
     use super::*;
 
     use glib::subclass::InitializingObject;
-    use gtk::{gio::SimpleActionGroup, CompositeTemplate};
+    use gtk::{CompositeTemplate, gio::SimpleActionGroup};
 
     #[derive(Default, CompositeTemplate)]
     #[template(resource = "/es/danirod/Cartero/settings/page_code_editor.ui")]

--- a/src/windows/settings/pages/http_client.rs
+++ b/src/windows/settings/pages/http_client.rs
@@ -24,6 +24,12 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
+impl Default for HttpClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HttpClient {
     pub fn new() -> Self {
         glib::Object::new()

--- a/src/windows/settings/pages/proxy.rs
+++ b/src/windows/settings/pages/proxy.rs
@@ -24,6 +24,12 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
+impl Default for Proxy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Proxy {
     pub fn new() -> Self {
         glib::Object::new()

--- a/src/windows/settings/pages/proxy.rs
+++ b/src/windows/settings/pages/proxy.rs
@@ -247,7 +247,7 @@ mod imp {
             dialog.add_response("cancel", &gettext("Cancel"));
             dialog.add_response("remove", &gettext("Remove"));
             dialog.set_response_appearance("remove", adw::ResponseAppearance::Destructive);
-            let response = dialog.choose_future(&parent).await;
+            let response = dialog.choose_future(Some(&parent)).await;
             "remove" == response
         }
 

--- a/src/windows/settings/pages/proxy.rs
+++ b/src/windows/settings/pages/proxy.rs
@@ -39,8 +39,8 @@ mod imp {
     use gettextrs::gettext;
     use glib::subclass::InitializingObject;
     use gtk::{
-        gio::{SimpleAction, SimpleActionGroup},
         CompositeTemplate,
+        gio::{SimpleAction, SimpleActionGroup},
     };
 
     #[derive(Default, CompositeTemplate)]

--- a/src/windows/settings/pages/security.rs
+++ b/src/windows/settings/pages/security.rs
@@ -24,6 +24,12 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
+impl Default for Security {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Security {
     pub fn new() -> Self {
         glib::Object::new()

--- a/src/windows/settings/pages/security.rs
+++ b/src/windows/settings/pages/security.rs
@@ -36,7 +36,7 @@ mod imp {
     use super::*;
 
     use glib::subclass::InitializingObject;
-    use gtk::{gio::SimpleActionGroup, CompositeTemplate};
+    use gtk::{CompositeTemplate, gio::SimpleActionGroup};
 
     #[derive(Default, CompositeTemplate)]
     #[template(resource = "/es/danirod/Cartero/settings/page_security.ui")]

--- a/src/windows/settings/pill.rs
+++ b/src/windows/settings/pill.rs
@@ -29,7 +29,7 @@ mod imp {
 
     use super::*;
 
-    use glib::{subclass::InitializingObject, Properties};
+    use glib::{Properties, subclass::InitializingObject};
     use gtk::CompositeTemplate;
 
     #[derive(Default, CompositeTemplate, Properties)]

--- a/src/windows/settings/shell.rs
+++ b/src/windows/settings/shell.rs
@@ -26,6 +26,12 @@ glib::wrapper! {
         @implements gtk::Accessible, gtk::Buildable, gtk::ConstraintTarget;
 }
 
+impl Default for Shell {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Shell {
     pub fn new() -> Self {
         glib::Object::new()
@@ -43,7 +49,7 @@ impl Shell {
                 row.activate();
                 return;
             }
-            index = index + 1;
+            index += 1;
         }
     }
 }
@@ -146,53 +152,48 @@ mod imp {
         }
 
         pub(super) fn init_native_window(&self, win: &gtk::Window) {
-            crate::native::prepare_window(&win);
+            crate::native::prepare_window(win);
 
             win.connect_fullscreened_notify(glib::clone!(
                 #[weak(rename_to = imp)]
                 self,
                 move |win| {
-                    imp.update_native_appearance(&win);
+                    imp.update_native_appearance(win);
                 }
             ));
             win.connect_maximized_notify(glib::clone!(
                 #[weak(rename_to = imp)]
                 self,
                 move |win| {
-                    imp.update_native_appearance(&win);
+                    imp.update_native_appearance(win);
                 }
             ));
             win.connect_default_width_notify(glib::clone!(
                 #[weak(rename_to = imp)]
                 self,
                 move |win| {
-                    imp.update_native_appearance(&win);
+                    imp.update_native_appearance(win);
                 }
             ));
             win.connect_default_height_notify(glib::clone!(
                 #[weak(rename_to = imp)]
                 self,
                 move |win| {
-                    imp.update_native_appearance(&win);
+                    imp.update_native_appearance(win);
                 }
             ));
             win.connect_realize(glib::clone!(
                 #[weak(rename_to = imp)]
                 self,
                 move |win| {
-                    imp.update_native_appearance(&win);
+                    imp.update_native_appearance(win);
                 }
             ));
         }
 
         fn update_native_appearance(&self, win: &gtk::Window) {
             let sidebar_width = 175;
-            crate::native::update_vibrancy(
-                &win,
-                VibrancyMode::Transient,
-                None,
-                Some(sidebar_width),
-            );
+            crate::native::update_vibrancy(win, VibrancyMode::Transient, None, Some(sidebar_width));
         }
 
         fn init_root_window(&self) {
@@ -232,17 +233,20 @@ mod imp {
         }
 
         fn init_sidebar(&self) {
-            for page in self.settings_stack.pages().iter::<adw::ViewStackPage>() {
-                if let Ok(page) = page {
-                    let pill: Pill = glib::Object::builder()
-                        .property("icon-name", page.icon_name())
-                        .property("label", page.title())
-                        .property("name", page.name())
-                        .build();
+            for page in self
+                .settings_stack
+                .pages()
+                .iter::<adw::ViewStackPage>()
+                .flatten()
+            {
+                let pill: Pill = glib::Object::builder()
+                    .property("icon-name", page.icon_name())
+                    .property("label", page.title())
+                    .property("name", page.name())
+                    .build();
 
-                    let child = gtk::ListBoxRow::builder().child(&pill).build();
-                    self.sidebar_box.append(&child);
-                }
+                let child = gtk::ListBoxRow::builder().child(&pill).build();
+                self.sidebar_box.append(&child);
             }
         }
 


### PR DESCRIPTION
- Updates dependencies of Rust packages. **Note: this might have bumped MSRV above 1.85. Needs to be checked**.
- The flake.nix has finally broken after bumping deps. Given that I am learning Nix anyway, take some time to update the flake.
- Upgrades Rust to 2024 edition. This causes noise because of changes to `cargo fmt`, but there are a few code changes and breaking changes to do.
- Runs cargo clippy on the code to fix all the pending issues.