### PR TITLE
Detect syntax highlighting for suffixed MIME types

### DIFF
--- a/NEWS.d/26.1/fixed
+++ b/NEWS.d/26.1/fixed
@@ -1,0 +1,1 @@
+- Responses whose content type used +yaml as a suffix (e.g. application/vnd.oai.openapi+yaml) were not being coloured as YAML.

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,11 @@ These are the user-visible changes noticeable within Cartero.
 - - Updated Rust project dependencies.
 - - Updated codebase Rust edition to Rust 2024.
 
+### Fixed
+
+- - Responses whose content type used +yaml as a suffix (e.g.
+    application/vnd.oai.openapi+yaml) were not being coloured as YAML.
+
 ### Translation Updates
 
 - Galician

--- a/src/widgets/endpoint/response_panel.rs
+++ b/src/widgets/endpoint/response_panel.rs
@@ -344,22 +344,21 @@ impl ResponsePanel {
             self.render_response_body_as_text();
         }
 
-        let language = if resp.is_json() {
-            LanguageManager::default().language("json")
-        } else if resp.is_xml() {
-            LanguageManager::default().language("xml")
-        } else {
-            resp.headers()
-                .find_by_name_icase("Content-Type")
-                .map(|ctypes| ctypes[0].to_owned())
-                .and_then(|ctype| {
-                    let ctype = match ctype.split_once(';') {
-                        Some((c, _)) => c.to_string(),
-                        None => ctype,
-                    };
-                    LanguageManager::default().guess_language(Option::<PathBuf>::None, Some(&ctype))
+        let language = resp
+            .headers()
+            .find_by_name_icase("Content-Type")
+            .map(|ctypes| ctypes[0].to_owned())
+            .and_then(|ctype| {
+                let ctype = match ctype.split_once(';') {
+                    Some((c, _)) => c.to_string(),
+                    None => ctype,
+                };
+                let media_types = compose_media_types(&ctype);
+                media_types.iter().find_map(|media_type| {
+                    LanguageManager::default()
+                        .guess_language(Option::<PathBuf>::None, Some(&media_type))
                 })
-        };
+            });
 
         match language {
             Some(language) => buffer.set_language(Some(&language)),
@@ -381,5 +380,35 @@ fn format_duration(duration: u64) -> String {
         // Format as milliseconds.
         // TRANSLATORS: duration measured in milliseconds, as in "234 ms"
         formatx!(gettext("{} ms"), duration).unwrap()
+    }
+}
+
+fn compose_media_types(string: &str) -> Vec<String> {
+    let Some((mtype, msubtype)) = string.split_once("/") else {
+        return vec![];
+    };
+    msubtype
+        .split("+")
+        .map(|variant| format!("{}/{}", mtype, variant))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_compose_media_types() {
+        let table = vec![
+            ("application/json", vec!["application/json"]),
+            ("text/svg+xml", vec!["text/svg", "text/xml"]),
+            (
+                "application/activity+json",
+                vec!["application/activity", "application/json"],
+            ),
+            ("invalid", vec![]),
+        ];
+        for (input, expected) in table {
+            let output = super::compose_media_types(input);
+            assert_eq!(output, expected);
+        }
     }
 }


### PR DESCRIPTION
In conformance with RFC 6838 section 4.2.8, the one that acknowledges that some MIME types in the Content-Type header may have a plus symbol and another type, this commit will fix Cartero not colouring every possible MIME type.

The exact case described in https://github.com/danirod/cartero/issues/339 is an OpenAPI endpoint that returns a YAML document with the content-type set to `application/vnd.oai.openapi+yaml`.

Previously, Cartero only considered a suffix when it was +json (as in `application/activity+json`) or +xml (as in `text/atom+xml`). Now we correctly detect other content-types. Most relevant is probably +yaml anyway. The full list is here:

    https://www.iana.org/assignments/media-type-structured-suffix/media-type-structured-suffix.xhtml

But to be fair most of them are binary and thus not rendered by Cartero, and others like +csv do not need syntax highlighting (although a CSV renderer for Cartero sounds like a good idea...)

Fixes #339