### PR TITLE
Update Homebrew installation command for cartero

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ reported first to the package manager or to the port maintainer, not here.
 You can also get it from Homebrew [using the tap][homebrew]:
 
 ```bash
-brew tap SoloAntonio/cartero
-brew install --cask cartero
+brew install --cask SoloAntonio/cartero/cartero
 ```
 
 #### Windows


### PR DESCRIPTION
To install Cartero from this cask, run the installation command using the fully-qualified name. This automatically handles the tap and trust verification required by Homebrew 6.0 in a single step: